### PR TITLE
fix: guard against malformed reference keys in ExternalReferenceResolver

### DIFF
--- a/uml4net.xmi.Tests/ReferenceResolver/ExternalReferenceResolverTestFixture.cs
+++ b/uml4net.xmi.Tests/ReferenceResolver/ExternalReferenceResolverTestFixture.cs
@@ -206,5 +206,23 @@ namespace uml4net.xmi.Tests.ReferenceResolver
 
             Assert.That(resolvedKnowReferences.Count, Is.EqualTo(0));
         }
+
+        [Test]
+        public void Verify_that_a_key_with_a_trailing_hash_is_not_processed_and_does_not_throw()
+        {
+            var property_1 = new Property
+            {
+                XmiId = "property_1",
+                Name = "IsValid",
+                DocumentName = "test",
+            };
+            property_1.SingleValueReferencePropertyIdentifiers.Add("type", "PrimitiveTypes#");
+
+            this.xmiElementCache.TryAdd(property_1);
+
+            var resolvedKnowReferences = this.referenceResolver.TryResolve("test");
+
+            Assert.That(resolvedKnowReferences.Count, Is.EqualTo(0));
+        }
     }
 }

--- a/uml4net.xmi/ReferenceResolver/ExternalReferenceResolver.cs
+++ b/uml4net.xmi/ReferenceResolver/ExternalReferenceResolver.cs
@@ -163,10 +163,19 @@ namespace uml4net.xmi.ReferenceResolver
         /// <c>true</c> if the context and resource ID were successfully resolved and, if applicable, the 
         /// context exists in the global cache; otherwise, <c>false</c>.
         /// </returns>
-        private static bool TryResolveContext(string resourceKey, out (string Context, string ResourceId) resolvedContextAndResource)
+        private bool TryResolveContext(string resourceKey, out (string Context, string ResourceId) resolvedContextAndResource)
         {
             var referenceString = resourceKey.Split(['#'], StringSplitOptions.RemoveEmptyEntries);
-            
+
+            if (referenceString.Length < 2)
+            {
+                logger.LogTrace("Resource key [{Key}] does not contain both a context and a resource id", resourceKey);
+
+                resolvedContextAndResource = default;
+
+                return false;
+            }
+
             resolvedContextAndResource = new ValueTuple<string, string>(referenceString[0], referenceString[1]);
 
             return true;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/uml4net/pulls) open
- [x] I have verified that I am following the ReqIFSharp [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/uml4net/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Fixes #174. A reference key such as `PrimitiveTypes#` passes `IsInvalidExternalResourceKey` but the trailing empty segment is dropped by `Split(StringSplitOptions.RemoveEmptyEntries)`, so `TryResolveContext` indexes `referenceString[1]` and throws an `IndexOutOfRangeException` that propagates out of `TryResolve`. `TryResolveContext` now checks that the split yields both a context and a resource id, logging a trace and returning `false` otherwise, and a test covers the malformed key case.
