### PR TITLE
Add tests for decorators and Handlebars helpers

### DIFF
--- a/uml4net.HandleBars.Tests/EnumHelperTestFixture.cs
+++ b/uml4net.HandleBars.Tests/EnumHelperTestFixture.cs
@@ -1,0 +1,83 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="EnumHelperTestFixture.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2019-2025 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace uml4net.HandleBars.Tests
+{
+    using System;
+    using System.Globalization;
+
+    using HandlebarsDotNet;
+
+    using NUnit.Framework;
+
+    using uml4net.HandleBars;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="EnumHelper"/> class.
+    /// </summary>
+    [TestFixture]
+    public class EnumHelperTestFixture
+    {
+        private IHandlebars handlebarsContext;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.handlebarsContext = Handlebars.Create();
+            this.handlebarsContext.Configuration.FormatProvider = CultureInfo.InvariantCulture;
+            EnumHelper.RegisterEnumHelper(this.handlebarsContext);
+        }
+
+        [Test]
+        public void Verify_EnumToString_returns_expected_value()
+        {
+            var result = EnumHelper.EnumToString(DayOfWeek.Friday);
+            Assert.That(result, Is.EqualTo("Friday"));
+        }
+
+        [Test]
+        public void Verify_helper_converts_enum_to_lowercase()
+        {
+            var template = "{{ #Enum.ToString this }}";
+            var action = this.handlebarsContext.Compile(template);
+            var result = action(DayOfWeek.Monday);
+
+            Assert.That(result, Is.EqualTo("monday"));
+        }
+
+        [Test]
+        public void Verify_helper_throws_when_argument_is_not_enum()
+        {
+            var template = "{{ #Enum.ToString this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            Assert.That(() => action(5), Throws.TypeOf<HandlebarsException>());
+        }
+
+        [Test]
+        public void Verify_helper_throws_when_parameter_count_invalid()
+        {
+            var template = "{{ #Enum.ToString this \"extra\" }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            Assert.That(() => action(DayOfWeek.Tuesday), Throws.TypeOf<HandlebarsException>());
+        }
+    }
+}

--- a/uml4net.HandleBars.Tests/NamedElementHelperTestFixture.cs
+++ b/uml4net.HandleBars.Tests/NamedElementHelperTestFixture.cs
@@ -1,0 +1,75 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="NamedElementHelperTestFixture.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2019-2025 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace uml4net.HandleBars.Tests
+{
+    using System;
+    using System.Globalization;
+
+    using HandlebarsDotNet;
+
+    using NUnit.Framework;
+
+    using uml4net.HandleBars;
+    using uml4net.Packages;
+    using uml4net.StructuredClassifiers;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="NamedElementHelper"/> class.
+    /// </summary>
+    [TestFixture]
+    public class NamedElementHelperTestFixture
+    {
+        private IHandlebars handlebarsContext;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.handlebarsContext = Handlebars.Create();
+            this.handlebarsContext.Configuration.FormatProvider = CultureInfo.InvariantCulture;
+            NamedElementHelper.RegisterNamedElementHelper(this.handlebarsContext);
+        }
+
+        [Test]
+        public void Verify_that_WriteNameSpace_returns_expected_namespace()
+        {
+            var root = new Package { Name = "root" };
+            var sub = new Package { Name = "sub" };
+            var cls = new Class { Name = "MyClass" };
+            root.PackagedElement.Add(sub);
+            sub.PackagedElement.Add(cls);
+
+            var template = "{{ #NamedElement.WriteNameSpace this }}";
+            var action = this.handlebarsContext.Compile(template);
+            var result = action(cls);
+
+            Assert.That(result, Is.EqualTo("sub"));
+        }
+
+        [Test]
+        public void Verify_that_WriteNameSpace_throws_when_context_is_invalid()
+        {
+            var template = "{{ #NamedElement.WriteNameSpace this }}";
+            var action = this.handlebarsContext.Compile(template);
+
+            Assert.That(() => action(5), Throws.TypeOf<ArgumentException>());
+        }
+    }
+}

--- a/uml4net.Tests/Decorators/ClassAttributeTestFixture.cs
+++ b/uml4net.Tests/Decorators/ClassAttributeTestFixture.cs
@@ -1,0 +1,54 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="ClassAttributeTestFixture.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2019-2025 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace uml4net.Tests.Decorators
+{
+    using NUnit.Framework;
+    using uml4net.Decorators;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ClassAttribute"/> type.
+    /// </summary>
+    [TestFixture]
+    public class ClassAttributeTestFixture
+    {
+        [Test]
+        public void Verify_that_constructor_sets_all_properties()
+        {
+            var attribute = new ClassAttribute("id", true, true, true);
+
+            Assert.That(attribute.XmiId, Is.EqualTo("id"));
+            Assert.That(attribute.IsAbstract, Is.True);
+            Assert.That(attribute.IsFinalSpecialization, Is.True);
+            Assert.That(attribute.IsActive, Is.True);
+        }
+
+        [Test]
+        public void Verify_default_values()
+        {
+            var attribute = new ClassAttribute();
+
+            Assert.That(attribute.XmiId, Is.EqualTo(string.Empty));
+            Assert.That(attribute.IsAbstract, Is.False);
+            Assert.That(attribute.IsFinalSpecialization, Is.False);
+            Assert.That(attribute.IsActive, Is.False);
+        }
+    }
+}

--- a/uml4net.Tests/Decorators/PropertyAttributeTestFixture.cs
+++ b/uml4net.Tests/Decorators/PropertyAttributeTestFixture.cs
@@ -1,0 +1,77 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="PropertyAttributeTestFixture.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2019-2025 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace uml4net.Tests.Decorators
+{
+    using NUnit.Framework;
+    using uml4net.Decorators;
+    using uml4net.Classification;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="PropertyAttribute"/> type.
+    /// </summary>
+    [TestFixture]
+    public class PropertyAttributeTestFixture
+    {
+        [Test]
+        public void Verify_that_constructor_sets_all_properties()
+        {
+            var attribute = new PropertyAttribute(
+                "id",
+                AggregationKind.Composite,
+                0,
+                2,
+                true,
+                true,
+                true,
+                true,
+                false,
+                "default");
+
+            Assert.That(attribute.XmiId, Is.EqualTo("id"));
+            Assert.That(attribute.Aggregation, Is.EqualTo(AggregationKind.Composite));
+            Assert.That(attribute.LowerValue, Is.EqualTo(0));
+            Assert.That(attribute.UpperValue, Is.EqualTo(2));
+            Assert.That(attribute.IsOrdered, Is.True);
+            Assert.That(attribute.IsReadOnly, Is.True);
+            Assert.That(attribute.IsDerived, Is.True);
+            Assert.That(attribute.IsDerivedUnion, Is.True);
+            Assert.That(attribute.IsUnique, Is.False);
+            Assert.That(attribute.DefaultValue, Is.EqualTo("default"));
+        }
+
+        [Test]
+        public void Verify_default_values()
+        {
+            var attribute = new PropertyAttribute();
+
+            Assert.That(attribute.XmiId, Is.EqualTo(string.Empty));
+            Assert.That(attribute.Aggregation, Is.EqualTo(AggregationKind.None));
+            Assert.That(attribute.LowerValue, Is.EqualTo(1));
+            Assert.That(attribute.UpperValue, Is.EqualTo(1));
+            Assert.That(attribute.IsOrdered, Is.False);
+            Assert.That(attribute.IsReadOnly, Is.False);
+            Assert.That(attribute.IsDerived, Is.False);
+            Assert.That(attribute.IsDerivedUnion, Is.False);
+            Assert.That(attribute.IsUnique, Is.True);
+            Assert.That(attribute.DefaultValue, Is.Null);
+        }
+    }
+}

--- a/uml4net.Tests/Extend/AssociationExtensionsTestFixture.cs
+++ b/uml4net.Tests/Extend/AssociationExtensionsTestFixture.cs
@@ -1,0 +1,50 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="AssociationExtensionsTestFixture.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2019-2025 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace uml4net.Tests.Extend
+{
+    using NUnit.Framework;
+    using uml4net.StructuredClassifiers;
+    using uml4net.Classification;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="AssociationExtensions"/> class.
+    /// </summary>
+    [TestFixture]
+    public class AssociationExtensionsTestFixture
+    {
+        [Test]
+        public void Verify_that_QueryEndType_returns_expected_types()
+        {
+            var association = new Association();
+            var classA = new Class { Name = "A" };
+            var classB = new Class { Name = "B" };
+            var property1 = new Property { Type = classA };
+            var property2 = new Property { Type = classB };
+
+            association.OwnedEnd.Add(property1);
+            association.OwnedEnd.Add(property2);
+
+            var result = association.QueryEndType();
+
+            Assert.That(result, Is.EquivalentTo([classA, classB]));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add NUnit tests for `ClassAttribute` and `PropertyAttribute`
- cover `AssociationExtensions.QueryEndType`
- test Handlebars helpers `NamedElementHelper` and `EnumHelper`

## Testing
- `dotnet test` *(fails: command not found)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel 403)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b3404024a88326aa274f70916d64ad