### PR TITLE
[Bug] include composition target classes as interesting classes; fixes #103

### DIFF
--- a/uml4net.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
+++ b/uml4net.Reporting.Tests/Generators/ModelInspectorTestFixture.cs
@@ -31,8 +31,11 @@ namespace uml4net.Reporting.Tests.Generators
 
     using Serilog;
 
+    using uml4net.Classification;
     using uml4net.Packages;
     using uml4net.Reporting.Generators;
+    using uml4net.StructuredClassifiers;
+    using uml4net.Values;
     using uml4net.xmi;
 
     [TestFixture]
@@ -191,7 +194,7 @@ namespace uml4net.Reporting.Tests.Generators
             var expectedResult = new List<string>
             {
                 "ActivityGroup", "Association", "Behavior", "Class", "Classifier", "Clause",
-                "ComponentRealization","Connector","CreateLinkAction", "DurationConstraint", "DurationObservation",
+                "ComponentRealization","Connector","ConnectorEnd","CreateLinkAction", "DurationConstraint", "DurationObservation",
                 "Element", "Extend", "Extension", "ExtensionEnd",
                 "LiteralInteger", "LiteralReal", "LiteralUnlimitedNatural", "MultiplicityElement",
                 "NamedElement", "OpaqueExpression", "Operation", "PackageableElement",
@@ -227,13 +230,13 @@ namespace uml4net.Reporting.Tests.Generators
 
             var expectedResult = new List<string>
             {
-                "ActivityGroup", "Association", "Behavior", "Class", "Classifier", "Clause",
-                "ComponentRealization", "Connector", "CreateLinkAction", "DurationConstraint", "DurationObservation",
-                "Element", "Extend", "Extension", "ExtensionEnd",
+                "Association", "Behavior", "Class", "Classifier", "Clause",
+                "ComponentRealization", "ConnectorEnd", "CreateLinkAction", "DurationConstraint", "DurationObservation",
+                "Element", "Extend", "Extension", "ExtensionEnd", "LinkAction",
                 "LiteralInteger", "LiteralReal", "LiteralUnlimitedNatural", "Message", "MultiplicityElement",
                 "NamedElement", "Namespace", "OpaqueExpression", "Operation", "PackageableElement",
-                "RedefinableTemplateSignature", "Region", "Relationship", "StructuredActivityNode", "TimeConstraint",
-                "UnmarshallAction", "ValueSpecification"
+                "RedefinableTemplateSignature", "Region", "Relationship", "StateInvariant", "StructuredActivityNode", "TimeConstraint",
+                "ValueSpecification"
             };
 
             using (Assert.EnterMultipleScope())
@@ -242,6 +245,39 @@ namespace uml4net.Reporting.Tests.Generators
 
                 // including operations introduces additional variations to cover, so the result must differ from the default
                 Assert.That(withOperations, Is.Not.EquivalentTo(withoutOperations));
+            }
+        }
+
+        [Test]
+        public void Verify_that_target_class_of_a_zero_to_one_composition_is_an_interesting_class()
+        {
+            // class A contains B via a 0..1 composition; B owns no properties of its own, so before
+            // the fix for issue #103 it was never reported as an interesting class
+            var containedClass = new Class { Name = "B" };
+
+            var compositeProperty = new Property
+            {
+                Name = "b",
+                Type = containedClass,
+                Aggregation = AggregationKind.Composite
+            };
+            compositeProperty.LowerValue.Add(new LiteralInteger { Value = 0 });
+
+            var containingClass = new Class { Name = "A" };
+            containingClass.OwnedAttribute.Add(compositeProperty);
+
+            var package = new Package { Name = "P" };
+            package.PackagedElement.Add(containingClass);
+            package.PackagedElement.Add(containedClass);
+
+            this.modelInspector = new ModelInspector(this.loggerFactory);
+
+            var interestingClasses = this.modelInspector.QueryInterestingClasses(package).Select(x => x.Name).ToList();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(interestingClasses, Does.Contain("B"));
+                Assert.That(interestingClasses, Does.Contain("A"));
             }
         }
 

--- a/uml4net.Reporting/Generators/ModelInspector.cs
+++ b/uml4net.Reporting/Generators/ModelInspector.cs
@@ -288,9 +288,17 @@ namespace uml4net.Reporting.Generators
 
             var classes = package.QueryPackages().SelectMany(x => x.PackagedElement.OfType<IClass>()).ToList();
 
+            // Seed every class with an empty variation set up front so that variations can be
+            // attributed to a class other than the one that owns the property (e.g. the target
+            // class of a composition - see the Contained variation below)
             foreach (var @class in classes)
             {
-                var propertyVariations = new HashSet<string>();
+                classPropertyVariations[@class] = new HashSet<string>();
+            }
+
+            foreach (var @class in classes)
+            {
+                var propertyVariations = classPropertyVariations[@class];
 
                 foreach (var property in @class.OwnedAttribute)
                 {
@@ -329,6 +337,16 @@ namespace uml4net.Reporting.Generators
                         }
 
                         propertyVariations.Add(referenceType);
+
+                        // The target class of a composition is implemented differently because it is
+                        // contained; attribute a multiplicity-aware containment variation to that class so
+                        // it becomes a candidate interesting class in its own right (see issue #103)
+                        if (property.IsComposite
+                            && property.Type is IClass containedClass
+                            && classPropertyVariations.TryGetValue(containedClass, out var containedVariations))
+                        {
+                            containedVariations.Add($"CONTAINED:{property.Lower}:{property.Upper}");
+                        }
                     }
 
                     if (property.QueryIsValueType())
@@ -398,8 +416,6 @@ namespace uml4net.Reporting.Generators
                         }
                     }
                 }
-
-                classPropertyVariations.Add(@class, propertyVariations);
             }
 
             return classPropertyVariations;


### PR DESCRIPTION
Fixes #103

## Problem

`ModelInspector.QueryInterestingClasses` returns a minimal representative set of classes that together cover every distinct structural property "variation" (a greedy set-cover). Variation tokens were attributed **only to the class that owns a property**. So when a class owns a composite (composition) property with multiplicity 0..1 — e.g. `LogarithmicScale` contains `ScaleReferenceQuantityValue [0..1]` — only `LogarithmicScale` (token `REF:0:1:composite`) was marked interesting. The **target/contained** class `ScaleReferenceQuantityValue` owns no special property, contributed no tokens, and was never selected, even though a 0..1-contained class is implemented differently (database-wise).

## Fix

In `MapClassPropertyVariation` (`uml4net.Reporting/Generators/ModelInspector.cs`):

- Pre-seed the variation dictionary with every class (empty sets) so variations can be attributed to a class other than the one owning the property.
- For each composite property, attribute a multiplicity-aware containment token `CONTAINED:{lower}:{upper}` to the **target** class, making "being the target of a composition" a coverable variation. The greedy set-cover then includes a representative contained class per distinct containment multiplicity.

Owner tokens are unchanged. `Inspect(IPackage, bool)` shares this method, so its report picks up the new variation automatically.

## Tests

- New synthetic regression test: class A contains B via a 0..1 composition (B owns no properties); asserts B is now reported as interesting.
- Updated the two characterization tests:
  - **without operations**: cleanly gains `ConnectorEnd`.
  - **with operations**: the greedy reducer selects different equally-valid representatives (−ActivityGroup/Connector/UnmarshallAction, +ConnectorEnd/LinkAction/StateInvariant) — deterministic, still a valid minimal cover, with the contained class `ConnectorEnd` now represented.

## Verification

- `ModelInspectorTestFixture`: 9/9 passed.
- Full `uml4net.Reporting.Tests`: 53/53 passed.
- New lines fully exercised by the synthetic test + UML-model tests (the only uncovered points in the method are pre-existing variation branches).
