### PR TITLE
Use StringComparison for case-insensitive checks

### DIFF
--- a/uml4net.CodeGenerator/Transformers/ModelTransformer.cs
+++ b/uml4net.CodeGenerator/Transformers/ModelTransformer.cs
@@ -74,7 +74,8 @@ namespace uml4net.CodeGenerator.Transformers
 
                 foreach (var @class in classes)
                 {
-                    var property = @class.QueryAllProperties().SingleOrDefault(x => x.Name.ToLowerInvariant()  == @class.Name.ToLowerInvariant());
+                    var property = @class.QueryAllProperties()
+                        .SingleOrDefault(x => string.Equals(x.Name, @class.Name, StringComparison.OrdinalIgnoreCase));
                     if (property != null)
                     {
                         var owner = property.Owner as INamedElement;

--- a/uml4net.Extensions/ElementExtensions.cs
+++ b/uml4net.Extensions/ElementExtensions.cs
@@ -222,7 +222,7 @@ namespace uml4net.Extensions
                     }
                 }
 
-                if (unwantedTags.Any(tag => tag == node.Name))
+                if (unwantedTags.Any(tag => string.Equals(tag, node.Name, StringComparison.OrdinalIgnoreCase)))
                 {
                     if (childNodes != null)
                     {


### PR DESCRIPTION
## Summary
- Use StringComparison.OrdinalIgnoreCase to compare class and property names in `ModelTransformer`
- Compare HTML tag names ignoring case in `ElementExtensions`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b48397f6148326939a450f1efe6479