### PR TITLE
fix: dispose AdhocWorkspace in code generation (#173)

### DIFF
--- a/uml4net.CodeGenerator/Generators/Generator.cs
+++ b/uml4net.CodeGenerator/Generators/Generator.cs
@@ -63,7 +63,7 @@ namespace uml4net.CodeGenerator.Generators
             ArgumentNullException.ThrowIfNullOrEmpty(generatedCode);
 
             generatedCode = generatedCode.Replace("&nbsp;", " ", StringComparison.OrdinalIgnoreCase);
-            var workspace = new AdhocWorkspace();
+            using var workspace = new AdhocWorkspace();
             var syntaxTree = CSharpSyntaxTree.ParseText(generatedCode);
             var root = syntaxTree.GetRoot();
             var formattedSyntaxNode = Formatter.Format(root, workspace);


### PR DESCRIPTION
Fixes #173

## Problem

`AdhocWorkspace` implements `IDisposable`, but the instance created in `Generator.CodeCleanup` (`uml4net.CodeGenerator/Generators/Generator.cs:66`) was never disposed — a new instance leaked on every formatted file. The code generator is a build-time tool (`IsPackable=false`), so production impact is limited, but the fix is trivial.

## Fix

Wrap the workspace in a `using` declaration so it is disposed when `CodeCleanup` returns.

## Verification

- `dotnet build uml4net.CodeGenerator` succeeds (no new warnings/errors).
- Generated code output is unchanged — only the workspace lifetime changes.