### PR TITLE
[Bug] surface the reason when auto-opening the generated report fails; fixes #177

### DIFF
--- a/uml4net.Tools.Tests/Commands/ReportHandlerTestFixture.cs
+++ b/uml4net.Tools.Tests/Commands/ReportHandlerTestFixture.cs
@@ -21,6 +21,7 @@
 namespace uml4net.Tools.Tests.Commands
 {
     using System;
+    using System.Collections.Generic;
     using System.ComponentModel;
 
     using Moq;
@@ -65,6 +66,38 @@ namespace uml4net.Tools.Tests.Commands
             }
         }
 
+        [Test]
+        public void Verify_that_OpenGeneratedReport_reports_success_when_the_report_can_be_opened()
+        {
+            var handler = new TestableReportHandler(exceptionToThrow: null);
+
+            var statuses = new List<string>();
+
+            handler.InvokeOpenGeneratedReport(statuses.Add);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(statuses, Does.Contain("Opening generated report"));
+                Assert.That(statuses, Does.Contain("Generated report opened"));
+            }
+        }
+
+        [Test]
+        public void Verify_that_OpenGeneratedReport_reports_failure_when_opening_fails()
+        {
+            var handler = new TestableReportHandler(new Win32Exception("Access is denied"));
+
+            var statuses = new List<string>();
+
+            handler.InvokeOpenGeneratedReport(statuses.Add);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(statuses, Does.Contain("Opening of generated report failed, please open manually"));
+                Assert.That(statuses, Does.Not.Contain("Generated report opened"));
+            }
+        }
+
         /// <summary>
         /// Test double that overrides the actual process launch so the best-effort open logic can be exercised
         /// without starting an external process.
@@ -82,6 +115,11 @@ namespace uml4net.Tools.Tests.Commands
             public bool InvokeTryOpenReport(out string failureReason)
             {
                 return this.TryOpenReport(out failureReason);
+            }
+
+            public void InvokeOpenGeneratedReport(Action<string> updateStatus)
+            {
+                this.OpenGeneratedReport(updateStatus);
             }
 
             protected override void OpenReport()

--- a/uml4net.Tools.Tests/Commands/ReportHandlerTestFixture.cs
+++ b/uml4net.Tools.Tests/Commands/ReportHandlerTestFixture.cs
@@ -1,0 +1,96 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="ReportHandlerTestFixture.cs" company="Starion Group S.A.">
+//
+//    Copyright (C) 2019-2026 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace uml4net.Tools.Tests.Commands
+{
+    using System;
+    using System.ComponentModel;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using uml4net.Reporting.Generators;
+    using uml4net.Tools.Commands;
+    using uml4net.Tools.Services;
+
+    /// <summary>
+    /// Suite of tests for the best-effort report opening behaviour of the <see cref="ReportHandler"/> class.
+    /// </summary>
+    [TestFixture]
+    public class ReportHandlerTestFixture
+    {
+        [Test]
+        public void Verify_that_TryOpenReport_returns_true_when_the_report_can_be_opened()
+        {
+            var handler = new TestableReportHandler(exceptionToThrow: null);
+
+            var success = handler.InvokeTryOpenReport(out var failureReason);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(success, Is.True);
+                Assert.That(failureReason, Is.Null);
+            }
+        }
+
+        [Test]
+        public void Verify_that_TryOpenReport_returns_false_and_a_reason_when_opening_fails()
+        {
+            var handler = new TestableReportHandler(new Win32Exception("Access is denied"));
+
+            var success = handler.InvokeTryOpenReport(out var failureReason);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(success, Is.False);
+                Assert.That(failureReason, Is.EqualTo("Access is denied"));
+            }
+        }
+
+        /// <summary>
+        /// Test double that overrides the actual process launch so the best-effort open logic can be exercised
+        /// without starting an external process.
+        /// </summary>
+        private sealed class TestableReportHandler : ReportHandler
+        {
+            private readonly Exception exceptionToThrow;
+
+            public TestableReportHandler(Exception exceptionToThrow)
+                : base(Mock.Of<IReportGenerator>(), Mock.Of<IVersionChecker>())
+            {
+                this.exceptionToThrow = exceptionToThrow;
+            }
+
+            public bool InvokeTryOpenReport(out string failureReason)
+            {
+                return this.TryOpenReport(out failureReason);
+            }
+
+            protected override void OpenReport()
+            {
+                if (this.exceptionToThrow != null)
+                {
+                    throw this.exceptionToThrow;
+                }
+            }
+        }
+    }
+}

--- a/uml4net.Tools/Commands/ReportHandler.cs
+++ b/uml4net.Tools/Commands/ReportHandler.cs
@@ -303,22 +303,34 @@ namespace uml4net.Tools.Commands
         {
             if (this.autoOpenReport)
             {
-                ctx.Status("Opening generated report");
-                Thread.Sleep(1500);
-
-                if (this.TryOpenReport(out var failureReason))
-                {
-                    ctx.Status("Generated report opened");
-                }
-                else
-                {
-                    ctx.Status("Opening of generated report failed, please open manually");
-                    Thread.Sleep(1500);
-
-                    AnsiConsole.MarkupLine($"[yellow]The generated report could not be opened automatically: {Markup.Escape(failureReason)}[/]");
-                    AnsiConsole.MarkupLine($"[yellow]Please open it manually at [bold]{Markup.Escape(this.outputReport.FullName)}[/][/]");
-                }
+                this.OpenGeneratedReport(status => ctx.Status(status));
             }
+        }
+
+        /// <summary>
+        /// Opens the generated report on a best-effort basis, reporting progress through the provided
+        /// <paramref name="updateStatus"/> callback. When opening fails, the reason and the report path are
+        /// written to the console so the report can still be opened manually.
+        /// </summary>
+        /// <param name="updateStatus">
+        /// Callback used to surface progress to the user (e.g. the Spectre <see cref="StatusContext"/> status)
+        /// </param>
+        protected void OpenGeneratedReport(Action<string> updateStatus)
+        {
+            updateStatus("Opening generated report");
+            Thread.Sleep(1500);
+
+            if (this.TryOpenReport(out var failureReason))
+            {
+                updateStatus("Generated report opened");
+                return;
+            }
+
+            updateStatus("Opening of generated report failed, please open manually");
+            Thread.Sleep(1500);
+
+            AnsiConsole.MarkupLine($"[yellow]The generated report could not be opened automatically: {Markup.Escape(failureReason)}[/]");
+            AnsiConsole.MarkupLine($"[yellow]Please open it manually at [bold]{Markup.Escape(this.outputReport?.FullName ?? string.Empty)}[/][/]");
         }
 
         /// <summary>

--- a/uml4net.Tools/Commands/ReportHandler.cs
+++ b/uml4net.Tools/Commands/ReportHandler.cs
@@ -23,6 +23,7 @@ namespace uml4net.Tools.Commands
     using System;
     using System.Collections.Generic;
     using System.CommandLine;
+    using System.ComponentModel;
     using System.Diagnostics;
     using System.Globalization;
     using System.IO;
@@ -305,18 +306,53 @@ namespace uml4net.Tools.Commands
                 ctx.Status("Opening generated report");
                 Thread.Sleep(1500);
 
-                try
+                if (this.TryOpenReport(out var failureReason))
                 {
-                    Process.Start(new ProcessStartInfo(this.outputReport.FullName)
-                    { UseShellExecute = true });
                     ctx.Status("Generated report opened");
                 }
-                catch
+                else
                 {
                     ctx.Status("Opening of generated report failed, please open manually");
                     Thread.Sleep(1500);
+
+                    AnsiConsole.MarkupLine($"[yellow]The generated report could not be opened automatically: {Markup.Escape(failureReason)}[/]");
+                    AnsiConsole.MarkupLine($"[yellow]Please open it manually at [bold]{Markup.Escape(this.outputReport.FullName)}[/][/]");
                 }
             }
+        }
+
+        /// <summary>
+        /// Attempts to open the generated report on a best-effort basis
+        /// </summary>
+        /// <param name="failureReason">
+        /// When the report could not be opened, contains a short reason describing why; otherwise <c>null</c>
+        /// </param>
+        /// <returns>
+        /// true when the report was opened, false when opening failed
+        /// </returns>
+        protected bool TryOpenReport(out string failureReason)
+        {
+            try
+            {
+                this.OpenReport();
+                failureReason = null;
+                return true;
+            }
+            catch (Exception exception) when (exception is Win32Exception or InvalidOperationException or FileNotFoundException or ObjectDisposedException or PlatformNotSupportedException)
+            {
+                // these are the exceptions Process.Start can raise (e.g. no associated application,
+                // access denied, missing file); surface the reason rather than swallowing it silently
+                failureReason = exception.Message;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Opens the generated report using the operating system's default application
+        /// </summary>
+        protected virtual void OpenReport()
+        {
+            Process.Start(new ProcessStartInfo(this.outputReport.FullName) { UseShellExecute = true });
         }
     }
 }


### PR DESCRIPTION
Fixes #177

## Problem

`ReportHandler.ExecuteAutoOpen` wrapped `Process.Start(...)` in a bare `catch { }` when auto-opening the generated report. Every exception was discarded, so the user only saw "Opening of generated report failed, please open manually" with no indication of why (permissions, no associated application, missing file, ...).

## Fix

- Extracted `protected virtual void OpenReport()` (the `Process.Start` call) so the open step is overridable and testable.
- Added `protected bool TryOpenReport(out string failureReason)` that catches the specific exceptions `Process.Start` can raise (`Win32Exception`, `InvalidOperationException`, `FileNotFoundException`, `ObjectDisposedException`, `PlatformNotSupportedException`) and surfaces the reason instead of swallowing it. Best-effort behaviour is preserved — no unexpected exception type is silently caught.
- On failure, `ExecuteAutoOpen` now prints the reason and reiterates the report path so the user can open it manually.
- Added `using System.ComponentModel;` for `Win32Exception`.

## Verification

- Added `ReportHandlerTestFixture` with a test double that overrides `OpenReport()` to cover both the success path (`true`, null reason) and the failure path (`false`, reason surfaced).
- Full `uml4net.Tools.Tests`: 32/32 passed.
