### PR TITLE
docs: document that XmiInspector omits attribute-less elements (#175)

### DIFF
--- a/uml4net.Reporting.Tests/Generators/XmiInspectorTestFixture.cs
+++ b/uml4net.Reporting.Tests/Generators/XmiInspectorTestFixture.cs
@@ -84,5 +84,34 @@ namespace uml4net.Reporting.Tests.Generators
 
             }, Throws.Nothing);
         }
+
+        [Test]
+        public void Verify_that_elements_without_attributes_are_omitted_from_the_report()
+        {
+            var xmi = """
+                      <?xml version="1.0" encoding="utf-8"?>
+                      <root>
+                        <withAttributes id="1" name="foo" />
+                        <withoutAttributes />
+                      </root>
+                      """;
+
+            var inputFileInfo = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "attribute-less-inspection-input.xmi"));
+            File.WriteAllText(inputFileInfo.FullName, xmi);
+
+            this.xmiInspector = new XmiInspector(this.loggerFactory);
+
+            var result = this.xmiInspector.Inspect(inputFileInfo);
+
+            using (Assert.EnterMultipleScope())
+            {
+                // elements that carry attributes are reported as "element: attr attr"
+                Assert.That(result, Is.EqualTo("withAttributes: id name"));
+
+                // the attribute-less "root" and "withoutAttributes" elements are intentionally omitted
+                Assert.That(result, Does.Not.Contain("withoutAttributes"));
+                Assert.That(result, Does.Not.Contain("root"));
+            }
+        }
     }
 }

--- a/uml4net.Reporting/Generators/XmiInspector.cs
+++ b/uml4net.Reporting/Generators/XmiInspector.cs
@@ -90,13 +90,16 @@ namespace uml4net.Reporting.Generators
                     {
                         var entry = $"{xmlReader.Name}:";
 
+                        // The inspector reports the distinct element-to-attribute combinations found in the
+                        // XMI. Elements without attributes carry no such combination and are intentionally
+                        // omitted from the report, so result.Add is only reached when attributes are present.
                         if (xmlReader.HasAttributes)
                         {
                             while (xmlReader.MoveToNextAttribute())
                             {
                                 entry = $"{entry} {xmlReader.Name}";
                             }
-   
+
                             xmlReader.MoveToElement();
                             result.Add(entry);
                         }


### PR DESCRIPTION
Fixes #175

## Background

`XmiInspector.Inspect` builds a deduplicated, sorted text report of distinct `element: attr1 attr2 …` combinations from the raw XMI — a diagnostic for seeing which element/attribute shapes exist in a file. `result.Add(entry)` sits inside the `if (xmlReader.HasAttributes)` block, so elements without attributes never appear in the report.

## Decision

This omission is **intentional**: the inspector reports element-to-attribute combinations, and an attribute-less element carries no such combination. Rather than change the behavior, this PR makes the intent explicit and pins it down with a test (per the issue's acceptance criteria).

## Changes

- **`uml4net.Reporting/Generators/XmiInspector.cs`** — added a comment documenting that attribute-less elements are intentionally omitted, so `result.Add` is deliberately reached only when attributes are present.
- **`uml4net.Reporting.Tests/Generators/XmiInspectorTestFixture.cs`** — added `Verify_that_elements_without_attributes_are_omitted_from_the_report`, which feeds a small XMI with one attributed element and two attribute-less ones (`root`, `withoutAttributes`) and asserts the report is exactly `"withAttributes: id name"`, excluding the attribute-less elements.

## Verification

`XmiInspectorTestFixture`: 3/3 passed (including the new regression test).
