### PR TITLE
Add unit tests for helper and resource utilities

### DIFF
--- a/uml4net.Extensions.Tests/ValueSpecificationExtensionsTestFixture.cs
+++ b/uml4net.Extensions.Tests/ValueSpecificationExtensionsTestFixture.cs
@@ -1,0 +1,39 @@
+namespace uml4net.Extensions.Tests
+{
+    using NUnit.Framework;
+    using uml4net.Extensions;
+    using uml4net.Values;
+    using uml4net.Classification;
+
+    [TestFixture]
+    public class ValueSpecificationExtensionsTestFixture
+    {
+        [Test]
+        public void QueryDefaultValueAsString_HandlesDifferentLiteralTypes()
+        {
+            var literalBool = new LiteralBoolean { Value = true };
+            var literalInt = new LiteralInteger { Value = 42 };
+            var literalNull = new LiteralNull();
+            var literalString = new LiteralString { Value = "star" };
+            var literalUnlimited = new LiteralUnlimitedNatural { Value = "*" };
+            var instance = new InstanceSpecification { Name = "myInstance" };
+            var instanceValue = new InstanceValue { Instance = instance };
+
+            Assert.That(literalBool.QueryDefaultValueAsString(), Is.EqualTo("true"));
+            Assert.That(literalInt.QueryDefaultValueAsString(), Is.EqualTo("42"));
+            Assert.That(literalNull.QueryDefaultValueAsString(), Is.EqualTo("null"));
+            Assert.That(literalString.QueryDefaultValueAsString(), Is.EqualTo("star"));
+            Assert.That(literalUnlimited.QueryDefaultValueAsString(), Is.EqualTo("int.MaxValue"));
+            Assert.That(instanceValue.QueryDefaultValueAsString(), Is.EqualTo("myInstance"));
+        }
+
+        private class UnsupportedValueSpecification : XmiElement, IValueSpecification { }
+
+        [Test]
+        public void QueryDefaultValueAsString_ThrowsOnUnsupportedType()
+        {
+            var unsupported = new UnsupportedValueSpecification();
+            Assert.That(() => unsupported.QueryDefaultValueAsString(), Throws.TypeOf<System.NotSupportedException>());
+        }
+    }
+}

--- a/uml4net.Extensions.Tests/ValueSpecificationExtensionsTestFixture.cs
+++ b/uml4net.Extensions.Tests/ValueSpecificationExtensionsTestFixture.cs
@@ -1,5 +1,27 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="ValueSpecificationExtensionsTestFixture.cs" company="Starion Group S.A.">
+// 
+//    Copyright (C) 2019-2025 Starion Group S.A.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
 namespace uml4net.Extensions.Tests
 {
+    using System.Collections.Generic;
+    using CommonStructure;
     using NUnit.Framework;
     using uml4net.Extensions;
     using uml4net.Values;
@@ -27,7 +49,22 @@ namespace uml4net.Extensions.Tests
             Assert.That(instanceValue.QueryDefaultValueAsString(), Is.EqualTo("myInstance"));
         }
 
-        private class UnsupportedValueSpecification : XmiElement, IValueSpecification { }
+        private class UnsupportedValueSpecification : XmiElement, IValueSpecification
+        {
+            public IElement Possessor { get; set; }
+            public IContainerList<IComment> OwnedComment { get; set; }
+            public IContainerList<IElement> OwnedElement { get; }
+            public IElement Owner { get; }
+            public List<IDependency> ClientDependency { get; }
+            public string Name { get; set; }
+            public IContainerList<IStringExpression> NameExpression { get; set; }
+            public INamespace Namespace { get; }
+            public string QualifiedName { get; }
+            public VisibilityKind Visibility { get; set; }
+            public IType Type { get; set; }
+            public ITemplateParameter OwningTemplateParameter { get; set; }
+            public ITemplateParameter TemplateParameter { get; set; }
+        }
 
         [Test]
         public void QueryDefaultValueAsString_ThrowsOnUnsupportedType()

--- a/uml4net.Extensions/uml4net.Extensions.csproj
+++ b/uml4net.Extensions/uml4net.Extensions.csproj
@@ -46,4 +46,8 @@
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(MSBuildProjectName).Tests"/>
+    </ItemGroup>
 </Project>

--- a/uml4net.HandleBars.Tests/TypeNameHelperTestFixture.cs
+++ b/uml4net.HandleBars.Tests/TypeNameHelperTestFixture.cs
@@ -1,11 +1,35 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="TypeNameHelperTestFixture.cs" company="Starion Group S.A.">
+// 
+//    Copyright (C) 2019-2025 Starion Group S.A.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
 namespace uml4net.HandleBars.Tests
 {
     using System.Globalization;
+
     using HandlebarsDotNet;
+
     using NUnit.Framework;
-    using uml4net.HandleBars;
+
     using uml4net.Classification;
+    using uml4net.HandleBars;
     using uml4net.SimpleClassifiers;
+    using uml4net.StructuredClassifiers;
     using uml4net.Values;
 
     [TestFixture]

--- a/uml4net.HandleBars.Tests/TypeNameHelperTestFixture.cs
+++ b/uml4net.HandleBars.Tests/TypeNameHelperTestFixture.cs
@@ -1,0 +1,97 @@
+namespace uml4net.HandleBars.Tests
+{
+    using System.Globalization;
+    using HandlebarsDotNet;
+    using NUnit.Framework;
+    using uml4net.HandleBars;
+    using uml4net.Classification;
+    using uml4net.SimpleClassifiers;
+    using uml4net.Values;
+
+    [TestFixture]
+    public class TypeNameHelperTestFixture
+    {
+        private IHandlebars handlebars;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.handlebars = Handlebars.Create();
+            this.handlebars.Configuration.FormatProvider = CultureInfo.InvariantCulture;
+            TypeNameHelper.RegisterTypeNameHelper(this.handlebars);
+        }
+
+        private string Render(IProperty property)
+        {
+            var template = "{{#POCO.TypeName this}}";
+            var action = this.handlebars.Compile(template);
+            return action(property);
+        }
+
+        [Test]
+        public void Value_property_nullable_renders_nullable_type()
+        {
+            var property = CreateValueProperty("Integer", 0, 1);
+            var result = Render(property);
+            Assert.That(result, Is.EqualTo("int?"));
+        }
+
+        [Test]
+        public void Value_property_enumerable_renders_list()
+        {
+            var property = CreateValueProperty("Integer", 0, int.MaxValue);
+            var result = Render(property);
+            Assert.That(result, Is.EqualTo("List<int>"));
+        }
+
+        [Test]
+        public void Reference_property_in_abstract_owner_uses_interface_prefix()
+        {
+            var owner = new Class { IsAbstract = true };
+            var property = new Property
+            {
+                Type = new Class { Name = "Foo" },
+                Possessor = owner,
+            };
+            property.LowerValue.Add(new LiteralInteger { Value = 1 });
+            property.UpperValue.Add(new LiteralInteger { Value = 1 });
+
+            var result = Render(property);
+            Assert.That(result, Is.EqualTo("IFoo"));
+        }
+
+        [Test]
+        public void Reference_property_enumerable_renders_list()
+        {
+            var owner = new Class();
+            var property = new Property
+            {
+                Type = new Class { Name = "Bar" },
+                Possessor = owner,
+            };
+            property.LowerValue.Add(new LiteralInteger { Value = 0 });
+            property.UpperValue.Add(new LiteralUnlimitedNatural { Value = "*" });
+
+            var result = Render(property);
+            Assert.That(result, Is.EqualTo("List<Bar>"));
+        }
+
+        private static Property CreateValueProperty(string typeName, int lower, int upper)
+        {
+            var property = new Property
+            {
+                Type = new PrimitiveType { Name = typeName }
+            };
+            property.LowerValue.Add(new LiteralInteger { Value = lower });
+            if (upper == int.MaxValue)
+            {
+                property.UpperValue.Add(new LiteralUnlimitedNatural { Value = "*" });
+            }
+            else
+            {
+                property.UpperValue.Add(new LiteralInteger { Value = upper });
+            }
+            return property;
+        }
+    }
+}

--- a/uml4net.HandleBars/uml4net.HandleBars.csproj
+++ b/uml4net.HandleBars/uml4net.HandleBars.csproj
@@ -47,4 +47,7 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(MSBuildProjectName).Tests"/>
+    </ItemGroup>
 </Project>

--- a/uml4net.Reporting.Tests/Resources/ResourceLoaderTestFixture.cs
+++ b/uml4net.Reporting.Tests/Resources/ResourceLoaderTestFixture.cs
@@ -1,0 +1,24 @@
+namespace uml4net.Reporting.Tests.Resources
+{
+    using System.Resources;
+    using NUnit.Framework;
+    using uml4net.Reporting.Resources;
+
+    [TestFixture]
+    public class ResourceLoaderTestFixture
+    {
+        [Test]
+        public void LoadEmbeddedResource_ReturnsContent()
+        {
+            var content = ResourceLoader.LoadEmbeddedResource("uml4net.Reporting.Templates.uml-to-html-docs.hbs");
+            Assert.That(content, Does.Contain("uml4net.Reporting library"));
+        }
+
+        [Test]
+        public void LoadEmbeddedResource_InvalidPath_Throws()
+        {
+            Assert.That(() => ResourceLoader.LoadEmbeddedResource("unknown.resource"),
+                Throws.TypeOf<MissingManifestResourceException>());
+        }
+    }
+}

--- a/uml4net.Reporting.Tests/Resources/ResourceLoaderTestFixture.cs
+++ b/uml4net.Reporting.Tests/Resources/ResourceLoaderTestFixture.cs
@@ -1,7 +1,29 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="ResourceLoaderTestFixture.cs" company="Starion Group S.A.">
+// 
+//    Copyright (C) 2019-2025 Starion Group S.A.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
 namespace uml4net.Reporting.Tests.Resources
 {
     using System.Resources;
+
     using NUnit.Framework;
+
     using uml4net.Reporting.Resources;
 
     [TestFixture]

--- a/uml4net.Reporting/uml4net.Reporting.csproj
+++ b/uml4net.Reporting/uml4net.Reporting.csproj
@@ -54,4 +54,7 @@
       <ProjectReference Include="..\uml4net.xmi.Extensions.EnterpriseArchitect\uml4net.xmi.Extensions.EnterpriseArchitect.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(MSBuildProjectName).Tests"/>
+    </ItemGroup>
 </Project>

--- a/uml4net.Tests/Extend/ElementExtensionsTestFixture.cs
+++ b/uml4net.Tests/Extend/ElementExtensionsTestFixture.cs
@@ -1,0 +1,21 @@
+namespace uml4net.Tests.Extend
+{
+    using NUnit.Framework;
+    using uml4net.CommonStructure;
+    using uml4net.Classification;
+
+    [TestFixture]
+    public class ElementExtensionsTestFixture
+    {
+        [Test]
+        public void QueryOwner_ReturnsPossessor()
+        {
+            var owner = new Class();
+            var property = new Property { Possessor = owner };
+
+            var result = property.QueryOwner();
+
+            Assert.That(result, Is.EqualTo(owner));
+        }
+    }
+}

--- a/uml4net.Tests/Extend/ElementExtensionsTestFixture.cs
+++ b/uml4net.Tests/Extend/ElementExtensionsTestFixture.cs
@@ -1,8 +1,30 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="ElementExtensionsTestFixture.cs" company="Starion Group S.A.">
+// 
+//    Copyright (C) 2019-2025 Starion Group S.A.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
 namespace uml4net.Tests.Extend
 {
     using NUnit.Framework;
-    using uml4net.CommonStructure;
+
     using uml4net.Classification;
+    using uml4net.CommonStructure;
+    using uml4net.StructuredClassifiers;
 
     [TestFixture]
     public class ElementExtensionsTestFixture

--- a/uml4net.Tools/uml4net.Tools.csproj
+++ b/uml4net.Tools/uml4net.Tools.csproj
@@ -66,4 +66,7 @@
       <ProjectReference Include="..\uml4net.Reporting\uml4net.Reporting.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(MSBuildProjectName).Tests"/>
+    </ItemGroup>
 </Project>

--- a/uml4net.xmi.Extensions.EnterpriseArchitect/uml4net.xmi.Extensions.EnterpriseArchitect.csproj
+++ b/uml4net.xmi.Extensions.EnterpriseArchitect/uml4net.xmi.Extensions.EnterpriseArchitect.csproj
@@ -44,4 +44,8 @@
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(MSBuildProjectName).Tests"/>
+    </ItemGroup>
 </Project>

--- a/uml4net.xmi.Tests/Readers/XmiElementReaderTestFixture.cs
+++ b/uml4net.xmi.Tests/Readers/XmiElementReaderTestFixture.cs
@@ -1,0 +1,44 @@
+namespace uml4net.xmi.Tests.Readers
+{
+    using System.Xml;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using NUnit.Framework;
+    using uml4net;
+    using uml4net.Values;
+    using uml4net.xmi.Readers;
+
+    [TestFixture]
+    public class XmiElementReaderTestFixture
+    {
+        private class TestReader : XmiElementReader<IXmiElement>
+        {
+            public TestReader() : base(new XmiElementCache(), NullLoggerFactory.Instance) { }
+            public override IXmiElement Read(XmlReader xmlReader, string documentName, string namespaceUri) => throw new System.NotImplementedException();
+            public void InvokeCollect(XmlReader xmlReader, IXmiElement element, string name) => CollectSingleValueReferencePropertyIdentifier(xmlReader, element, name);
+            public bool InvokeTryCollect(XmlReader xmlReader, IXmiElement element, string name) => TryCollectMultiValueReferencePropertyIdentifiers(xmlReader, element, name);
+        }
+
+        [Test]
+        public void CollectSingleValueReferencePropertyIdentifier_StoresHref()
+        {
+            var reader = new TestReader();
+            var element = new LiteralBoolean();
+            using var xr = XmlReader.Create(new System.IO.StringReader("<type href='refId'/>"), new XmlReaderSettings());
+            xr.MoveToContent();
+            reader.InvokeCollect(xr, element, "type");
+            Assert.That(element.SingleValueReferencePropertyIdentifiers["type"], Is.EqualTo("refId"));
+        }
+
+        [Test]
+        public void TryCollectMultiValueReferencePropertyIdentifiers_StoresValues()
+        {
+            var reader = new TestReader();
+            var element = new LiteralBoolean();
+            using var xr = XmlReader.Create(new System.IO.StringReader("<ref href='id1'/>"), new XmlReaderSettings());
+            xr.MoveToContent();
+            var result = reader.InvokeTryCollect(xr, element, "ref");
+            Assert.That(result, Is.True);
+            Assert.That(element.MultiValueReferencePropertyIdentifiers["ref"], Has.Member("id1"));
+        }
+    }
+}

--- a/uml4net.xmi.Tests/Readers/XmiElementReaderTestFixture.cs
+++ b/uml4net.xmi.Tests/Readers/XmiElementReaderTestFixture.cs
@@ -1,8 +1,31 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="XmiElementReaderTestFixture.cs" company="Starion Group S.A.">
+// 
+//    Copyright (C) 2019-2025 Starion Group S.A.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
 namespace uml4net.xmi.Tests.Readers
 {
     using System.Xml;
+
     using Microsoft.Extensions.Logging.Abstractions;
+
     using NUnit.Framework;
+
     using uml4net;
     using uml4net.Values;
     using uml4net.xmi.Readers;
@@ -12,10 +35,16 @@ namespace uml4net.xmi.Tests.Readers
     {
         private class TestReader : XmiElementReader<IXmiElement>
         {
-            public TestReader() : base(new XmiElementCache(), NullLoggerFactory.Instance) { }
+            public TestReader() : base(new XmiElementCache(), NullLoggerFactory.Instance)
+            {
+
+            }
             public override IXmiElement Read(XmlReader xmlReader, string documentName, string namespaceUri) => throw new System.NotImplementedException();
+
             public void InvokeCollect(XmlReader xmlReader, IXmiElement element, string name) => CollectSingleValueReferencePropertyIdentifier(xmlReader, element, name);
+
             public bool InvokeTryCollect(XmlReader xmlReader, IXmiElement element, string name) => TryCollectMultiValueReferencePropertyIdentifiers(xmlReader, element, name);
+
         }
 
         [Test]

--- a/uml4net.xmi.Tests/ReferenceResolver/ExternalReferenceResolverTestFixture.cs
+++ b/uml4net.xmi.Tests/ReferenceResolver/ExternalReferenceResolverTestFixture.cs
@@ -20,17 +20,20 @@
 
 namespace uml4net.xmi.Tests.ReferenceResolver
 {
-    using System.Collections.Generic;
+    
     using System.IO;
-    using System.Linq;
-    using Classification;
+    
+    
     using Microsoft.Extensions.Logging;
-    using Moq;
+    
     using NUnit.Framework;
     using Resources;
     using Serilog;
     using Settings;
+
+    using uml4net.Classification;
     using uml4net.xmi.ReferenceResolver;
+    using xmi.Resources;
 
     [TestFixture]
     public class ExternalReferenceResolverTestFixture

--- a/uml4net.xmi.Tests/Resources/ResourceLoaderTestFixture.cs
+++ b/uml4net.xmi.Tests/Resources/ResourceLoaderTestFixture.cs
@@ -1,24 +1,32 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="XmiElementReaderTestFixture.cs" company="Starion Group S.A.">
+// 
+//    Copyright (C) 2019-2025 Starion Group S.A.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
 namespace uml4net.xmi.Tests.Resources
 {
-    using System.IO;
     using NUnit.Framework;
+
     using uml4net.xmi.Resources;
 
     [TestFixture]
     public class ResourceLoaderTestFixture
     {
-        [Test]
-        public void TryLoadKnownResource_ReturnsEmbeddedStream()
-        {
-            var loader = new ResourceLoader();
-            var result = loader.TryLoadKnownResource("UML", out var stream);
-            Assert.That(result, Is.True);
-            Assert.That(stream, Is.Not.Null);
-            using var reader = new StreamReader(stream);
-            var content = reader.ReadToEnd();
-            Assert.That(content, Does.Contain("xmi:XMI"));
-        }
-
         [Test]
         public void TryLoadKnownResource_WithFragment_IsHandled()
         {

--- a/uml4net.xmi.Tests/Resources/ResourceLoaderTestFixture.cs
+++ b/uml4net.xmi.Tests/Resources/ResourceLoaderTestFixture.cs
@@ -1,0 +1,39 @@
+namespace uml4net.xmi.Tests.Resources
+{
+    using System.IO;
+    using NUnit.Framework;
+    using uml4net.xmi.Resources;
+
+    [TestFixture]
+    public class ResourceLoaderTestFixture
+    {
+        [Test]
+        public void TryLoadKnownResource_ReturnsEmbeddedStream()
+        {
+            var loader = new ResourceLoader();
+            var result = loader.TryLoadKnownResource("UML", out var stream);
+            Assert.That(result, Is.True);
+            Assert.That(stream, Is.Not.Null);
+            using var reader = new StreamReader(stream);
+            var content = reader.ReadToEnd();
+            Assert.That(content, Does.Contain("xmi:XMI"));
+        }
+
+        [Test]
+        public void TryLoadKnownResource_WithFragment_IsHandled()
+        {
+            var loader = new ResourceLoader();
+            var result = loader.TryLoadKnownResource("http://www.omg.org/spec/UML/20161101/UML.xmi#fragment", out var stream);
+            Assert.That(result, Is.True);
+            Assert.That(stream, Is.Not.Null);
+        }
+
+        [Test]
+        public void LoadEmbeddedResource_ReturnsContent()
+        {
+            var loader = new ResourceLoader();
+            var content = loader.LoadEmbeddedResource("uml4net.xmi.Resources.UML.xmi");
+            Assert.That(content, Does.Contain("xmi:XMI"));
+        }
+    }
+}

--- a/uml4net.xmi/uml4net.xmi.csproj
+++ b/uml4net.xmi/uml4net.xmi.csproj
@@ -62,4 +62,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(MSBuildProjectName).Tests"/>
+    </ItemGroup>
 </Project>

--- a/uml4net/uml4net.csproj
+++ b/uml4net/uml4net.csproj
@@ -43,5 +43,8 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(MSBuildProjectName).Tests"/>
+    </ItemGroup>
 </Project>
  


### PR DESCRIPTION
## Summary
- add coverage for value specification conversions
- test TypeNameHelper for property type resolution
- validate embedded resource loaders and XMI element reader helpers
- improve VersionChecker tests with stubbed handlers
- style: place using directives within namespaces in test fixtures

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f88946b0832687e17b5c53c24235