### PR TITLE
fix: correct license header wording

### DIFF
--- a/uml4net.CodeGenerator.Tests/Expected/ExpectedClasses.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/ExpectedClasses.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.CodeGenerator.Tests/Generators/CorePocoGeneratorTestFixture.cs
+++ b/uml4net.CodeGenerator.Tests/Generators/CorePocoGeneratorTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.CodeGenerator.Tests/Transformers/ModelTransformerTestFixture.cs
+++ b/uml4net.CodeGenerator.Tests/Transformers/ModelTransformerTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.CodeGenerator/Generators/CorePocoGenerator.cs
+++ b/uml4net.CodeGenerator/Generators/CorePocoGenerator.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.CodeGenerator/Generators/Generator.cs
+++ b/uml4net.CodeGenerator/Generators/Generator.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.CodeGenerator/Generators/HandleBarsGenerator.cs
+++ b/uml4net.CodeGenerator/Generators/HandleBarsGenerator.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.CodeGenerator/Generators/UmlHandleBarsGenerator.cs
+++ b/uml4net.CodeGenerator/Generators/UmlHandleBarsGenerator.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.Extensions.Tests/ClassExtensionsTestFixture.cs
+++ b/uml4net.Extensions.Tests/ClassExtensionsTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Extensions.Tests/ClassifierExtensionsTestFixture.cs
+++ b/uml4net.Extensions.Tests/ClassifierExtensionsTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Extensions.Tests/EAPropertyExtensionsTestFixture.cs
+++ b/uml4net.Extensions.Tests/EAPropertyExtensionsTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Extensions.Tests/PropertyExtensionsTestFixture.cs
+++ b/uml4net.Extensions.Tests/PropertyExtensionsTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Extensions/ClassExtensions.cs
+++ b/uml4net.Extensions/ClassExtensions.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Extensions/ClassifierExtensions.cs
+++ b/uml4net.Extensions/ClassifierExtensions.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Extensions/ElementExtensions.cs
+++ b/uml4net.Extensions/ElementExtensions.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Extensions/PackageExtensions.cs
+++ b/uml4net.Extensions/PackageExtensions.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.Extensions/PropertyExtensions.cs
+++ b/uml4net.Extensions/PropertyExtensions.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Extensions/StringExtensions.cs
+++ b/uml4net.Extensions/StringExtensions.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Extensions/ValueSpecificationExtensions.cs
+++ b/uml4net.Extensions/ValueSpecificationExtensions.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars.Tests/BooleanHelperTestFixture.cs
+++ b/uml4net.HandleBars.Tests/BooleanHelperTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars.Tests/DecoratorHelperTestFixture.cs
+++ b/uml4net.HandleBars.Tests/DecoratorHelperTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars.Tests/PropertyHelperTestFixture.cs
+++ b/uml4net.HandleBars.Tests/PropertyHelperTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars.Tests/RegisterCustomDataTypesTestFixture.cs
+++ b/uml4net.HandleBars.Tests/RegisterCustomDataTypesTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars/BooleanHelper.cs
+++ b/uml4net.HandleBars/BooleanHelper.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars/ClassHelper.cs
+++ b/uml4net.HandleBars/ClassHelper.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars/DecoratorHelper.cs
+++ b/uml4net.HandleBars/DecoratorHelper.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars/DocumentationHelper.cs
+++ b/uml4net.HandleBars/DocumentationHelper.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars/EnumHelper.cs
+++ b/uml4net.HandleBars/EnumHelper.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars/GeneralizationHelper.cs
+++ b/uml4net.HandleBars/GeneralizationHelper.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars/IEnumerableHelper.cs
+++ b/uml4net.HandleBars/IEnumerableHelper.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars/PropertyHelper.cs
+++ b/uml4net.HandleBars/PropertyHelper.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars/StringHelper.cs
+++ b/uml4net.HandleBars/StringHelper.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.HandleBars/TypeNameHelper.cs
+++ b/uml4net.HandleBars/TypeNameHelper.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting.Tests/Generators/HtmlReportGeneratorTestFixture.cs
+++ b/uml4net.Reporting.Tests/Generators/HtmlReportGeneratorTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
+++ b/uml4net.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting/Generators/HandleBarsReportGenerator.cs
+++ b/uml4net.Reporting/Generators/HandleBarsReportGenerator.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting/Generators/IHtmlReportGenerator.cs
+++ b/uml4net.Reporting/Generators/IHtmlReportGenerator.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting/Generators/IMarkdownReportGenerator.cs
+++ b/uml4net.Reporting/Generators/IMarkdownReportGenerator.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting/Generators/IReportGenerator.cs
+++ b/uml4net.Reporting/Generators/IReportGenerator.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting/Generators/IXlReportGenerator.cs
+++ b/uml4net.Reporting/Generators/IXlReportGenerator.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting/Generators/MarkdownReportGenerator.cs
+++ b/uml4net.Reporting/Generators/MarkdownReportGenerator.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting/Generators/ReportGenerator.cs
+++ b/uml4net.Reporting/Generators/ReportGenerator.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting/Generators/XlReportGenerator.cs
+++ b/uml4net.Reporting/Generators/XlReportGenerator.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting/Payload/HandlebarsPayload.cs
+++ b/uml4net.Reporting/Payload/HandlebarsPayload.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Reporting/Resources/ResourceLoader.cs
+++ b/uml4net.Reporting/Resources/ResourceLoader.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tests/Extend/NamedElementExtensionsTestFixture.cs
+++ b/uml4net.Tests/Extend/NamedElementExtensionsTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
+++ b/uml4net.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools.Tests/Commands/MarkdownReportCommandTestFixture.cs
+++ b/uml4net.Tools.Tests/Commands/MarkdownReportCommandTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools.Tests/Commands/ModelInspectionCommandTestFixture.cs
+++ b/uml4net.Tools.Tests/Commands/ModelInspectionCommandTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools.Tests/Commands/ReportCommandTestFixture.cs
+++ b/uml4net.Tools.Tests/Commands/ReportCommandTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools.Tests/Services/VersionCheckerTestFixture.cs
+++ b/uml4net.Tools.Tests/Services/VersionCheckerTestFixture.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools/Commands/HtmlReportCommand.cs
+++ b/uml4net.Tools/Commands/HtmlReportCommand.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools/Commands/MarkdownReportCommand.cs
+++ b/uml4net.Tools/Commands/MarkdownReportCommand.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools/Commands/ModelInspectionCommand.cs
+++ b/uml4net.Tools/Commands/ModelInspectionCommand.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools/Commands/ReportCommand.cs
+++ b/uml4net.Tools/Commands/ReportCommand.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools/Commands/ReportHandler.cs
+++ b/uml4net.Tools/Commands/ReportHandler.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools/Commands/XlReportCommand.cs
+++ b/uml4net.Tools/Commands/XlReportCommand.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools/Middlewares/VersionCheckerMiddleware.cs
+++ b/uml4net.Tools/Middlewares/VersionCheckerMiddleware.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools/Resources/ResourceLoader.cs
+++ b/uml4net.Tools/Resources/ResourceLoader.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools/Services/GitHubRelease.cs
+++ b/uml4net.Tools/Services/GitHubRelease.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.Tools/Services/VersionChecker.cs
+++ b/uml4net.Tools/Services/VersionChecker.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.xmi.Tests/SysML2.XmiReaderTestFixture.cs
+++ b/uml4net.xmi.Tests/SysML2.XmiReaderTestFixture.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.xmi.Tests/SysML2_with_unknown_element.XmiReaderTestFixture.cs
+++ b/uml4net.xmi.Tests/SysML2_with_unknown_element.XmiReaderTestFixture.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.xmi.Tests/SystemsModelingAPIandServicesPIMXmiReaderTestFixture.cs
+++ b/uml4net.xmi.Tests/SystemsModelingAPIandServicesPIMXmiReaderTestFixture.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.xmi.Tests/UMLXmiReaderTestFixture.cs
+++ b/uml4net.xmi.Tests/UMLXmiReaderTestFixture.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.xmi/IXmiReaderScope.cs
+++ b/uml4net.xmi/IXmiReaderScope.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.xmi/Readers/IXmiElementReader.cs
+++ b/uml4net.xmi/Readers/IXmiElementReader.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.xmi/Readers/IXmiReader.cs
+++ b/uml4net.xmi/Readers/IXmiReader.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.xmi/Readers/XmiElementReader.cs
+++ b/uml4net.xmi/Readers/XmiElementReader.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.xmi/Readers/XmiReader.cs
+++ b/uml4net.xmi/Readers/XmiReader.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net.xmi/Readers/XmiReaderResult.cs
+++ b/uml4net.xmi/Readers/XmiReaderResult.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.xmi/ReferenceResolver/ExternalReferenceResolver.cs
+++ b/uml4net.xmi/ReferenceResolver/ExternalReferenceResolver.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.xmi/ReferenceResolver/IExternalReferenceResolver.cs
+++ b/uml4net.xmi/ReferenceResolver/IExternalReferenceResolver.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.xmi/Settings/DefaultSettings.cs
+++ b/uml4net.xmi/Settings/DefaultSettings.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.xmi/Settings/IXmiReaderSettings.cs
+++ b/uml4net.xmi/Settings/IXmiReaderSettings.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net.xmi/XmiReaderScope.cs
+++ b/uml4net.xmi/XmiReaderScope.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net/Assembler.cs
+++ b/uml4net/Assembler.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net/ContainerList.cs
+++ b/uml4net/ContainerList.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net/Decorators/ClassAttribute.cs
+++ b/uml4net/Decorators/ClassAttribute.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net/Decorators/ImplementsAttribute.cs
+++ b/uml4net/Decorators/ImplementsAttribute.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net/Decorators/PropertyAttribute.cs
+++ b/uml4net/Decorators/PropertyAttribute.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net/Decorators/RedefinedByPropertyAttribute.cs
+++ b/uml4net/Decorators/RedefinedByPropertyAttribute.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net/Decorators/RedefinedPropertyAttribute.cs
+++ b/uml4net/Decorators/RedefinedPropertyAttribute.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net/Decorators/SubsettedPropertyAttribute.cs
+++ b/uml4net/Decorators/SubsettedPropertyAttribute.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net/IAssembler.cs
+++ b/uml4net/IAssembler.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net/IContainerList.cs
+++ b/uml4net/IContainerList.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net/IElement.cs
+++ b/uml4net/IElement.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net/IXmiElement.cs
+++ b/uml4net/IXmiElement.cs
@@ -9,7 +9,7 @@
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
 //
-//   Unless required by applicable law or agreed to in writing, softwareUseCases
+//   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and

--- a/uml4net/IXmiElementCache.cs
+++ b/uml4net/IXmiElementCache.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and

--- a/uml4net/XmiElementCache.cs
+++ b/uml4net/XmiElementCache.cs
@@ -9,7 +9,7 @@
 // 
 //        http://www.apache.org/licenses/LICENSE-2.0
 // 
-//    Unless required by applicable law or agreed to in writing, softwareUseCases
+//    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and


### PR DESCRIPTION
## Summary
- fix license header 'softwareUseCases' typo to 'software' across repository

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b309e00a188326a34c121f5479d276