### PR TITLE
[Bug] fix invalid YAML in release workflow heredoc causing startup failures

### DIFF
--- a/.github/workflows/nuget-release.yml
+++ b/.github/workflows/nuget-release.yml
@@ -153,19 +153,19 @@ jobs:
           # The exe is published --self-contained, so it also bundles the .NET
           # runtime (Microsoft.NETCore.App), which the PackageReference-based
           # tool above does not enumerate. Credit it explicitly.
-          cat >> ReleaseBuilds/THIRD-PARTY-NOTICES.txt <<'EOF'
-
---------------------------------------------------------------------------------
-
-.NET Runtime
-Copyright (c) .NET Foundation and Contributors
-https://github.com/dotnet/runtime
-Licensed under the MIT License.
-
-The self-contained distribution bundles the .NET runtime and its libraries
-(Microsoft.NETCore.App). See https://github.com/dotnet/runtime/blob/main/LICENSE.TXT
-for the full MIT License text.
-EOF
+          printf '%s\n' \
+            '' \
+            '--------------------------------------------------------------------------------' \
+            '' \
+            '.NET Runtime' \
+            'Copyright (c) .NET Foundation and Contributors' \
+            'https://github.com/dotnet/runtime' \
+            'Licensed under the MIT License.' \
+            '' \
+            'The self-contained distribution bundles the .NET runtime and its libraries' \
+            '(Microsoft.NETCore.App). See https://github.com/dotnet/runtime/blob/main/LICENSE.TXT' \
+            'for the full MIT License text.' \
+            >> ReleaseBuilds/THIRD-PARTY-NOTICES.txt
 
           echo "----- THIRD-PARTY-NOTICES.txt (head) -----"
           head -n 40 ReleaseBuilds/THIRD-PARTY-NOTICES.txt


### PR DESCRIPTION
## Problem

The `Nuget-Release` workflow was running on **every push** (as failed runs), no longer showed the manual "Run workflow" button, and appeared in the Actions UI as `.github/workflows/nuget-release.yml` instead of `Nuget-Release`.

Root cause: **the workflow file is invalid YAML.** In the *Generate THIRD-PARTY-NOTICES.txt* step the heredoc body and its `EOF` terminator sit at **column 0**, but they live inside a `run: |` block scalar indented 10 spaces. A line less-indented than the block terminates the YAML scalar, so the parser then tries to read `------`, `.NET Runtime`, `https://…` as workflow structure and fails.

A single invalid file produces all three symptoms:

| Symptom | Cause |
|---|---|
| Runs on every commit | Invalid file → GitHub creates a **startup-failure** run on each push |
| No "Run workflow" button | Parser never reads `on: workflow_dispatch` |
| Name shown as file path | Parser never reads `name:` |

Introduced in #182 (commit `b3c3b4f1`) when the THIRD-PARTY-NOTICES block was added — exactly when manual dispatch stopped working.

## Fix

Replace the `cat <<'EOF'` heredoc with an indented `printf` that produces byte-identical output. A heredoc can't be used here cleanly: its `EOF` terminator must be at column 0 (which breaks the YAML), and `<<-` only strips tabs (banned by the project style). With `printf`, every line stays inside the block scalar, so the file is valid YAML and bash output is unchanged.

## Verification (after merge to `development`)

```
gh api repos/STARIONGROUP/uml4net/actions/workflows --jq '.workflows[] | {name, path, state}'
```
The release entry should now show `name: Nuget-Release` (not the path). Then push a commit and confirm **no** new startup-failure run is created, and that the "Run workflow" dropdown appears in the Actions tab.
