### PR TITLE
feat: add global log level option to tools CLI

### DIFF
--- a/uml4net.Tools/uml4net.Tools.csproj
+++ b/uml4net.Tools/uml4net.Tools.csproj
@@ -53,6 +53,8 @@
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
         <PackageReference Include="Spectre.Console" Version="0.50.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.File" Version="9.0.8" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.1" PrivateAssets="all" />
     </ItemGroup>
 

--- a/uml4net.Tools/uml4net.Tools.csproj
+++ b/uml4net.Tools/uml4net.Tools.csproj
@@ -50,11 +50,11 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
+        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
         <PackageReference Include="Spectre.Console" Version="0.50.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
-        <PackageReference Include="Microsoft.Extensions.Logging.File" Version="9.0.8" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.1" PrivateAssets="all" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add `--log-level`/`-l` option with default `Information` for tool commands
- configure logging minimum level from parsed option
- expose option globally to all subcommands
- add `--log-target`/`-t` option to choose console or file logging
- enable console or file providers based on selected target

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af232ea8f48326b5c60346964f90e3