### PR TITLE
Fix #95: Read XREFS extension part and QueryIsId extension method

### DIFF
--- a/uml4net.xmi.Extensions.EnterpriseArchitect.Tests/Readers/EnterpriseArchitectXmiReaderTestFixture.cs
+++ b/uml4net.xmi.Extensions.EnterpriseArchitect.Tests/Readers/EnterpriseArchitectXmiReaderTestFixture.cs
@@ -83,6 +83,10 @@ namespace uml4net.xmi.Extensions.EnterpriseArchitect.Tests.Readers
                 Assert.That(operationParameter.QueryDocumentationFromExtensions(), Is.EqualTo("The parameter documentation"));
                 Assert.That(returnParameter.QueryDocumentationFromExtensions(), Is.EqualTo("Return value"));
                 Assert.That(associationParameter.Association.QueryDocumentationFromExtensions(), Is.EqualTo("Gets or sets the reference to a &lt;see cref=\"SecondElement\" /&gt;"));
+                Assert.That(attribute.IsID, Is.False);
+                Assert.That(attribute.QueryIsId, Is.True);
+                Assert.That(secondAttribute.IsID, Is.False);
+                Assert.That(secondAttribute.QueryIsId, Is.False);
             });
         }
     }

--- a/uml4net.xmi.Extensions.EnterpriseArchitect.Tests/Resources/EAExport.xmi
+++ b/uml4net.xmi.Extensions.EnterpriseArchitect.Tests/Resources/EAExport.xmi
@@ -1,6 +1,6 @@
 <?xml  version='1.0' encoding='windows-1252' ?>
 <xmi:XMI xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.omg.org/spec/UML/20161101" xmlns:umldi="http://www.omg.org/spec/UML/20161101/UMLDI" xmlns:dc="http://www.omg.org/spec/UML/20161101/UMLDC">
-	<xmi:Documentation exporter="Enterprise Architect" exporterVersion="6.5" exporterID="1703"/>
+	<xmi:Documentation exporter="Enterprise Architect" exporterVersion="6.5" exporterID="1704"/>
 	<uml:Model xmi:type="uml:Model" name="EA_Model">
 		<packagedElement xmi:type="uml:Package" xmi:id="EAPK_974A24AF_DDAB_4dd7_AED8_10D3CECC202C" name="XmiTest">
 			<packagedElement xmi:type="uml:Class" xmi:id="EAID_E7DEF3AB_2BF1_474f_A118_48F9DC5ED70A" name="Element">
@@ -75,7 +75,7 @@
 						<style/>
 						<styleex value="volatile=0;"/>
 						<tags/>
-						<xrefs/>
+						<xrefs value="$XREFPROP=$XID={CE6709FE-5161-4b56-ABDD-05AF6546F364}$XID;$NAM=CustomProperties$NAM;$TYP=attribute property$TYP;$VIS=Public$VIS;$PAR=0$PAR;$DES=@PROP=@NAME=isID@ENDNAME;@TYPE=Boolean@ENDTYPE;@VALU=1@ENDVALU;@PRMT=@ENDPRMT;@ENDPROP;$DES;$CLT={957B58DC-9D90-4781-A642-E060CB7F142A}$CLT;$SUP=&lt;none&gt;$SUP;$ENDXREF;"/>
 					</attribute>
 					<attribute xmi:idref="EAID_09432622_34AB_4e04_B9E8_A00C6CCAF80A" name="AnotherAttribute" scope="Public">
 						<initial/>

--- a/uml4net.xmi.Extensions.EnterpriseArchitect/CommonStructureExtension/ExtensionAttribute.cs
+++ b/uml4net.xmi.Extensions.EnterpriseArchitect/CommonStructureExtension/ExtensionAttribute.cs
@@ -24,5 +24,11 @@ namespace uml4net.xmi.Extensions.EnterpriseArchitect.CommonStructureExtension
     /// Represents an attribute within an extension element, providing additional metadata
     /// or functionality for integration with extended models.
     /// </summary>
-    public class ExtensionAttribute : ExtensionElement, IExtensionAttribute;
+    public class ExtensionAttribute : ExtensionElement, IExtensionAttribute
+    {
+        /// <summary>
+        /// Gets or sets the XREFS value from the extension 
+        /// </summary>
+        public string Xrefs { get; set; }
+    }
 }

--- a/uml4net.xmi.Extensions.EnterpriseArchitect/CommonStructureExtension/IExtensionAttribute.cs
+++ b/uml4net.xmi.Extensions.EnterpriseArchitect/CommonStructureExtension/IExtensionAttribute.cs
@@ -25,5 +25,11 @@ namespace uml4net.xmi.Extensions.EnterpriseArchitect.CommonStructureExtension
     /// This interface extends <see cref="IExtensionElement" /> to provide
     /// additional behavior specific to extension attributes.
     /// </summary>
-    public interface IExtensionAttribute : IExtensionElement;
+    public interface IExtensionAttribute : IExtensionElement
+    {
+        /// <summary>
+        /// Gets or sets the XREFS value from the extension 
+        /// </summary>
+        string Xrefs { get; set; }
+    }
 }

--- a/uml4net.xmi.Extensions.EnterpriseArchitect/Extensions/ExtendedPropertyExtensions.cs
+++ b/uml4net.xmi.Extensions.EnterpriseArchitect/Extensions/ExtendedPropertyExtensions.cs
@@ -1,0 +1,49 @@
+﻿// -------------------------------------------------------------------------------------------------
+//  <copyright file="ExtendedPropertyExtensions.cs" company="Starion Group S.A.">
+// 
+//    Copyright 2019-2025 Starion Group S.A.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Extensions.EnterpriseArchitect.Extensions
+{
+    using System.Linq;
+
+    using uml4net.Classification;
+    using uml4net.xmi.Extensions.EnterpriseArchitect.CommonStructureExtension;
+
+    /// <summary>
+    /// Extensions methods for <see cref="IProperty" />
+    /// </summary>
+    public static class ExtendedPropertyExtensions
+    {
+        /// <summary>
+        /// Pattern that represent the exported value of the isID attribute from Enterprise Architect
+        /// </summary>
+        private const string IsIdPattern = "$TYP=attribute property$TYP;$VIS=Public$VIS;$PAR=0$PAR;$DES=@PROP=@NAME=isID@ENDNAME;@TYPE=Boolean@ENDTYPE;@VALU=1@ENDVALU;@PRMT=@ENDPRMT;@ENDPROP;";
+        
+        /// <summary>
+        /// Asserts that a <see cref="IProperty"/> have the <see cref="IProperty.IsID"/> value
+        /// </summary>
+        /// <param name="property">The <see cref="IProperty"/></param>
+        /// <returns>True if the <see cref="IProperty.IsID"/> is set or if the xrefs of a linked extension contains the <see cref="IsIdPattern"/></returns>
+        public static bool QueryIsId(this IProperty property)
+        {
+            return property.IsID ||  property.Extensions.OfType<IExtensionAttribute>()
+                .Any(x => !string.IsNullOrEmpty(x.Xrefs) && x.Xrefs.Contains(IsIdPattern));
+        }
+    }
+}

--- a/uml4net.xmi.Extensions.EnterpriseArchitect/Readers/AttributeReader.cs
+++ b/uml4net.xmi.Extensions.EnterpriseArchitect/Readers/AttributeReader.cs
@@ -98,6 +98,15 @@ namespace uml4net.xmi.Extensions.EnterpriseArchitect.Readers
                             }
 
                             break;
+
+                        case "xrefs":
+                            using (var xrefsReader = xmlReader.ReadSubtree())
+                            {
+                                xrefsReader.Read();
+                                element.Xrefs = xrefsReader.GetAttribute("value");
+                            }
+
+                            break;
                         default:
                             this.Logger.LogTrace("AttributeReader - Extension: {ElementName}", xmlReader.LocalName);
                             break;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/uml4net/pulls) open
- [x] I have verified that I am following the ReqIFSharp [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/uml4net/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #95 

- Read the __xrefs__ part of extension
- Provide extension method to check whether the __isID__ value is set or not
<!-- Thanks for contributing to uml4net! -->