### PR TITLE
docs: make NOTICE Apache-2.0 compliant, add THIRD-PARTY-NOTICES for bundled exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,43 @@ jobs:
             -r win-x64 --self-contained true -p:PublishSingleFile=true \
             -o ReleaseBuilds
 
+      - name: Generate THIRD-PARTY-NOTICES.txt for the bundled exe
+        run: |
+          set -euo pipefail
+
+          # The self-contained, single-file uml4net.Tools.exe bundles every
+          # transitive dependency's bytes, so we must redistribute their
+          # attribution/license notices alongside it. Generate them from the
+          # uml4net.Tools transitive dependency closure.
+          dotnet tool install --global nuget-license
+          export PATH="$PATH:$HOME/.dotnet/tools"
+
+          nuget-license \
+            --input uml4net.Tools/uml4net.Tools.csproj \
+            --include-transitive \
+            --output Markdown \
+            --file-output ReleaseBuilds/THIRD-PARTY-NOTICES.txt
+
+          # The exe is published --self-contained, so it also bundles the .NET
+          # runtime (Microsoft.NETCore.App), which the PackageReference-based
+          # tool above does not enumerate. Credit it explicitly.
+          cat >> ReleaseBuilds/THIRD-PARTY-NOTICES.txt <<'EOF'
+
+--------------------------------------------------------------------------------
+
+.NET Runtime
+Copyright (c) .NET Foundation and Contributors
+https://github.com/dotnet/runtime
+Licensed under the MIT License.
+
+The self-contained distribution bundles the .NET runtime and its libraries
+(Microsoft.NETCore.App). See https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
+for the full MIT License text.
+EOF
+
+          echo "----- THIRD-PARTY-NOTICES.txt (head) -----"
+          head -n 40 ReleaseBuilds/THIRD-PARTY-NOTICES.txt
+
       - name: Append binary SHA256 to release notes
         run: |
           set -euo pipefail
@@ -162,5 +199,6 @@ jobs:
           body_path: RELEASE_NOTES.md
           files: |
             ReleaseBuilds/uml4net.Tools.exe
+            ReleaseBuilds/THIRD-PARTY-NOTICES.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/NOTICE
+++ b/NOTICE
@@ -5,15 +5,7 @@ https://github.com/STARIONGROUP/uml4net
 This product includes software developed by Starion Group S.A.
 and contributors (https://github.com/STARIONGROUP/uml4net/graphs/contributors).
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
-This NOTICE file is part of the distribution of uml4net and must
-be included in all copies or substantial portions of the Software.
+The self-contained, single-file binary distribution of uml4net.Tools
+bundles third-party software (and the .NET runtime). Attribution and
+license notices for those components are provided in the accompanying
+THIRD-PARTY-NOTICES.txt file distributed alongside the executable.


### PR DESCRIPTION
## Context

Brings the `NOTICE` file in line with Apache 2.0 / ASF best practice and adds third-party attributions for the bundled executable.

Two issues were addressed:

1. **`NOTICE` was non-compliant.** It embedded the Apache *license grant* boilerplate ("Licensed under... WITHOUT WARRANTIES...") plus a non-standard "This NOTICE file is part of the distribution..." clause. A NOTICE file should be minimal — product name, copyright, and required attributions only (the full license text already lives in `LICENSE`).

2. **The self-contained `uml4net.Tools.exe` bundles dependencies.** The release workflow publishes it via `dotnet publish --self-contained -p:PublishSingleFile=true` and attaches it to every GitHub release. That single-file exe physically embeds every transitive dependency plus the .NET runtime, which triggers real redistribution obligations (Apache-2.0 section 4(d) NOTICE propagation for Serilog, and copyright/permission-notice preservation for the MIT/BSD/MS-PL deps). The NuGet packages are reference-only and carry no such obligation.

## Changes

- **`NOTICE`** — rewritten to minimal canonical form (product name, copyright `2019-2026`, repo URL, contributor attribution, pointer to the third-party notices). Still packed into every NuGet package.
- **`.github/workflows/release.yml`** — after the self-contained publish, auto-generate `THIRD-PARTY-NOTICES.txt` from the `uml4net.Tools` transitive dependency closure via `nuget-license` (markdown table of package/version/license/copyright/URLs), append a fixed .NET runtime credit (MIT, not enumerable from PackageReferences), and attach the file to the GitHub release alongside the exe.

## Verification

- Ran the generation step locally: produces a 56-package attribution table covering Apache-2.0 (`Serilog*`, `SixLabors.Fonts`), MS-PL (`Svg`), and the MIT set, followed by the .NET runtime block. Exit code 0.
- Confirmed the minimal `NOTICE` no longer contains license boilerplate and remains packed into the NuGet artifacts.
