### PR TITLE
Fix typo in VersionChecker XML comment

### DIFF
--- a/uml4net.Tools/Services/VersionChecker.cs
+++ b/uml4net.Tools/Services/VersionChecker.cs
@@ -63,7 +63,7 @@ namespace uml4net.Tools.Services
         /// </summary>
         /// <returns>
         /// an instance of <see cref="GitHubRelease"/> or null if not found or a connection
-        /// error occured
+        /// error occurred
         /// </returns>
         public async Task<GitHubRelease> QueryLatestReleaseAsync()
         {


### PR DESCRIPTION
## Summary
- fix typo in XML documentation for `VersionChecker.QueryLatestReleaseAsync`

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b30ba232508326a98e80a9e8bbe8d8