### PR TITLE
fix: remove duplicate Class.QueryAllOperations Handlebars helper (#172)

### DIFF
--- a/uml4net.HandleBars.Tests/ClassHelperTestFixture.cs
+++ b/uml4net.HandleBars.Tests/ClassHelperTestFixture.cs
@@ -35,6 +35,7 @@ namespace uml4net.HandleBars.Tests
 
     using Serilog;
 
+    using uml4net.Extensions;
     using uml4net.StructuredClassifiers;
     using uml4net.xmi;
     using uml4net.xmi.Readers;
@@ -113,6 +114,31 @@ namespace uml4net.HandleBars.Tests
             var property = activity.OwnedAttribute.First();
 
             Assert.That(() => action(property), Throws.TypeOf<ArgumentException>());
+        }
+
+        [Test]
+        public void Verify_that_QueryAllOperations_returns_expected_result()
+        {
+            var template = "{{#each (#Class.QueryAllOperations this) as | operation |}}{{ operation.Name }};{{/each}}";
+
+            var action = this.handlebarsContext.Compile(template);
+
+            var root = this.xmiReaderResult.QueryRoot(xmiId: "_0", name: "UML");
+
+            var commonStructurePackage = root.NestedPackage.Single(x => x.Name == "CommonStructure");
+            var dependency = commonStructurePackage.PackagedElement.OfType<IClass>().Single(x => x.Name == "Dependency");
+
+            var expected = string.Concat(dependency.QueryAllOperations().Select(x => $"{x.Name};"));
+
+            var result = action(dependency);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(expected, Is.Not.Empty);
+                Assert.That(result, Is.EqualTo(expected));
+            }
+
+            Assert.That(() => action(new Dependency()), Throws.ArgumentException);
         }
 
         [Test]

--- a/uml4net.HandleBars/ClassHelper.cs
+++ b/uml4net.HandleBars/ClassHelper.cs
@@ -288,21 +288,6 @@ namespace uml4net.HandleBars
                     options.Template(output, svg);
                 }
             });
-            
-            handlebars.RegisterHelper("Class.QueryAllOperations", (_, arguments) =>
-            {
-                if (arguments.Length != 1)
-                {
-                    throw new ArgumentException("#Class.QueryAllOperations expects to have  exactly 1 argument");
-                }
-
-                if (arguments[0] is not IClass umlClass)
-                {
-                    throw new ArgumentException("#Class.QueryAllOperations argument should be an IClass");
-                }
-
-                return umlClass.QueryAllOperations();
-            });
         }
     }
 }


### PR DESCRIPTION
Fixes #172

## Problem

`Class.QueryAllOperations` was registered twice in `uml4net.HandleBars/ClassHelper.cs` — once in the context form (`(context, _)`, reading `context.Value`) and once in the argument form (`(_, arguments)`, requiring exactly one argument). Handlebars.NET keeps only the last registration, so one registration was always dead code.

## Fix

Removed the duplicate and kept a single **context-form** registration, consistent with the sibling `Class.Query*` helpers (`QueryAllProperties`, `QueryAllConstraints`, `QueryAllSpecializations`, …) that are invoked identically on adjacent lines of `uml-to-html-docs.hbs` (621/672/701). Added a regression test mirroring the established sibling-test pattern.

## Why the context form

Both production templates invoke the helper without a `#` prefix and inside an `{{#each … as | class |}}` block, where the context and the passed argument are the same class — so either registration renders correctly:

- uml4net: `{{ #each (Class.QueryAllOperations class) as | operation | }}`
- SysML2.NET: `{{#each (Class.QueryAllOperations this) as | operation | }}`

The deciding factor is therefore consistency with the sibling helpers on the same template lines.

## Downstream impact (SysML2.NET)

SysML2.NET consumes `uml4net.HandleBars` via NuGet and has no own `Class.QueryAllOperations` registration — it relies on this one and calls it in the argument form `(Class.QueryAllOperations this)`, which the kept context form renders correctly. No change is needed there; it will pick up the de-duplicated helper on its next `uml4net.HandleBars` bump.

## Verification

- `uml4net.HandleBars.Tests`: 42/42 passed (incl. the new `Verify_that_QueryAllOperations_returns_expected_result` regression test).
- `uml4net.Reporting.Tests`: 51/51 passed (incl. end-to-end UML + SysML2 report generation that renders the production no-`#` form).
