### PR TITLE
fix: lower Microsoft.Extensions.Logging.Abstractions floor to 6.0.0

### DIFF
--- a/.github/workflows/nuget-reference-check.yml
+++ b/.github/workflows/nuget-reference-check.yml
@@ -27,8 +27,10 @@ jobs:
       run: |
         set -e
 
-        # Packages to ignore (SDK/runtime-managed)
-        IGNORE_PACKAGES="Microsoft\.NETCore\.Platforms|Microsoft\.NETCore\.Targets"
+        # Packages to ignore: SDK/runtime-managed, plus deliberately low-floored stable abstractions
+        # (Microsoft.Extensions.Logging.Abstractions is intentionally pinned to a low floor to avoid
+        # forcing version upgrades on downstream consumers - see uml4net/uml4net.csproj).
+        IGNORE_PACKAGES="Microsoft\.NETCore\.Platforms|Microsoft\.NETCore\.Targets|Microsoft\.Extensions\.Logging\.Abstractions"
 
         dotnet list uml4net.sln package --outdated --include-transitive > outdated-raw.log
 

--- a/uml4net.HandleBars/uml4net.HandleBars.csproj
+++ b/uml4net.HandleBars/uml4net.HandleBars.csproj
@@ -54,6 +54,11 @@
         <InternalsVisibleTo Include="$(MSBuildProjectName).Tests" />
     </ItemGroup>
 
+    <!-- Deliberate security override, NOT a normal dependency: forces the transitively-referenced
+         System.Private.Uri up to 4.3.2, which patches CVE-2019-0657 (domain spoofing) and CVE-2019-0981
+         (denial of service). This is a legacy out-of-band package and 4.3.2 is effectively terminal, so do
+         NOT "update" it when the reference check flags it as outdated. Remove this entire ItemGroup only
+         once no transitive dependency pulls in a vulnerable System.Private.Uri version. -->
     <ItemGroup Label="override transitive vulnerable dependency">
         <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     </ItemGroup>

--- a/uml4net/uml4net.csproj
+++ b/uml4net/uml4net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
       <TargetFramework>netstandard2.0</TargetFramework>
-      <Version>4.1.8</Version>
+      <Version>4.1.7</Version>
       <LangVersion>12.0</LangVersion>
       <Company>Starion Group S.A.</Company>
       <Copyright>Copyright © Starion Group S.A.</Copyright>

--- a/uml4net/uml4net.csproj
+++ b/uml4net/uml4net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
       <TargetFramework>netstandard2.0</TargetFramework>
-      <Version>4.1.7</Version>
+      <Version>4.1.8</Version>
       <LangVersion>12.0</LangVersion>
       <Company>Starion Group S.A.</Company>
       <Copyright>Copyright © Starion Group S.A.</Copyright>
@@ -28,8 +28,7 @@
       <GenerateDocumentationFile>true</GenerateDocumentationFile>
       <GenerateSBOM>true</GenerateSBOM>
       <PackageReleaseNotes>
-          [Update] Microsoft.Extensions.Logging.Abstractions to verion 10.0.7
-          [Update] Microsoft.SourceLink.GitHub to version 10.0.203
+          [Lower] Microsoft.Extensions.Logging.Abstractions floor to 6.0.0 to reduce consumer version conflicts
       </PackageReleaseNotes>
   </PropertyGroup>
 
@@ -41,7 +40,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+        <!-- Deliberately kept at a low floor: this is a stable abstraction consumed by uml4net's users.
+             NuGet unifies to the highest version in the consumer's graph, so a low floor avoids forcing
+             downstream apps to upgrade their Microsoft.Extensions.* stack. Do NOT bump on new releases;
+             raise only if a newer API is actually required. -->
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
     </ItemGroup>


### PR DESCRIPTION
### Description

In a consumed library, a `PackageReference` version is a **minimum floor** — NuGet unifies the dependency graph to the *highest* floor demanded across it. The previous `Microsoft.Extensions.Logging.Abstractions` floor of **10.0.7** therefore forced **every downstream consumer** to drag in `>= 10.0.7`, even apps on .NET 8 whose `Microsoft.Extensions.*` stack is 8.0.x — producing NU1605/NU1608 downgrade-conflict friction for an API that has been stable since the 2.x era. This works against uml4net's goal of broad adoption.

uml4net only uses the long-stable surface — `ILogger`, `ILogger<T>`, `ILoggerFactory`, and the `LogTrace/LogDebug/LogWarning/LogError` extensions — all present in 6.0.0. The floor is lowered to **6.0.0** (LTS lineage, netstandard2.0, clean closure, no known advisories) with **no source changes**. Consumers on net6–10 now satisfy the floor with their own (higher) version and are never forced to upgrade.

### Changes

- `uml4net/uml4net.csproj`: floor `10.0.7` → `6.0.0` with an explanatory comment; version bump `4.1.7` → `4.1.8` + release notes.
- `.github/workflows/nuget-reference-check.yml`: ignore this package in the **outdated** check so the daily job stops filing an issue demanding the bump we are intentionally avoiding. Deprecated/vulnerable checks remain fully active.
- `uml4net.HandleBars/uml4net.HandleBars.csproj`: add a comment documenting the existing `System.Private.Uri` 4.3.2 entry as a deliberate security override (patches CVE-2019-0657 / CVE-2019-0981) that must not be "updated" when flagged as outdated, and the condition under which it may be removed.

### Scope

Intentionally limited to the logging abstraction only. Autofac and the implementation libraries (ClosedXML, Svg, Microsoft.Msagl, HtmlAgilityPack, Handlebars.Net.Helpers) stay at current stable — flooring *implementation* libraries low would ship old/buggy code to consumers. The `System.Private.Uri` 4.3.2 override is untouched (only documented).

### Verification

- ✅ `dotnet build` — 0 errors (no new warnings).
- ✅ `dotnet list package` confirms the core lib resolves `6.0.0`.
- ✅ `dotnet test` — 350 passed, 0 failed across all 8 test projects (net10.0 test/tools projects resolve Abstractions upward to 10.x, exercising the unification behaviour that makes this safe).
- ✅ `dotnet list package --vulnerable --include-transitive` — no vulnerable packages.