### PR TITLE
[Bug] resolve bare same-document href references; fixes #192

### DIFF
--- a/resources/SySML2/KerML_only_xmi.uml
+++ b/resources/SySML2/KerML_only_xmi.uml
@@ -1,0 +1,7845 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_mcxnIFn3EfG_XZTXp4TXuA" name="KerML" URI="https://www.omg.org/spec/KerML/20250201">
+  <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1562427331290_651623_19809" name="Root" visibility="public" URI="">
+    <ownedComment xmi:id="_19_0_2_12e503d9_1584042059016_401103_80" annotatedElement="_18_5_3_12e503d9_1562427331290_651623_19809">
+      <body>The Root layer provides the syntactic foundation for KerML.
+</body>
+    </ownedComment>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1594006176967_759898_16" name="Dependencies" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1594006219028_628649_74" name="Dependency" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1594006719188_539702_234" annotatedElement="_19_0_2_12e503d9_1594006219028_628649_74">
+          <body>&lt;p>A &lt;code>Dependency&lt;/code> is a &lt;code>Relationship&lt;/code> that indicates that one or more &lt;code>client&lt;/code> &lt;code>Elements&lt;/code> require one more &lt;code>supplier&lt;/code> &lt;code>Elements&lt;/code> for their complete specification. In general, this means that a change to one of the &lt;code>supplier&lt;/code> &lt;code>Elements&lt;/code> may necessitate a change to, or re-specification of, the &lt;code>client&lt;/code> &lt;code>Elements&lt;/code>.&lt;/p>
+
+&lt;p>Note that a &lt;code>Dependency&lt;/code> is entirely a model-level &lt;code>Relationship&lt;/code>, without instance-level semantics.&lt;/p></body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_2_12e503d9_1594006233935_75175_101" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594006406653_175551_182" name="client" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" association="_19_0_2_12e503d9_1594006406652_46598_181">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594007011173_654654_235" annotatedElement="_19_0_2_12e503d9_1594006406653_175551_182">
+            <body>&lt;p>The &lt;code>Element&lt;/code> or &lt;code>Elements&lt;/code> dependent on the &lt;code>supplier&lt;/code> &lt;code>Elements&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594006452323_979997_192" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594006452331_684227_193" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594006525044_548771_207" name="supplier" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_19_0_2_12e503d9_1594006525044_799593_206">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594007053545_534588_236" annotatedElement="_19_0_2_12e503d9_1594006525044_548771_207">
+            <body>&lt;p>The &lt;code>Element&lt;/code> or &lt;code>Elements&lt;/code> on which the &lt;code>client&lt;/code> &lt;code>Elements&lt;/code> depend in some respect.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594006549522_180410_217" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594006549522_35681_218" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594006525044_799593_206" name="A_supplier_supplierDependency" visibility="public" memberEnd="_19_0_2_12e503d9_1594006525044_548771_207 _19_0_2_12e503d9_1594006525045_138636_208">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1594006525045_138636_208" name="supplierDependency" visibility="public" type="_19_0_2_12e503d9_1594006219028_628649_74" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_2_12e503d9_1594006525044_799593_206">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594007189145_760656_248" annotatedElement="_19_0_2_12e503d9_1594006525045_138636_208">
+            <body>&lt;p>The &lt;code>Dependencies&lt;/code> that have a certain &lt;code>supplier&lt;/code> &lt;code>Element&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594006574251_744092_223" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594006574251_758618_224" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594006406652_46598_181" name="A_client_clientDependency" visibility="public" memberEnd="_19_0_2_12e503d9_1594006406653_175551_182 _19_0_2_12e503d9_1594006406653_821287_183">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1594006406653_821287_183" name="clientDependency" visibility="public" type="_19_0_2_12e503d9_1594006219028_628649_74" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227" association="_19_0_2_12e503d9_1594006406652_46598_181">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594007091851_632292_237" annotatedElement="_19_0_2_12e503d9_1594006406653_821287_183">
+            <body>&lt;p>The &lt;code>Dependencies&lt;/code> that have a certain &lt;code>client&lt;/code> &lt;code>Element&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594006472189_64499_198" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594006472189_593514_199" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1561108673940_450237_22418" name="Annotations" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651696_959404_42181" name="Comment" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1584041457850_499683_63" annotatedElement="_18_5_3_12e503d9_1533160651696_959404_42181">
+          <body>&lt;p>A &lt;code>Comment&lt;/code> is an &lt;code>AnnotatingElement&lt;/code> whose &lt;code>body&lt;/code> in some way describes its &lt;code>annotatedElements&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674981_420870_43276" general="_19_0_2_12e503d9_1594145576693_532940_27"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1647722682836_708148_649" name="locale" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1647723182272_992119_903" annotatedElement="_19_0_4_12e503d9_1647722682836_708148_649">
+            <body>&lt;p>Identification of the language of the &lt;code>body&lt;/code> text and, optionally, the region and/or encoding. The format shall be a POSIX locale conformant to ISO/IEC 15897, with the format &lt;code>[language[_territory][.codeset][@modifier]]&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1647722691598_544046_653" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1647722691601_276909_654" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674981_840045_43277" name="body" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1584043589202_304398_10" annotatedElement="_18_5_3_12e503d9_1533160674981_840045_43277">
+            <body>&lt;p>The annotation text for the &lt;code>Comment&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594152358971_349818_2489" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594152358971_895419_2490" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1543093613150_792705_18263" name="Annotation" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1584041437410_19649_62" annotatedElement="_18_5_3_12e503d9_1543093613150_792705_18263">
+          <body>&lt;p>An &lt;code>Annotation&lt;/code> is a Relationship between an &lt;code>AnnotatingElement&lt;/code> and the &lt;code>Element&lt;/code> that is annotated by that &lt;code>AnnotatingElement&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735845748382_511506_43" name="validateAnnotationAnnotatedElementOwnership" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735845875266_558043_45" annotatedElement="_2022x_2_12e503d9_1735845748382_511506_43">
+            <body>&lt;p>An &lt;code>Annotation&lt;/code> owns its &lt;code>annotatingElement&lt;/code> if and only if it is owned by its &lt;code>annotatedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735845748383_945756_44" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>(owningAnnotatedElement &lt;> null) = (ownedAnnotatingElement &lt;> null)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735845653641_786315_40" name="validateAnnotationAnnotatingElement" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735845745291_3174_42" annotatedElement="_2022x_2_12e503d9_1735845653641_786315_40">
+            <body>&lt;p>Either the &lt;code>ownedAnnotatingElement&lt;/code> of an &lt;code>Annotation&lt;/code> must be non-null, or the &lt;code>owningAnnotatingElement&lt;/code> must be non-null, but not both.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735845653641_705621_41" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedAnnotatingElement &lt;> null xor owningAnnotatingElement &lt;> null</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735845602380_427689_37" name="deriveAnnotationOwnedAnnotatingElement" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735845649894_277406_39" annotatedElement="_2022x_2_12e503d9_1735845602380_427689_37">
+            <body>&lt;p>The &lt;code>ownedAnnotatingElement&lt;/code> of an &lt;code>Annotation&lt;/code> is the first &lt;code>ownedRelatedElement&lt;/code> that is an &lt;code>AnnotatingElement&lt;/code>, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735845602380_319316_38" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedAnnotatingElement =
+    let ownedAnnotatingElements : Sequence(AnnotatingElement) = 
+        ownedRelatedElement->selectByKind(AnnotatingElement) in
+    if ownedAnnotatingElements->isEmpty() then null
+    else ownedAnnotatingElements->first()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735845525374_502771_34" name="deriveAnnotationAnnotatingElement" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735845586701_730060_36" annotatedElement="_2022x_2_12e503d9_1735845525374_502771_34">
+            <body>&lt;p>The &lt;code>annotatingElement&lt;/code> of an &lt;code>Annotation&lt;/code> is either its &lt;code>ownedAnnotatingElement&lt;/code> or its &lt;code>owningAnnotatingElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735845525375_709188_35" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>annotatingElement =
+    if ownedAnnotatingElement &lt;> null then ownedAnnotatingElement
+    else owningAnnotatingElement
+    endif</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1543093626050_588210_18305" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543094212714_638255_18408" name="annotatingElement" visibility="public" type="_19_0_2_12e503d9_1594145576693_532940_27" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" association="_18_5_3_12e503d9_1543094212714_89063_18406">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777235994_27506_15516" annotatedElement="_18_5_3_12e503d9_1543094212714_638255_18408">
+            <body> &lt;p>The &lt;code>AnnotatingElement&lt;/code> that annotates the &lt;code>annotatedElement&lt;/code> of this &lt;code>Annotation&lt;/code>. This is always either the &lt;code>ownedAnnotatingElement&lt;/code> or the &lt;code>owningAnnotatingElement&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543094279524_485248_18455" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543094279524_411273_18456" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543094430277_494140_18542" name="annotatedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_18_5_3_12e503d9_1543094430277_194870_18541">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777200389_72633_15515" annotatedElement="_18_5_3_12e503d9_1543094430277_494140_18542">
+            <body>&lt;p>The &lt;code>Element&lt;/code> that is annotated by the &lt;code>annotatingElement&lt;/code> of this Annotation.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543094520370_351885_18626" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543094520371_506261_18627" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594152527165_104456_2501" name="owningAnnotatedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543094430277_494140_18542 _18_5_3_12e503d9_1543092026091_693018_16749" association="_19_0_2_12e503d9_1594152527165_731400_2499">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594153380523_921282_2632" annotatedElement="_19_0_2_12e503d9_1594152527165_104456_2501">
+            <body>&lt;p>The &lt;code>annotatedElement&lt;/code> of this &lt;code>Annotation&lt;/code>, when it is also the &lt;code>owningRelatedElement&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594152589379_525937_2516" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594152589379_661065_2517" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1703019570939_266622_19" name="owningAnnotatingElement" visibility="public" type="_19_0_2_12e503d9_1594145576693_532940_27" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543094212714_638255_18408 _18_5_3_12e503d9_1543092026091_693018_16749" association="_19_0_4_12e503d9_1703019570888_501453_17">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1705636966695_11053_843" annotatedElement="_19_0_4_12e503d9_1703019570939_266622_19">
+            <body>&lt;p>The &lt;code>annotatingElement&lt;/code> of this &lt;code>Annotation&lt;/code>, when it is the &lt;code>owningRelatedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1703019740096_822598_30" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1703019740109_127251_31" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1735188506571_384269_375" name="ownedAnnotatingElement" visibility="public" type="_19_0_2_12e503d9_1594145576693_532940_27" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543094212714_638255_18408 _18_5_3_12e503d9_1533160674986_59873_43302" association="_2022x_2_12e503d9_1735188506571_828001_374">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735196501289_141130_1010" annotatedElement="_2022x_2_12e503d9_1735188506571_384269_375">
+            <body>&lt;p>The &lt;code>annotatingElement&lt;/code> of this &lt;code>Annotation&lt;/code>, when it is an &lt;code>ownedRelatedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1735188553783_870184_405" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1735188553784_964372_406" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543094212714_89063_18406" name="A_annotation_annotatingElement" visibility="public" memberEnd="_18_5_3_12e503d9_1543094212714_953084_18407 _18_5_3_12e503d9_1543094212714_638255_18408"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543094430277_194870_18541" name="A_annotatedElement_annotation" visibility="public" memberEnd="_18_5_3_12e503d9_1543094430277_494140_18542 _18_5_3_12e503d9_1543094430277_599480_18543">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1543094430277_599480_18543" name="annotation" visibility="public" type="_18_5_3_12e503d9_1543093613150_792705_18263" isOrdered="true" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_18_5_3_12e503d9_1543094430277_194870_18541">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594153160692_807407_2602" annotatedElement="_18_5_3_12e503d9_1543094430277_599480_18543">
+            <body>&lt;p>The Annotations associated with a certain &lt;code>annotatedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543094537301_63432_18640" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543094537302_530724_18641" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1594145576693_532940_27" name="AnnotatingElement" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1594152974899_924944_2600" annotatedElement="_19_0_2_12e503d9_1594145576693_532940_27">
+          <body>&lt;p>An &lt;code>AnnotatingElement&lt;/code> is an &lt;code>Element&lt;/code> that provides additional description of or metadata on some other &lt;code>Element&lt;/code>. An &lt;code>AnnotatingElement&lt;/code> is either attached to its &lt;code>annotatedElements&lt;/code> by &lt;code>Annotation&lt;/code> &lt;code>Relationships&lt;/code>, or it implicitly annotates its &lt;code>owningNamespace&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543094739813_421271_18849" name="deriveAnnotatingElementAnnotatedElement" visibility="public" constrainedElement="_19_0_2_12e503d9_1594145576693_532940_27">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676411286196_36749_20474" annotatedElement="_18_5_3_12e503d9_1543094739813_421271_18849">
+            <body>&lt;p>If an &lt;code>AnnotatingElement&lt;/code> has &lt;code>annotations&lt;/code>, then its &lt;code>annotatedElements&lt;/code> are the &lt;code>annotatedElements&lt;/code> of all its &lt;code>annotations&lt;/code>. Otherwise, it's single &lt;code>annotatedElement&lt;/code> is its &lt;code>owningNamespace&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543094739814_355147_18850" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>annotatedElement = 
+ if annotation->notEmpty() then annotation.annotatedElement
+ else Sequence{owningNamespace} endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1705636570069_502356_840" name="deriveAnnotatingElementOwnedAnnotatingRelationship" visibility="public" constrainedElement="_19_0_2_12e503d9_1594145576693_532940_27">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1705636692351_340732_842" annotatedElement="_19_0_4_12e503d9_1705636570069_502356_840">
+            <body>&lt;p>The &lt;code>ownedAnnotatingRelationships&lt;/code> of an &lt;code>AnnotatingElement&lt;/code> are its &lt;code>ownedRelationships&lt;/code> that are &lt;code>Annotations&lt;/code>, for which the &lt;code>AnnotatingElement&lt;/code> is not the &lt;code>annotatedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1705636570096_578915_841" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedAnnotatingRelationship = ownedRelationship->
+    selectByKind(Annotation)->
+    select(a | a.annotatedElement &lt;> self)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735844992507_438717_16" name="deriveAnnotatingElementAnnotation" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735845029761_366493_18" annotatedElement="_2022x_2_12e503d9_1735844992507_438717_16">
+            <body>&lt;p>The &lt;code>annotations&lt;/code> of an &lt;code>AnnotatingElement&lt;/code> are its &lt;code>owningAnnotatingRelationship&lt;/code> (if any) followed by all its &lt;code>ownedAnnotatingRelationships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735844992509_5662_17" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>annotation = 
+    if owningAnnotatingRelationship = null then ownedAnnotatingRelationship
+    else owningAnnotatingRelationship->prepend(owningAnnotatingRelationship)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1594145622489_665503_54" general="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594145755058_99428_86" name="annotatedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1594145755058_702623_85">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594153403012_259486_2633" annotatedElement="_19_0_2_12e503d9_1594145755058_99428_86">
+            <body>&lt;p>The &lt;code>Elements&lt;/code> that are annotated by this &lt;code>AnnotatingElement&lt;/code>. If &lt;code>annotation&lt;/code> is not empty, these are the &lt;code>annotatedElements&lt;/code> of the &lt;code>annotations&lt;/code>. If &lt;code>annotation&lt;/code> is empty, then it is the &lt;code>owningNamespace&lt;/code> of the &lt;code>AnnotatingElement&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594145844171_591303_191" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594145844172_805810_192" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1703019570915_375100_18" name="ownedAnnotatingRelationship" visibility="public" type="_18_5_3_12e503d9_1543093613150_792705_18263" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543094212714_953084_18407 _18_5_3_12e503d9_1543092026091_217766_16748" association="_19_0_4_12e503d9_1703019570888_501453_17">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1703020125206_415867_73" annotatedElement="_19_0_4_12e503d9_1703019570915_375100_18">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>AnnotatingElement&lt;/code> that are &lt;code>Annotations&lt;/code>, for which this &lt;code>AnnotatingElement&lt;/code> is the &lt;code>annotatingElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1703019753619_446714_36" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1703019753628_344411_37" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1735188506571_308678_376" name="owningAnnotatingRelationship" visibility="public" type="_18_5_3_12e503d9_1543093613150_792705_18263" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674986_482273_43303 _18_5_3_12e503d9_1543094212714_953084_18407" association="_2022x_2_12e503d9_1735188506571_828001_374">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735196287080_375793_1005" annotatedElement="_2022x_2_12e503d9_1735188506571_308678_376">
+            <body>&lt;p>The &lt;code>owningRelationship&lt;/code> of this &lt;code>AnnotatingRelationship&lt;/code>, if it is an &lt;code>Annotation&lt;/code>&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1735188661980_905697_437" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1735188661981_655077_438" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543094212714_953084_18407" name="annotation" visibility="public" type="_18_5_3_12e503d9_1543093613150_792705_18263" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227" association="_18_5_3_12e503d9_1543094212714_89063_18406">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777267496_292249_15517" annotatedElement="_18_5_3_12e503d9_1543094212714_953084_18407">
+            <body>&lt;p>The &lt;code>Annotations&lt;/code> that relate this &lt;code>AnnotatingElement&lt;/code> to its &lt;code>annotatedElements&lt;/code>. This includes the &lt;code>owningAnnotatingRelationship&lt;/code> (if any) followed by all the &lt;code>ownedAnnotatingRelationshps&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543094361259_500465_18491" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543094361259_210883_18492" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594145755058_702623_85" name="A_annotatedElement_annotatingElement" visibility="public" memberEnd="_19_0_2_12e503d9_1594145755058_99428_86 _19_0_2_12e503d9_1594145755059_76214_87">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1594145755059_76214_87" name="annotatingElement" visibility="public" type="_19_0_2_12e503d9_1594145576693_532940_27" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1594145755058_702623_85">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594153684960_598472_2634" annotatedElement="_19_0_2_12e503d9_1594145755059_76214_87">
+            <body>&lt;p>The AnnotatingElements that have a certain Element as their &lt;code>annotatedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594145812251_245277_157" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594145812253_330203_158" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1594152214531_455349_2448" name="TextualRepresentation" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1594157060791_478379_4131" annotatedElement="_19_0_2_12e503d9_1594152214531_455349_2448">
+          <body>&lt;p>A &lt;code>TextualRepresentation&lt;/code> is an &lt;code>AnnotatingElement&lt;/code> whose &lt;code>body&lt;/code> represents the &lt;code>representedElement&lt;/code> in a given &lt;code>language&lt;/code>. The &lt;code>representedElement&lt;/code> must be the &lt;code>owner&lt;/code> of the &lt;code>TextualRepresentation&lt;/code>. The named &lt;code>language&lt;/code> can be a natural language, in which case the &lt;code>body&lt;/code> is an informal representation, or an artificial language, in which case the &lt;code>body&lt;/code> is expected to be a formal, machine-parsable representation.&lt;/p>
+
+&lt;p>If the named &lt;code>language&lt;/code> of a &lt;code>TextualRepresentation&lt;/code> is machine-parsable, then the &lt;code>body&lt;/code> text should be legal input text as defined for that &lt;code>language&lt;/code>. The interpretation of the named language string shall be case insensitive. The following &lt;code>language&lt;/code> names are defined to correspond to the given standard languages:&lt;/p>
+
+&lt;table border=&quot;1&quot; cellpadding=&quot;1&quot; cellspacing=&quot;1&quot; width=&quot;498&quot;>
+	&lt;thead>
+	&lt;/thead>
+	&lt;tbody>
+		&lt;tr>
+			&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>kerml&lt;/code>&lt;/td>
+			&lt;td style=&quot;width: 332px;&quot;>Kernel Modeling Language&lt;/td>
+		&lt;/tr>
+		&lt;tr>
+			&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>ocl&lt;/code>&lt;/td>
+			&lt;td style=&quot;width: 332px;&quot;>Object Constraint Language&lt;/td>
+		&lt;/tr>
+		&lt;tr>
+			&lt;td style=&quot;text-align: center; width: 154px;&quot;>&lt;code>alf&lt;/code>&lt;/td>
+			&lt;td style=&quot;width: 332px;&quot;>Action Language for fUML&lt;/td>
+		&lt;/tr>
+	&lt;/tbody>
+&lt;/table>
+
+&lt;p>Other specifications may define specific &lt;code>language&lt;/code> strings, other than those shown above, to be used to indicate the use of languages from those specifications in KerML &lt;code>TextualRepresentation&lt;/code>.&lt;/p>
+
+&lt;p>If the &lt;code>language&lt;/code> of a &lt;code>TextualRepresentation&lt;/code> is &amp;quot;&lt;code>kerml&lt;/code>&amp;quot;, then the &lt;code>body&lt;/code> text shall be a legal representation of the &lt;code>representedElement&lt;/code> in the KerML textual concrete syntax. A conforming tool can use such a &lt;code>TextualRepresentation&lt;/code> &lt;code>Annotation&lt;/code> to record the original KerML concrete syntax text from which an &lt;code>Element&lt;/code> was parsed. In this case, it is a tool responsibility to ensure that the &lt;code>body&lt;/code> of the &lt;code>TextualRepresentation&lt;/code> remains correct (or the Annotation is removed) if the annotated &lt;code>Element&lt;/code> changes other than by re-parsing the &lt;code>body&lt;/code> text.&lt;/p>
+
+&lt;p>An &lt;code>Element&lt;/code> with a &lt;code>TextualRepresentation&lt;/code> in a language other than KerML is essentially a semantically &amp;quot;opaque&amp;quot; &lt;code>Element&lt;/code> specified in the other language. However, a conforming KerML tool may interpret such an element consistently with the specification of the named language.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_2_12e503d9_1594152230889_716082_2475" general="_19_0_2_12e503d9_1594145576693_532940_27"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594152270061_927814_2479" name="language" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607319520973_505680_13" annotatedElement="_19_0_2_12e503d9_1594152270061_927814_2479">
+            <body>&lt;p>The natural or artifical language in which the &lt;code>body&lt;/code> text is written.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594152383632_115937_2491" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594152383632_488663_2492" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594154758494_414887_3389" name="representedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1594145755058_99428_86" subsettedProperty="_18_5_3_12e503d9_1543092869879_744477_17277" association="_19_0_2_12e503d9_1594154758493_626101_3387">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594157296619_493414_4135" annotatedElement="_19_0_2_12e503d9_1594154758494_414887_3389">
+            <body>&lt;p>The &lt;code>Element&lt;/code> that is represented by this &lt;code>TextualRepresentation&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594154929755_571689_3504" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594154929756_964967_3505" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1647817353412_339800_421" name="body" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1647817353452_177646_423" annotatedElement="_19_0_4_12e503d9_1647817353412_339800_421">
+            <body>&lt;p>The textual representation of the &lt;code>representedElement&lt;/code> in the given &lt;code>language&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1647817353454_957687_424" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1647817353437_962619_422" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1647722169749_235252_587" name="Documentation" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1648589286325_996199_16" annotatedElement="_19_0_4_12e503d9_1647722169749_235252_587">
+          <body>&lt;p>&lt;code>Documentation&lt;/code> is a &lt;code>Comment&lt;/code> that specifically documents a &lt;code>documentedElement&lt;/code>, which must be its &lt;code>owner&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_12e503d9_1647722245166_89362_624" general="_18_5_3_12e503d9_1533160651696_959404_42181"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594150061166_948466_1622" name="documentedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1594145755058_99428_86" subsettedProperty="_18_5_3_12e503d9_1543092869879_744477_17277" association="_19_0_2_12e503d9_1594150061165_948966_1620">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594157690812_425883_4138" annotatedElement="_19_0_2_12e503d9_1594150061166_948466_1622">
+            <body>&lt;p>The &lt;code>Element&lt;/code> that is documented by this &lt;code>Documentation&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594150136356_345825_1691" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594150136356_617879_1692" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1703019570888_501453_17" name="A_ownedAnnotatingRelationship_owningAnnotatingElement" visibility="public" memberEnd="_19_0_4_12e503d9_1703019570915_375100_18 _19_0_4_12e503d9_1703019570939_266622_19"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_2022x_2_12e503d9_1735188506571_828001_374" name="A_ownedAnnotatingElement_owningAnnotatingRelationship" visibility="public" memberEnd="_2022x_2_12e503d9_1735188506571_384269_375 _2022x_2_12e503d9_1735188506571_308678_376"/>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1561108643182_583211_22407" name="Namespaces" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651694_110063_42176" name="Namespace" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1584041670253_77963_67" annotatedElement="_18_5_3_12e503d9_1533160651694_110063_42176">
+          <body>&lt;p>A &lt;code>Namespace&lt;/code> is an &lt;code>Element&lt;/code> that contains other &lt;code>Elements&lt;/code>, known as its &lt;code>members&lt;/code>, via &lt;code>Membership&lt;/code> &lt;code>Relationships&lt;/code> with those &lt;code>Elements&lt;/code>. The &lt;code>members&lt;/code> of a &lt;code>Namespace&lt;/code> may be owned by the &lt;code>Namespace&lt;/code>, aliased in the &lt;code>Namespace&lt;/code>, or imported into the &lt;code>Namespace&lt;/code> via &lt;code>Import&lt;/code> &lt;code>Relationships&lt;/code>.&lt;/p>
+
+&lt;p>A &lt;code>Namespace&lt;/code> can provide names for its &lt;code>members&lt;/code> via the &lt;code>memberNames&lt;/code> and &lt;code>memberShortNames&lt;/code> specified by the &lt;code>Memberships&lt;/code> in the &lt;code>Namespace&lt;/code>. If a &lt;code>Membership&lt;/code> specifies a &lt;code>memberName&lt;/code> and/or &lt;code>memberShortName&lt;/code>, then those are names of the corresponding &lt;code>memberElement&lt;/code> relative to the &lt;code>Namespace&lt;/code>. For an &lt;code>OwningMembership&lt;/code>, the &lt;code>ownedMemberName&lt;/code> and &lt;code>ownedMemberShortName&lt;/code> are given by the &lt;code>Element&lt;/code> &lt;code>name&lt;/code> and &lt;code>shortName&lt;/code>. Note that the same &lt;code>Element&lt;/code> may be the &lt;code>memberElement&lt;/code> of multiple &lt;code>Memberships&lt;/code> in a &lt;code>Namespace&lt;/code> (though it may be owned at most once), each of which may define a separate alias for the &lt;code>Element&lt;/code> relative to the &lt;code>Namespace&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1533160674977_825266_43261" name="validateNamespaceDistinguishibility" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651694_110063_42176">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1650477109734_433870_33" annotatedElement="_18_5_3_12e503d9_1533160674977_825266_43261">
+            <body>&lt;p>All &lt;code>memberships&lt;/code> of a &lt;code>Namespace&lt;/code> must be distinguishable from each other.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1533160678374_128711_44047" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>membership->forAll(m1 | 
+    membership->forAll(m2 | 
+        m1 &lt;> m2 implies m1.isDistinguishableFrom(m2)))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1533160674977_187671_43262" name="deriveNamespaceMembers" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651694_110063_42176">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1650477282372_452490_35" annotatedElement="_18_5_3_12e503d9_1533160674977_187671_43262">
+            <body>&lt;p>The &lt;code>members&lt;/code> of a &lt;code>Namespace&lt;/code> are the &lt;code>memberElements&lt;/code> of all its &lt;code>memberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1533160678374_813969_44048" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>member = membership.memberElement</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1533160674978_265206_43263" name="deriveNamespaceOwnedMember" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651694_110063_42176">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1650477388489_128925_37" annotatedElement="_18_5_3_12e503d9_1533160674978_265206_43263">
+            <body>&lt;p>The &lt;code>ownedMembers&lt;/code> of a &lt;code>Namespace&lt;/code> are the &lt;code>ownedMemberElements&lt;/code> of all its &lt;code>ownedMemberships&lt;/code> that are &lt;code>OwningMemberships&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1533160678374_796486_44049" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMember = ownedMembership->selectByKind(OwningMembership).ownedMemberElement</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1533160674978_338488_43264" name="deriveNamespaceImportedMembership" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651694_110063_42176">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1650477219802_488752_34" annotatedElement="_18_5_3_12e503d9_1533160674978_338488_43264">
+            <body>&lt;p>The &lt;code>importedMemberships&lt;/code> of a &lt;code>Namespace&lt;/code> are derived using the &lt;code>importedMemberships()&lt;/code> operation, with no initially &lt;code>excluded&lt;/code> &lt;code>Namespaces&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1533160678374_473832_44050" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>importedMembership = importedMemberships(Set{})</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614230590193_678569_304" name="deriveNamespaceOwnedImport" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651694_110063_42176">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1650477326436_888320_36" annotatedElement="_19_0_4_12e503d9_1614230590193_678569_304">
+            <body>&lt;p>The &lt;code>ownedImports&lt;/code> of a &lt;code>Namespace&lt;/code> are all its &lt;code>ownedRelationships&lt;/code> that are &lt;code>Imports&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614230590193_91599_305" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedImport = ownedRelationship->selectByKind(Import)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614230506624_652148_302" name="deriveNamespaceOwnedMembership" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651694_110063_42176">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1650477435724_211524_38" annotatedElement="_19_0_4_12e503d9_1614230506624_652148_302">
+            <body>&lt;p>The &lt;code>ownedMemberships&lt;/code> of a &lt;code>Namespace&lt;/code> are all its &lt;code>ownedRelationships&lt;/code> that are &lt;code>Memberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614230506625_352607_303" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMembership = ownedRelationship->selectByKind(Membership)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674977_812723_43259" general="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674962_198288_43183" name="membership" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" isDerived="true" isDerivedUnion="true" association="_18_5_3_12e503d9_1533160651679_703508_42148">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778382375_277919_15564" annotatedElement="_18_5_3_12e503d9_1533160674962_198288_43183">
+            <body>&lt;p>All &lt;code>Memberships&lt;/code> in this &lt;code>Namespace&lt;/code>, including (at least) the union of &lt;code>ownedMemberships&lt;/code> and &lt;code>importedMemberships&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678359_506521_43954" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678359_601107_43953" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674974_746786_43247" name="ownedImport" visibility="public" type="_18_5_3_12e503d9_1533160651693_673132_42174" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543092026091_217766_16748 _18_5_3_12e503d9_1533160674971_80547_43227" association="_18_5_3_12e503d9_1533160651691_638857_42170">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778437009_851886_15565" annotatedElement="_18_5_3_12e503d9_1533160674974_746786_43247">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Namespace&lt;/code> that are &lt;code>Imports&lt;/code>, for which the &lt;code>Namespace&lt;/code> is the &lt;code>importOwningNamespace&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678371_459347_44037" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678371_432754_44036" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674979_644335_43267" name="member" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isDerived="true" association="_18_5_3_12e503d9_1533160651695_526341_42178">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778367269_472473_15563" annotatedElement="_18_5_3_12e503d9_1533160674979_644335_43267">
+            <body>&lt;p>The set of all member &lt;code>Elements&lt;/code> of this &lt;code>Namespace&lt;/code>, which are the &lt;code>memberElements&lt;/code> of all &lt;code>memberships&lt;/code> of the &lt;code>Namespace&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678376_858159_44056" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678375_207534_44055" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674979_259543_43268" name="ownedMember" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_644335_43267" association="_18_5_3_12e503d9_1533160651707_41633_42205">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1584043456646_443941_6" annotatedElement="_18_5_3_12e503d9_1533160674979_259543_43268">
+            <body>&lt;p>The owned &lt;code>members&lt;/code> of this &lt;code>Namespace&lt;/code>, which are the &lt;cpde>&lt;code>ownedMemberElements&lt;/code> of the &lt;code>ownedMemberships&lt;/code> of the &lt;code>Namespace&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678376_104496_44058" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678376_148737_44057" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674979_190614_43269" name="ownedMembership" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674962_198288_43183 _18_5_3_12e503d9_1533160674971_80547_43227 _18_5_3_12e503d9_1543092026091_217766_16748" association="_18_5_3_12e503d9_1533160651720_498368_42259">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778475112_142224_15566" annotatedElement="_18_5_3_12e503d9_1533160674979_190614_43269">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Namespace&lt;/code> that are &lt;code>Memberships&lt;/code>, for which the &lt;code>Namespace&lt;/code> is the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678376_715749_44060" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678376_759716_44059" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674979_207869_43270" name="importedMembership" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674962_198288_43183" association="_18_5_3_12e503d9_1533160651721_427967_42260">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778350931_195063_15562" annotatedElement="_18_5_3_12e503d9_1533160674979_207869_43270">
+            <body>&lt;p>The &lt;code>Memberships&lt;/code> in this &lt;code>Namespace&lt;/code> that result from the &lt;code>ownedImports&lt;/code> of this &lt;code>Namespace&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678376_330317_44062" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678376_869565_44061" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_18_5_3_12e503d9_1533160674978_692584_43265" name="namesOf" visibility="public" bodyCondition="_19_0_4_12e503d9_1617485000141_789391_27526">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1584043476995_491302_7" annotatedElement="_18_5_3_12e503d9_1533160674978_692584_43265">
+            <body>&lt;p>Return the names of the given &lt;code>element&lt;/code> as it is known in this &lt;code>Namespace&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617485000141_789391_27526" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617485000142_707095_27527" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let elementMemberships : Sequence(Membership) = 
+    memberships->select(memberElement = element) in
+memberships.memberShortName->
+    union(memberships.memberName)->
+    asSet()</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_18_5_3_12e503d9_1533160678375_821277_44051" name="element" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          <ownedParameter xmi:id="_18_5_3_12e503d9_1533160678375_283539_44052" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678502_188627_44557" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678502_239330_44556" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1617478450347_147085_26780" name="visibilityOf" visibility="public" bodyCondition="_19_0_4_12e503d9_1617478867823_663067_26785">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617478616134_138567_26784" annotatedElement="_19_0_4_12e503d9_1617478450347_147085_26780">
+            <body>&lt;p>Returns this visibility of &lt;code>mem&lt;/code> relative to this &lt;code>Namespace&lt;/code>. If &lt;code>mem&lt;/code> is an &lt;code>importedMembership&lt;/code>, this is the &lt;code>visibility&lt;/code> of its Import. Otherwise it is the &lt;code>visibility&lt;/code> of the &lt;code>Membership&lt;/code> itself.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617478867823_663067_26785" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617478867834_915410_26786" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if importedMembership->includes(mem) then
+    ownedImport->
+        select(importedMemberships(Set{})->includes(mem)).
+        first().visibility
+else if memberships->includes(mem) then
+    mem.visibility
+else
+    VisibilityKind::private
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617478469828_695514_26782" name="mem" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617478469954_855566_26783" name="" visibility="public" type="_18_5_3_12e503d9_1533160651691_865992_42172" direction="return"/>
+        </ownedOperation>
+        <ownedOperation xmi:id="_18_5_3_12e503d9_1551974328473_571863_19917" name="visibleMemberships" visibility="public" bodyCondition="_19_0_4_12e503d9_1617478407558_572792_26776">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1584043507889_140796_9" annotatedElement="_18_5_3_12e503d9_1551974328473_571863_19917">
+            <body>&lt;p>If &lt;code>includeAll = true&lt;/code>, then return all the &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code>. Otherwise, return only the publicly visible &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code>, including &lt;code>ownedMemberships&lt;/code> that have a &lt;code>visibility&lt;/code> of &lt;code>public&lt;/code> and &lt;code>Memberships&lt;/code> imported with a &lt;code>visibility&lt;/code> of &lt;code>public&lt;/code>. If &lt;code>isRecursive = true&lt;/code>, also recursively include all visible &lt;code>Memberships&lt;/code> of any &lt;code>public&lt;/code> owned &lt;code>Namespaces&lt;/code>, or, if &lt;code>IncludeAll = true&lt;/code>, all &lt;code>Memberships&lt;/code> of all owned &lt;code>Namespaces&lt;/code>. When computing imported &lt;code>Memberships&lt;/code>, ignore this &lt;code>Namespace&lt;/code> and any &lt;code>Namespaces&lt;/code> in the given &lt;code>excluded&lt;/code> set.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617478407558_572792_26776" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617478407558_989648_26777" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let visibleMemberships : OrderedSet(Membership) = 
+    if includeAll then membershipsOfVisibility(null, excluded)
+    else membershipsOfVisibility(VisibilityKind::public, excluded)
+    endif in
+if not isRecursive then visibleMemberships
+else visibleMemberships->union(ownedMember->
+    selectAsKind(Namespace).
+    select(includeAll or owningMembership.visibility = VisibilityKind::public)->
+    visibleMemberships(excluded->including(self), true, includeAll))
+endif
+</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617487029413_678776_27804" name="excluded" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617487029428_468695_27805" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617487029429_738106_27806" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1622146385803_933097_620" name="isRecursive" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1622578280509_689813_75" name="includeAll" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_18_5_3_12e503d9_1563834147266_758655_20322" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1563834147275_872455_20323" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1563834147277_678704_20324" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1606943219472_311375_5504" name="importedMemberships" visibility="public" bodyCondition="_19_0_4_12e503d9_1606943487264_779017_5513">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606943622178_967457_5515" annotatedElement="_19_0_4_12e503d9_1606943219472_311375_5504">
+            <body>&lt;p>Derive the imported &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code> as the &lt;code>importedMembership&lt;/code> of all &lt;code>ownedImports&lt;/code>, excluding those Imports whose &lt;code>importOwningNamespace&lt;/code> is in the &lt;code>excluded&lt;/code> set, and excluding &lt;code>Memberships&lt;/code> that have distinguisibility collisions with each other or with any &lt;code>ownedMembership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1606943487264_779017_5513" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1606943487266_166350_5514" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>ownedImport.importedMemberships(excluded->including(self))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617487066560_405594_27821" name="excluded" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617487066577_981225_27822" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617487066578_202205_27823" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1606943235794_610195_5507" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606943237380_98190_5508" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606943237382_476054_5509" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1736633737270_285230_35" name="membershipsOfVisibility" visibility="public" bodyCondition="_2022x_2_12e503d9_1736634171362_318819_59">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736634177378_139300_61" annotatedElement="_2022x_2_12e503d9_1736633737270_285230_35">
+            <body>&lt;p>If &lt;code>visibility&lt;/code> is not null, return the &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code> with the given &lt;code>visibility&lt;/code>, including &lt;code>ownedMemberships&lt;/code> with the given &lt;code>visibility&lt;/code> and &lt;code>Memberships&lt;/code> imported with the given &lt;code>visibility&lt;/code>. If &lt;code>visibility&lt;/code> is null, return all &lt;code>ownedMemberships&lt;/code> and imported &lt;code>Memberships&lt;/code> regardless of visibility. When computing imported &lt;code>Memberships&lt;/code>, ignore this &lt;code>Namespace&lt;/code> and any &lt;code>Namespaces&lt;/code> in the given &lt;code>excluded&lt;/code> set.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1736634171362_318819_59" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736634171363_283587_60" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>ownedMembership->
+    select(mem | visibility = null or mem.visibility = visibility)->
+    union(ownedImport->
+        select(imp | visibility = null or imp.visibility = visibility).
+        importedMemberships(excluded->including(self)))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736633756322_362779_37" name="visibility" visibility="public" type="_18_5_3_12e503d9_1533160651691_865992_42172">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736633756363_751360_38" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736633756363_887710_39" name="" visibility="public" value="1"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736633756365_502463_40" name="excluded" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736633756404_321268_41" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736633756404_283589_42" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736633756406_3176_43" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736633756450_610631_44" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736633756450_211379_45" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1667160493350_47312_42" name="resolve" visibility="public" bodyCondition="_19_0_4_12e503d9_1669844802802_594484_70">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1667160768747_677437_48" annotatedElement="_19_0_4_12e503d9_1667160493350_47312_42">
+            <body>&lt;p>Resolve the given qualified name to the named &lt;code>Membership&lt;/code> (if any), starting with this &lt;code>Namespace&lt;/code> as the local scope. The qualified name string must conform to the concrete syntax of the KerML textual notation. According to the KerML name resolution rules every qualified name will resolve to either a single &lt;code>Membership&lt;/code>, or to none.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1669844802802_594484_70" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669844802827_524535_71" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let qualification : String = qualificationOf(qualifiedName) in
+let name : String = unqualifiedNameOf(qualifiedName) in
+if qualification = null then resolveLocal(name)
+else if qualification = '$' then  resolveGlobal(name)
+else 
+    let namespaceMembership : Membership = resolve(qualification) in
+    if namespaceMembership = null or 
+       not namespaceMembership.memberElement.oclIsKindOf(Namespace) 
+    then null
+    else 
+        namespaceMembership.memberElement.oclAsType(Namespace).
+        resolveVisible(name) 
+    endif
+endif endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1667160535186_576198_44" name="qualifiedName" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1667160535341_133527_45" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1667160535351_654260_46" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1667160535359_337569_47" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669834521887_883651_42" name="resolveGlobal" visibility="public" bodyCondition="_19_0_4_12e503d9_1673538842629_16035_107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669844359383_614286_66" annotatedElement="_19_0_4_12e503d9_1669834521887_883651_42">
+            <body>&lt;p>Resolve the given qualified name to the named &lt;code>Membership&lt;/code> (if any) in the effective global &lt;code>Namespace&lt;/code> that is the outermost naming scope. The qualified name string must conform to the concrete syntax of the KerML textual notation.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1673538842629_16035_107" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673538842648_640999_108" name="" visibility="public">
+              <language>English</language>
+              <body>No OCL</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669834574896_709124_44" name="qualifiedName" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669834574962_514100_45" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1669834574969_336613_46" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1669834574975_310611_47" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669834721800_725825_48" name="resolveLocal" visibility="public" bodyCondition="_19_0_4_12e503d9_1669845312698_641316_79">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669844454115_127429_67" annotatedElement="_19_0_4_12e503d9_1669834721800_725825_48">
+            <body>&lt;p>Resolve a simple &lt;code>name&lt;/code> starting with this &lt;code>Namespace&lt;/code> as the local scope, and continuing with containing outer scopes as necessary. However, if this &lt;code>Namespace&lt;/code> is a root &lt;code>Namespace&lt;/code>, then the resolution is done directly in global scope.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1669845312698_641316_79" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669845312733_401436_80" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if owningNamespace = null then resolveGlobal(name)
+else
+    let memberships : Membership = membership->
+        select(memberShortName = name or memberName = name) in
+    if memberships->notEmpty() then memberships->first()
+    else owningNamespace.resolveLocal(name)
+    endif
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669834743168_59455_50" name="name" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669834743435_700790_51" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1669834743607_342192_52" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1669834743612_386534_53" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669844808740_535554_72" name="resolveVisible" visibility="public" bodyCondition="_19_0_4_12e503d9_1669845557544_643460_85">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669844911189_408370_78" annotatedElement="_19_0_4_12e503d9_1669844808740_535554_72">
+            <body>&lt;p>Resolve a simple name from the visible &lt;code>Memberships&lt;/code> of this &lt;code>Namespace&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1669845557544_643460_85" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669845557567_960220_86" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let memberships : Sequence(Membership) =
+    visibleMemberships(Set{}, false, false)->
+    select(memberShortName = name or memberName = name) in
+if memberships->isEmpty() then null
+else memberships->first()
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669844847432_500838_74" name="name" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669844847460_793208_75" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1669844847462_481883_76" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1669844847464_369656_77" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669844093179_385067_56" name="qualificationOf" visibility="public" bodyCondition="_19_0_4_12e503d9_1673498058417_628493_85">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669844556499_439644_68" annotatedElement="_19_0_4_12e503d9_1669844093179_385067_56">
+            <body>&lt;p>Return a string with valid KerML syntax representing the qualification part of a given &lt;code>qualifiedName&lt;/code>, that is, a qualified name with all the segment names of the given name except the last. If the given &lt;code>qualifiedName&lt;/code> has only one segment, then return null.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1673498058417_628493_85" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673498058438_870207_86" name="" visibility="public">
+              <language>English</language>
+              <body>No OCL</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669844134073_997325_58" name="qualifiedName" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669844134104_23040_59" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1669844134111_665604_60" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1669844134113_413661_61" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669844134410_814149_62" name="unqualifiedNameOf" visibility="public" bodyCondition="_19_0_4_12e503d9_1673498076139_705369_87">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669844586099_524307_69" annotatedElement="_19_0_4_12e503d9_1669844134410_814149_62">
+            <body>&lt;p>Return the simple name that is the last segment name of the given &lt;code>qualifiedName&lt;/code>. If this segment name has the form of a KerML unrestricted name, then &quot;unescape&quot; it by removing the surrounding single quotes and replacing all escape sequences with the specified character.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1673498076139_705369_87" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673498076141_447253_88" name="" visibility="public">
+              <language>English</language>
+              <body>No OCL</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669844164792_645402_64" name="qualifiedName" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669844164819_595711_65" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651687_388329_42164" name="A_ownedMemberElement_owningMembership" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674965_501750_43196 _18_5_3_12e503d9_1533160674972_622493_43236"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651707_41633_42205" name="A_ownedMember_owningNamespace" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674979_259543_43268 _18_5_3_12e503d9_1533160674986_474739_43306"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651693_673132_42174" name="Import" visibility="public" isAbstract="true">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1584041510717_779150_64" annotatedElement="_18_5_3_12e503d9_1533160651693_673132_42174">
+          <body>&lt;p>An &lt;code>Import&lt;/code> is an &lt;code>Relationship&lt;/code> between its &lt;code>importOwningNamespace&lt;/code> and either a &lt;code>Membership&lt;/code> (for a &lt;code>MembershipImport&lt;/code>) or another &lt;code>Namespace&lt;/code> (for a &lt;code>NamespaceImport&lt;/code>), which determines a set of &lt;code>Memberships&lt;/code> that become &lt;code>importedMemberships&lt;/code> of the &lt;code>importOwningNamespace&lt;/code>. If &lt;code>isImportAll = false&lt;/code> (the default), then only public &lt;code>Memberships&lt;/code> are considered &amp;quot;visible&amp;quot;. If &lt;code>isImportAll = true&lt;/code>, then all &lt;code>Memberships&lt;/code> are considered &amp;quot;visible&amp;quot;, regardless of their declared &lt;code>visibility&lt;/code>. If &lt;code>isRecursive = true&lt;/code>, then visible &lt;code>Memberships&lt;/code> are also recursively imported from owned sub-&lt;code>Namespaces&lt;/code>.&lt;/p>
+
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1720280122658_778803_80" name="validateImportTopLevelVisibility" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651693_673132_42174">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720280229184_448537_82" annotatedElement="_2022x_2_12e503d9_1720280122658_778803_80">
+            <body>&lt;p>A top-level &lt;code>Import&lt;/code> (that is, one that is owned by a root &lt;code>Namespace&lt;/code>) must have a &lt;code>visibility&lt;/code> of &lt;code>private&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1720280122659_143087_81" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>importOwningNamespace.owner = null implies 
+    visibility = VisibilityKind::private</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674976_592502_43255" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674974_548878_43248" name="importOwningNamespace" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" subsettedProperty="_18_5_3_12e503d9_1543092026091_693018_16749" association="_18_5_3_12e503d9_1533160651691_638857_42170">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778153589_917786_15559" annotatedElement="_18_5_3_12e503d9_1533160674974_548878_43248">
+            <body>&lt;p>The Namespace into which Memberships are imported by this Import, which must be the &lt;code>owningRelatedElement&lt;/code> of the Import.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678372_659781_44039" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678372_415506_44038" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674976_798509_43257" name="visibility" visibility="public" type="_18_5_3_12e503d9_1533160651691_865992_42172">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1584042141562_25094_82" annotatedElement="_18_5_3_12e503d9_1533160674976_798509_43257">
+            <body>&lt;p>The visibility level of the imported &lt;code>members&lt;/code> from this Import relative to the &lt;code>importOwningNamespace&lt;/code>. The default is &lt;code>private&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_18_5_3_12e503d9_1533160678372_177654_44043" name="" visibility="public" instance="_18_5_3_12e503d9_1533160674975_71898_43251"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1605759116711_596237_5033" name="isRecursive" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606346407443_37039_2333" annotatedElement="_19_0_4_12e503d9_1605759116711_596237_5033">
+            <body>&lt;p>Whether to recursively import Memberships from visible, owned sub-Namespaces.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1605761972022_917532_6432" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1622577942205_869984_64" name="isImportAll" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1630341940914_51495_424" annotatedElement="_19_0_4_12e503d9_1622577942205_869984_64">
+            <body>&lt;p>Whether to import memberships without regard to declared visibility.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1622577960901_980524_68" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1668801846848_909736_64" name="importedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isDerived="true" association="_19_0_4_12e503d9_1668801846842_441161_63">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1668802064772_376911_88" annotatedElement="_19_0_4_12e503d9_1668801846848_909736_64">
+            <body>&lt;p>The effectively imported &lt;code>Element&lt;/code> for this &lt;/code>Import&lt;/code>. For a &lt;code>MembershipImport&lt;/code>, this is the &lt;code>memberElement&lt;/code> of the &lt;code>importedMembership&lt;/code>. For a &lt;code>NamespaceImport&lt;/code>, it is the &lt;code>importedNamespace&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1668801863577_785400_74" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1668801863585_752070_75" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_18_5_3_12e503d9_1533160674976_875543_43256" name="importedMemberships" visibility="public" isAbstract="true">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1584042160699_896116_83" annotatedElement="_18_5_3_12e503d9_1533160674976_875543_43256">
+            <body>&lt;p>Returns Memberships that are to become &lt;code>importedMemberships&lt;/code> of the &lt;code>importOwningNamespace&lt;/code>. (The &lt;code>excluded&lt;/code> parameter is used to handle the possibility of circular Import Relationships.)&lt;/p>
+</body>
+          </ownedComment>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617486980326_679328_27782" name="excluded" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617486980404_148601_27784" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617486980405_818389_27785" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_18_5_3_12e503d9_1533160678372_920664_44042" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678502_297918_44555" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678501_272682_44554" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651691_638857_42170" name="A_ownedImport_importOwningNamespace" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674974_746786_43247 _18_5_3_12e503d9_1533160674974_548878_43248"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1668208086726_425885_108" name="MembershipImport" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1668469680803_667750_915" annotatedElement="_19_0_4_12e503d9_1668208086726_425885_108">
+          <body>&lt;p>A &lt;code>MembershipImport&lt;/code> is an &lt;code>Import&lt;/code> that imports its &lt;code>importedMembership&lt;/code> into the &lt;code>importOwningNamespace&lt;/code>. If &lt;code>isRecursive = true&lt;/code> and the &lt;code>memberElement&lt;/code> of the &lt;code>importedMembership&lt;/code> is a &lt;code>Namespace&lt;/code>, then the equivalent of a recursive &lt;code>NamespaceImport&lt;/code> is also performed on that &lt;code>Namespace&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1668802585653_660575_92" name="deriveMembershipImportImportedElement" visibility="public" constrainedElement="_19_0_4_12e503d9_1668208086726_425885_108">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676414060077_68039_20511" annotatedElement="_19_0_4_12e503d9_1668802585653_660575_92">
+            <body>&lt;p>The &lt;code>importedElement&lt;/code> of a &lt;code>MembershipImport&lt;/code> is the &lt;code>memberElement&lt;/code> of its &lt;code>importedMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1668802585661_249984_93" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>importedElement = importedMembership.memberElement</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1668208132661_668541_157" general="_18_5_3_12e503d9_1533160651693_673132_42174"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1668466089734_604404_605" name="importedMembership" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_19_0_4_12e503d9_1668466089731_278142_604">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1668470440399_933521_917" annotatedElement="_19_0_4_12e503d9_1668466089734_604404_605">
+            <body>&lt;p>The &lt;code>Membership&lt;/code> to be imported.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1668466129267_181313_661" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1668466129300_234258_662" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1668464891473_70858_331" name="importedMemberships" visibility="public" bodyCondition="_19_0_4_12e503d9_1668464891517_422028_332" redefinedOperation="_18_5_3_12e503d9_1533160674976_875543_43256">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1668464891544_369061_335" annotatedElement="_19_0_4_12e503d9_1668464891473_70858_331">
+            <body>&lt;p>Returns at least the &lt;code>importedMembership&lt;/code>. If &lt;code>isRecursive = true&lt;/code> and the &lt;code>memberElement&lt;/code> of the &lt;code>importedMembership&lt;/code> is a &lt;code>Namespace&lt;/code>, then &lt;code>Memberships&lt;/code> are also recursively imported from that &lt;code>Namespace&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1668464891517_422028_332" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1668464891549_267457_336" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if not isRecursive or 
+   not importedElement.oclIsKindOf(Namespace) or
+   excluded->includes(importedElement)
+then Sequence{importedMembership}
+else importedElement.oclAsType(Namespace).
+        visibleMemberships(excluded, true, importAll)->
+        prepend(importedMembership)
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1668464891528_594301_333" name="excluded" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1668464891569_935813_338" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1668464891567_329311_337" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1668464891539_876457_334" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1668464891571_726231_340" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1668464891570_753414_339" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651689_286045_42167" name="A_memberElement_membership" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674964_819490_43195 _18_5_3_12e503d9_1533160674973_469277_43243">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674973_469277_43243" name="membership" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_18_5_3_12e503d9_1533160651689_286045_42167">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607032362501_999190_6142" annotatedElement="_18_5_3_12e503d9_1533160674973_469277_43243">
+            <body>&lt;p>The Membership with a certain Element as its &lt;code>memberElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678371_91391_44031" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678370_672675_44030" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1668801846842_441161_63" name="A_importedElement_membershipImport" visibility="public" memberEnd="_19_0_4_12e503d9_1668801846848_909736_64 _19_0_4_12e503d9_1668801846861_843325_65">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1668801846861_843325_65" name="membershipImport" visibility="public" type="_18_5_3_12e503d9_1533160651693_673132_42174" isDerived="true" association="_19_0_4_12e503d9_1668801846842_441161_63">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1668802526627_939047_91" annotatedElement="_19_0_4_12e503d9_1668801846861_843325_65">
+            <body>&lt;p>An Import with a certain &lt;code>importedElement&lt;/code>.&lt;/p> </body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1668801892431_917968_80" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1668801892436_904218_81" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1668208114894_902739_132" name="NamespaceImport" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1668469722235_440881_916" annotatedElement="_19_0_4_12e503d9_1668208114894_902739_132">
+          <body>&lt;p>A &lt;code>NamespaceImport&lt;/code> is an Import that imports &lt;code>Memberships&lt;/code> from its &lt;code>importedNamespace&lt;/code> into the &lt;code>importOwningNamespace&lt;/code>. If &lt;code> isRecursive = false&lt;/code>, then only the visible &lt;code>Memberships&lt;/code> of the &lt;code>importedNamespace&lt;/code> are imported. If &lt;code> isRecursive = true&lt;/code>, then, in addition, &lt;code>Memberships&lt;/code> are recursively imported from any &lt;code>ownedMembers&lt;/code> of the &lt;code>importedNamespace&lt;/code> that are &lt;code>Namespaces&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1668968835532_234394_75" name="deriveNamespaceImportImportedElement" visibility="public" constrainedElement="_19_0_4_12e503d9_1668208114894_902739_132">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676414266381_531995_20512" annotatedElement="_19_0_4_12e503d9_1668968835532_234394_75">
+            <body>&lt;p>The &lt;code>importedElement&lt;/code> of a &lt;code>NamespaceImport&lt;/code> is its &lt;code>importedNamespace&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1668968835563_571005_76" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>importedElement = importedNamespace</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1668208136377_528804_160" general="_18_5_3_12e503d9_1533160651693_673132_42174"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674966_977620_43202" name="importedNamespace" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_18_5_3_12e503d9_1533160651682_703922_42155">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778126657_602103_15558" annotatedElement="_18_5_3_12e503d9_1533160674966_977620_43202">
+            <body>&lt;p>The &lt;code>Namespace&lt;/code> whose visible &lt;code>Memberships&lt;/code> are imported by this &lt;code>NamespaceImport&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678363_796931_43981" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678363_109882_43980" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1668464906703_498507_354" name="importedMemberships" visibility="public" bodyCondition="_19_0_4_12e503d9_1668464906766_900549_355" redefinedOperation="_18_5_3_12e503d9_1533160674976_875543_43256">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1668464906790_436882_358" annotatedElement="_19_0_4_12e503d9_1668464906703_498507_354">
+            <body>&lt;p>Returns at least the visible &lt;code>Memberships&lt;/code> of the &lt;code>importedNamespace&lt;/code>. If &lt;code>isRecursive = true&lt;/code>, then &lt;code>Memberships&lt;/code> are also recursively imported from any &lt;code>ownedMembers&lt;/code> of the &lt;code>importedNamespace&lt;/code> that are themselves &lt;code>Namespaces&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1668464906766_900549_355" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1668464906796_333962_359" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if excluded->includes(importedNamespace) then Sequence{}
+else importedNamespace.visibleMemberships(excluded, isRecursive, isImportAll)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1668464906773_104128_356" name="excluded" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1668464906801_75767_361" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1668464906801_11145_360" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1668464906785_717013_357" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1668464906802_401861_363" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1668464906802_624144_362" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651679_703508_42148" name="A_membership_membershipNamespace" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674962_198288_43183 _18_5_3_12e503d9_1533160674962_531296_43182">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674962_531296_43182" name="membershipNamespace" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176" isDerived="true" isDerivedUnion="true" association="_18_5_3_12e503d9_1533160651679_703508_42148">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607032166117_565359_6140" annotatedElement="_18_5_3_12e503d9_1533160674962_531296_43182">
+            <body>&lt;p>The Namespace that has a certain &lt;code>membership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678359_944361_43952" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678359_606881_43951" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651680_888716_42152" name="Membership" visibility="public">
+        <ownedComment xmi:id="_18_5_3_4a9015d_1556716858711_360444_23481" annotatedElement="_18_5_3_12e503d9_1533160651680_888716_42152">
+          <body>&lt;p>A &lt;code>Membership&lt;/code> is a &lt;code>Relationship&lt;/code> between a &lt;code>Namespace&lt;/code> and an &lt;code>Element&lt;/code> that indicates the &lt;code>Element&lt;/code> is a &lt;code>member&lt;/code> of (i.e., is contained in) the Namespace. Any &lt;code>memberNames&lt;/code> specify how the &lt;code>memberElement&lt;/code> is identified in the &lt;code>Namespace&lt;/code> and the &lt;code>visibility&lt;/code> specifies whether or not the &lt;code>memberElement&lt;/code> is publicly visible from outside the &lt;code>Namespace&lt;/code>.&lt;/p>
+
+&lt;p>If a &lt;code>Membership&lt;/code> is an &lt;code>OwningMembership&lt;/code>, then it owns its &lt;code>memberElement&lt;/code>, which becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code>. Otherwise, the &lt;code>memberNames&lt;/code> of a &lt;code>Membership&lt;/code> are effectively aliases within the &lt;code>membershipOwningNamespace&lt;/code> for an &lt;code>Element&lt;/code> with a separate &lt;code>OwningMembership&lt;/code> in the same or a different &lt;code>Namespace&lt;/code>.&lt;/p>
+
+&lt;p>&amp;nbsp;&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676413842307_30007_20508" name="deriveMembershipMemberElementId" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651680_888716_42152">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676413968744_791337_20510" annotatedElement="_19_0_4_12e503d9_1676413842307_30007_20508">
+            <body>&lt;p>The &lt;code>memberElementId&lt;/code> of a &lt;code>Membership&lt;/code> is the &lt;code>elementId&lt;/code> of its &lt;code>memberElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676413842316_614553_20509" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>memberElementId = memberElement.elementId</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674963_553649_43190" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1651721199802_246768_242" name="memberElementId" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651721409733_657176_252" annotatedElement="_19_0_4_12e503d9_1651721199802_246768_242">
+            <body>&lt;p>The &lt;code>elementId&lt;/code> of the &lt;code>memberElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674965_193857_43197" name="membershipOwningNamespace" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" subsettedProperty="_18_5_3_12e503d9_1533160674962_531296_43182 _18_5_3_12e503d9_1543092026091_693018_16749" association="_18_5_3_12e503d9_1533160651720_498368_42259">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778267848_253386_15561" annotatedElement="_18_5_3_12e503d9_1533160674965_193857_43197">
+            <body>&lt;p>The &lt;code>Namespace&lt;/code> of which the &lt;code>memberElement&lt;/code> becomes a &lt;code>member&lt;/code> due to this &lt;code>Membership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678363_705004_43975" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678362_223606_43974" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1651721174176_601088_238" name="memberShortName" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651721422011_158104_253" annotatedElement="_19_0_4_12e503d9_1651721174176_601088_238">
+            <body>&lt;p>The short name of the &lt;code>memberElement&lt;/code> relative to the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1651721190359_432547_240" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1651721190388_781783_241" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674964_819490_43195" name="memberElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_18_5_3_12e503d9_1533160651689_286045_42167">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778235973_850505_15560" annotatedElement="_18_5_3_12e503d9_1533160674964_819490_43195">
+            <body>&lt;p>The &lt;code>Element&lt;/code> that becomes a &lt;code>member&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> due to this &lt;code>Membership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678362_721719_43971" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678362_838514_43970" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674964_35293_43192" name="memberName" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583775989137_999155_4530" annotatedElement="_18_5_3_12e503d9_1533160674964_35293_43192">
+            <body>&lt;p>The name of the &lt;code>memberElement&lt;/code> relative to the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678361_445606_43966" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678361_170396_43965" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674964_42975_43193" name="visibility" visibility="public" type="_18_5_3_12e503d9_1533160651691_865992_42172">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1584043401095_394494_4" annotatedElement="_18_5_3_12e503d9_1533160674964_42975_43193">
+            <body>&lt;p>Whether or not the &lt;code>Membership&lt;/code> of the &lt;code>memberElement&lt;/code> in the &lt;code>membershipOwningNamespace&lt;/code> is publicly visible outside that &lt;code>Namespace&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_18_5_3_12e503d9_1533160678361_219923_43967" name="" visibility="public" instance="_18_5_3_12e503d9_1533160674975_849914_43250"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_18_5_3_12e503d9_1533160674963_944902_43191" name="isDistinguishableFrom" visibility="public" bodyCondition="_19_0_4_12e503d9_1651721861032_922449_254">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1584043421572_710896_5" annotatedElement="_18_5_3_12e503d9_1533160674963_944902_43191">
+            <body>&lt;p>Whether this &lt;code>Membership&lt;/code> is distinguishable from a given &lt;code>other&lt;/code> &lt;code>Membership&lt;/code>. By default, this is true if this &lt;code>Membership&lt;/code> has no &lt;code>memberShortName&lt;/code> or &lt;code>memberName&lt;/code>; or each of the &lt;code>memberShortName&lt;/code> and &lt;code>memberName&lt;/code> are different than both of those of the &lt;code>other&lt;/code> &lt;code>Membership&lt;/code>; or neither of the metaclasses of the &lt;code>memberElement&lt;/code> of this &lt;code>Membership&lt;/code> and the &lt;code>memberElement&lt;/code> of the &lt;code>other&lt;/code> &lt;code>Membership&lt;/code> conform to the other. But this may be overridden in specializations of &lt;code>Membership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1651721861032_922449_254" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1651721861054_650974_255" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>not (memberElement.oclKindOf(other.memberElement.oclType()) or
+     other.memberElement.oclKindOf(memberElement.oclType())) or
+(shortMemberName = null or
+    (shortMemberName &lt;> other.shortMemberName and
+     shortMemberName &lt;> other.memberName)) and
+(memberName = null or
+    (memberName &lt;> other.shortMemberName and
+     memberName &lt;> other.memberName)))
+</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_18_5_3_12e503d9_1533160678361_329605_43963" name="other" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152"/>
+          <ownedParameter xmi:id="_18_5_3_12e503d9_1533160678361_197292_43964" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651721_427967_42260" name="A_importedMembership_importingNamespace" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674979_207869_43270 _18_5_3_12e503d9_1533160674998_40489_43371">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674998_40489_43371" name="importingNamespace" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674962_531296_43182" association="_18_5_3_12e503d9_1533160651721_427967_42260">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607032192306_576101_6141" annotatedElement="_18_5_3_12e503d9_1533160674998_40489_43371">
+            <body>&lt;p>The Namespace with a certain &lt;code>importedMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678387_395445_44148" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678387_773491_44147" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651720_498368_42259" name="A_ownedMembership_membershipOwningNamespace" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674979_190614_43269 _18_5_3_12e503d9_1533160674965_193857_43197"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651682_703922_42155" name="A_importedNamespace_import" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674966_977620_43202 _18_5_3_12e503d9_1533160674966_540098_43201">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674966_540098_43201" name="import" visibility="public" type="_19_0_4_12e503d9_1668208114894_902739_132" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_18_5_3_12e503d9_1533160651682_703922_42155">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607032131766_265966_6139" annotatedElement="_18_5_3_12e503d9_1533160674966_540098_43201">
+            <body>&lt;p>A NamespaceImport that has a certain &lt;code>importedNamespace&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678363_400682_43979" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678363_853905_43978" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1648180804650_933390_31" name="OwningMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1650472293015_284381_18" annotatedElement="_19_0_4_12e503d9_1648180804650_933390_31">
+          <body>&lt;p>An &lt;code>OwningMembership&lt;/code> is a &lt;code>Membership&lt;/code> that owns its &lt;code>memberElement&lt;/code> as a &lt;code>ownedRelatedElement&lt;/code>. The &lt;code>ownedMemberElement&lt;/code> becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1650483180363_981198_41" name="deriveOwningMembershipOwnedMemberName" visibility="public" constrainedElement="_19_0_4_12e503d9_1648180804650_933390_31">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1650483307679_935611_43" annotatedElement="_19_0_4_12e503d9_1650483180363_981198_41">
+            <body>&lt;p>The &lt;code>ownedMemberName&lt;/code> of an &lt;code>OwningMembership&lt;/code> is the &lt;code>name&lt;/code> of its &lt;code>ownedMemberElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1650483180396_442767_42" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMemberName = ownedMemberElement.name</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1651722237767_963980_261" name="deriveOwningMembershipOwnedMemberShortName" visibility="public" constrainedElement="_19_0_4_12e503d9_1648180804650_933390_31">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651722237811_717860_263" annotatedElement="_19_0_4_12e503d9_1651722237767_963980_261">
+            <body>&lt;p>The &lt;code>ownedMemberShortName&lt;/code> of an &lt;code>OwningMembership&lt;/code> is the &lt;code>shortName&lt;/code> of its &lt;code>ownedMemberElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1651722237801_94414_262" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMemberShortName = ownedMemberElement.shortName</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1648180819135_584816_72" general="_18_5_3_12e503d9_1533160651680_888716_42152"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674965_501750_43196" name="ownedMemberElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" aggregation="composite" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674964_819490_43195" subsettedProperty="_18_5_3_12e503d9_1533160674986_59873_43302" association="_18_5_3_12e503d9_1533160651687_388329_42164">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583776310122_445596_4936" annotatedElement="_18_5_3_12e503d9_1533160674965_501750_43196">
+            <body>&lt;p>The &lt;code>Element&lt;/code> that becomes an &lt;code>ownedMember&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> due to this &lt;code>OwningMembership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678362_418237_43973" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678362_680060_43972" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1651721234828_904219_244" name="ownedMemberElementId" visibility="public" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1651721199802_246768_242">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651722097260_735930_260" annotatedElement="_19_0_4_12e503d9_1651721234828_904219_244">
+            <body>&lt;p>The &lt;code>elementId&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1651721262092_909505_246" name="ownedMemberShortName" visibility="public" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1651721174176_601088_238">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651722087477_113851_259" annotatedElement="_19_0_4_12e503d9_1651721262092_909505_246">
+            <body>&lt;p>The &lt;code>shortName&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1651721272951_323184_248" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1651721272956_883059_249" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1648181616390_323441_387" name="ownedMemberName" visibility="public" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674964_35293_43192">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1648181616432_831781_389" annotatedElement="_19_0_4_12e503d9_1648181616390_323441_387">
+            <body>&lt;p>The &lt;code>name&lt;/code> of the &lt;code>ownedMemberElement&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1648181616434_626007_390" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1648181616428_845844_388" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1740263070659_22033_1617" name="path" visibility="public" bodyCondition="_2022x_2_12e503d9_1740263122544_317823_1622" redefinedOperation="_2022x_2_12e503d9_1740262422101_730962_1585">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740263198242_123529_1624" annotatedElement="_2022x_2_12e503d9_1740263070659_22033_1617">
+            <body>&lt;p>If the &lt;code>ownedMemberElement&lt;/code> of this &lt;code>OwningMembership&lt;/code> has a non-null &lt;code>qualifiedName&lt;/code>, then return the string constructed by appending to that &lt;code>qualifiedName&lt;/code> the string &lt;code>&quot;/owningMembership&quot;&lt;/code>. Otherwise, return the &lt;code>path&lt;/code> of the &lt;code>OwningMembership&lt;/code> as specified for a &lt;code>Relationship&lt;/code> in general.</body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1740263122544_317823_1622" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740263122548_684959_1623" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if ownedElement.qualifiedName &lt;> null then
+    ownedElement.qualifiedName + '/owningMembership'
+else self.oclAsType(Relationship).path()
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1740263076758_469247_1620" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651695_526341_42178" name="A_member_namespace" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674979_644335_43267 _18_5_3_12e503d9_1533160674980_717955_43271">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674980_717955_43271" name="namespace" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176" isDerived="true" association="_18_5_3_12e503d9_1533160651695_526341_42178">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607031639842_785943_6138" annotatedElement="_18_5_3_12e503d9_1533160674980_717955_43271">
+            <body>&lt;p>The Namespace the has a certain Element as a &lt;code>member&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678377_980112_44064" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678376_872768_44063" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_18_5_3_12e503d9_1533160651691_865992_42172" name="VisibilityKind" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1583778596203_151778_15567" annotatedElement="_18_5_3_12e503d9_1533160651691_865992_42172">
+          <body>&lt;p>&lt;code>VisibilityKind&lt;/code> is an enumeration whose literals specify the visibility of a &lt;code>Membership&lt;/code> of an &lt;code>Element&lt;/code> in a &lt;code>Namespace&lt;/code> outside of that &lt;code>Namespace&lt;/code>. Note that &amp;quot;visibility&amp;quot; specifically restricts whether an &lt;code>Element&lt;/code> in a &lt;code>Namespace&lt;/code> may be referenced by name from outside the &lt;code>Namespace&lt;/code> and only otherwise restricts access to an &lt;code>Element&lt;/code> as provided by specific constraints in the abstract syntax (e.g., preventing the import or inheritance of private &lt;code>Elements&lt;/code>).&lt;/p>
+</body>
+        </ownedComment>
+        <ownedLiteral xmi:id="_18_5_3_12e503d9_1533160674975_71898_43251" name="private" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778659349_992694_15569" annotatedElement="_18_5_3_12e503d9_1533160674975_71898_43251">
+            <body>&lt;p>Indicates a &lt;code>Membership&lt;/code> is not visible outside its owning &lt;code>Namespace&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_18_5_3_12e503d9_1533160674975_217055_43252" name="protected" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778840129_197307_15570" annotatedElement="_18_5_3_12e503d9_1533160674975_217055_43252">
+            <body>&lt;p>An intermediate level of visibility between &lt;code>public&lt;/code> and &lt;code>private&lt;/code>. By default, it is equivalent to &lt;code>private&lt;/code> for the purposes of normal access to and import of &lt;code>Elements&lt;/code> from a &lt;code>Namespace&lt;/code>. However, other &lt;code>Relationships&lt;/code> may be specified to include &lt;code>Memberships&lt;/code> with &lt;code>protected&lt;/code> visibility in the list of &lt;code>memberships&lt;/code> for a &lt;code>Namespace&lt;/code> (e.g., &lt;code>Specialization&lt;/code>).&lt;/p>
+</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_18_5_3_12e503d9_1533160674975_849914_43250" name="public" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583778633371_177820_15568" annotatedElement="_18_5_3_12e503d9_1533160674975_849914_43250">
+            <body>&lt;p>Indicates that a &lt;code>Membership&lt;/code> is publicly visible outside its owning &lt;code>Namespace&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1668466089731_278142_604" name="A_importedMembership_import" visibility="public" memberEnd="_19_0_4_12e503d9_1668466089734_604404_605 _19_0_4_12e503d9_1668466089745_901729_606">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1668466089745_901729_606" name="import" visibility="public" type="_19_0_4_12e503d9_1668208086726_425885_108" redefinedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_4_12e503d9_1668466089731_278142_604">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1668470460264_868724_918" annotatedElement="_19_0_4_12e503d9_1668466089745_901729_606">
+            <body>&lt;p>A MembershipImport that has a certain &lt;code>importedMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1668466156008_811602_685" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1668466156024_288497_686" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1533160651675_236823_42141" name="Elements" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651703_306405_42199" name="Element" visibility="public" isAbstract="true">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1570563047660_481555_9475" annotatedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <body>&lt;p>An &lt;code>Element&lt;/code> is a constituent of a model that is uniquely identified relative to all other &lt;code>Elements&lt;/code>. It can have &lt;code>Relationships&lt;/code> with other &lt;code>Elements&lt;/code>. Some of these &lt;code>Relationships&lt;/code> might imply ownership of other &lt;code>Elements&lt;/code>, which means that if an &lt;code>Element&lt;/code> is deleted from a model, then so are all the &lt;code>Elements&lt;/code> that it owns.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543093039396_86283_17600" name="deriveElementOwnedElement" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651721087964_277532_236" annotatedElement="_18_5_3_12e503d9_1543093039396_86283_17600">
+            <body>&lt;p>The &lt;code>ownedElements&lt;/code> of an &lt;code>Element&lt;/code> are the &lt;code>ownedRelatedElements&lt;/code> of its &lt;code>ownedRelationships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543093039402_941251_17601" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedElement = ownedRelationship.ownedRelatedElement</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543093147982_438682_17614" name="deriveElementOwner" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651721127793_23702_237" annotatedElement="_18_5_3_12e503d9_1543093147982_438682_17614">
+            <body>&lt;p>The &lt;code>owner&lt;/code> of an &lt;code>Element&lt;/code> is the &lt;code>owningRelatedElement&lt;/code> of its &lt;code>owningRelationship&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543093147983_616389_17615" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owner = owningRelationship.owningRelatedElement</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1611357205413_708152_604" name="deriveElementQualifiedName" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611357790983_697216_616" annotatedElement="_19_0_4_12e503d9_1611357205413_708152_604">
+            <body>&lt;p>If this &lt;code>Element&lt;/code> does not have an &lt;code>owningNamespace&lt;/code>, then its &lt;code>qualifiedName&lt;/code> is null. If the &lt;code>owningNamespace&lt;/code> of this Element is a root &lt;code>Namespace&lt;/code>, then the &lt;code>qualifiedName&lt;/code> of the &lt;code>Element&lt;/code> is the escaped name of the &lt;code>Element&lt;/code> (if any). If the &lt;code>owningNamespace&lt;/code> is non-null but not a root &lt;code>Namespace&lt;/code>, then the &lt;code>qualifiedName&lt;/code> of this &lt;code>Element&lt;/code> is constructed from the &lt;code>qualifiedName&lt;/code> of the &lt;code>owningNamespace&lt;/code> and the escaped name of the &lt;code>Element&lt;/code>, unless the &lt;code>qualifiedName&lt;/code> of the &lt;code>owningNamespace&lt;/code> is null or the escaped name is null, in which case the &lt;code>qualifiedName&lt;/code> of this &lt;code>Element&lt;/code> is also null. Further, if the &lt;code>owningNamespace&lt;/code> has other &lt;code>ownedMembers&lt;/code> with the same non-null name as this &lt;code>Element&lt;/code>, and this &lt;code>Element&lt;/code> is not the first, then the &lt;code>qualifiedName&lt;/code> of this &lt;code>Element&lt;/code> is null.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1611357205413_521443_605" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>qualifiedName =
+    if owningNamespace = null then null
+    else if name &lt;> null and 
+        owningNamespace.ownedMember->
+        select(m | m.name = name).indexOf(self) &lt;> 1 then null
+    else if owningNamespace.owner = null then escapedName()
+    else if owningNamespace.qualifiedName = null or 
+            escapedName() = null then null
+    else owningNamespace.qualifiedName + '::' + escapedName()
+    endif endif endif endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614228882813_757461_44" name="deriveElementDocumentation" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651720956651_258797_234" annotatedElement="_19_0_4_12e503d9_1614228882813_757461_44">
+            <body>&lt;p>The &lt;code>documentation&lt;/code> of an &lt;code>Element&lt;/code> is its &lt;code>ownedElements&lt;/code> that are &lt;code>Documentation&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614228882814_715682_45" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>documentation = ownedElement->selectByKind(Documentation)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614229056894_843730_102" name="deriveElementOwnedAnnotation" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651721031439_737941_235" annotatedElement="_19_0_4_12e503d9_1614229056894_843730_102">
+            <body>&lt;p>The &lt;code>ownedAnnotations&lt;/code> of an &lt;code>Element&lt;/code> are its &lt;code>ownedRelationships&lt;/code> that are &lt;code>Annotations&lt;/code>, for which the &lt;code>Element&lt;/code> is the &lt;code>annotatedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614229056894_475602_103" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedAnnotation = ownedRelationship->
+    selectByKind(Annotation)->
+    select(a | a.annotatedElement = self)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1617485249153_164493_27536" name="deriveElementName" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617485318306_557608_27538" annotatedElement="_19_0_4_12e503d9_1617485249153_164493_27536">
+            <body>&lt;p>The &lt;code>name&lt;/code> of an &lt;code>Element&lt;/code> is given by the result of the &lt;code>effectiveName()&lt;/code> operation.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617485249154_845844_27537" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>name = effectiveName()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1662071586075_584077_3663" name="validateElementIsImpliedIncluded" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1662071829811_235597_3666" annotatedElement="_19_0_4_12e503d9_1662071586075_584077_3663">
+            <body>&lt;p>If an &lt;code>Element&lt;/code> has any &lt;code>ownedRelationships&lt;/code> for which &lt;code>isImplied = true&lt;/code>, then the &lt;code>Element&lt;/code> must also have &lt;code>isImpliedIncluded = true&lt;/code>. (Note that an &lt;code>Element&lt;/code> &lt;em>can&lt;/em> have &lt;code>isImplied = true&lt;/code> even if no &lt;code>ownedRelationships&lt;/code> have &lt;code>isImplied = true&lt;/code>, indicating the &lt;code>Element&lt;/code> simply has no implied &lt;code>Relationships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1662071586084_372563_3664" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedRelationship->exists(isImplied) implies isImpliedIncluded</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1665443840579_234309_730" name="deriveElementIsLibraryElement" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665458279757_884461_812" annotatedElement="_19_0_4_12e503d9_1665443840579_234309_730">
+            <body>&lt;p>An &lt;code>Element&lt;/code> &lt;code>isLibraryElement&lt;/code> if &lt;code>libraryNamespace()&lt;/code> is not null.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665443840606_288300_731" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isLibraryElement = libraryNamespace() &lt;> null
+</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673497106248_968771_48" name="deriveElementShortName" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673497106284_91904_50" annotatedElement="_19_0_4_12e503d9_1673497106248_968771_48">
+            <body>&lt;p>The &lt;code>shortName&lt;/code> of an &lt;code>Element&lt;/code> is given by the result of the &lt;code>effectiveShortName()&lt;/code> operation.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673497106275_422673_49" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>shortName = effectiveShortName()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676411745334_570984_20487" name="deriveElementOwningNamespace" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676413427811_999439_20505" annotatedElement="_19_0_4_12e503d9_1676411745334_570984_20487">
+            <body>&lt;p>The &lt;code>owningNamespace&lt;/code> of an &lt;code>Element&lt;/code> is the &lt;code>membershipOwningNamespace&lt;/code> of its &lt;code>owningMembership&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676411745344_881353_20488" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningNamespace =
+    if owningMembership = null then null
+    else owningMembership.membershipOwningNamespace
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676412286731_73568_20492" name="deriveElementTextualRepresentation" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651703_306405_42199">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676412317710_399633_20494" annotatedElement="_19_0_4_12e503d9_1676412286731_73568_20492">
+            <body>&lt;p>The &lt;code>textualRepresentations&lt;/code> of an &lt;code>Element&lt;/code> are its &lt;code>ownedElements&lt;/code> that are &lt;code>TextualRepresentations&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676412286737_625249_20493" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>textualRepresentation = ownedElement->selectByKind(TextualRepresentation)</body>
+          </specification>
+        </ownedRule>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674972_622493_43236" name="owningMembership" visibility="public" type="_19_0_4_12e503d9_1648180804650_933390_31" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674973_469277_43243 _18_5_3_12e503d9_1533160674986_482273_43303" association="_18_5_3_12e503d9_1533160651687_388329_42164">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777554515_12664_15549" annotatedElement="_18_5_3_12e503d9_1533160674972_622493_43236">
+            <body>&lt;p>The &lt;code>owningRelationship&lt;/code> of this &lt;code>Element&lt;/code>, if that &lt;code>Relationship&lt;/code> is a &lt;code>Membership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678370_671245_44027" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678370_727495_44026" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674986_482273_43303" name="owningRelationship" visibility="public" type="_18_5_3_12e503d9_1533160651700_869737_42192" subsettedProperty="_18_5_3_12e503d9_1533160674961_585972_43176" association="_18_5_3_12e503d9_1533160651703_78535_42198">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777606790_176565_15551" annotatedElement="_18_5_3_12e503d9_1533160674986_482273_43303">
+            <body>&lt;p>The Relationship for which this Element is an &lt;tt>ownedRelatedElement&lt;/tt>, if any.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678382_826333_44101" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678381_339750_44100" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674986_474739_43306" name="owningNamespace" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674980_717955_43271" association="_18_5_3_12e503d9_1533160651707_41633_42205">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777577792_356446_15550" annotatedElement="_18_5_3_12e503d9_1533160674986_474739_43306">
+            <body>&lt;p>The &lt;code>Namespace&lt;/code> that owns this &lt;code>Element&lt;/code>, which is the &lt;code>membershipOwningNamespace&lt;/code> of the &lt;code>owningMembership&lt;/code> of this &lt;code>Element&lt;/code>, if any.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678382_241636_44106" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678382_72045_44105" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674986_844338_43305" name="elementId" visibility="public" isID="true">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583775583586_526551_3618" annotatedElement="_18_5_3_12e503d9_1533160674986_844338_43305">
+            <body>&lt;p>The globally unique identifier for this Element. This is intended to be set by tooling, and it must not change during the lifetime of the Element.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543092026091_217766_16748" name="ownedRelationship" visibility="public" type="_18_5_3_12e503d9_1533160651700_869737_42192" isOrdered="true" aggregation="composite" subsettedProperty="_18_5_3_12e503d9_1533160674961_585972_43176" association="_18_5_3_12e503d9_1543092026091_319505_16747">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777515262_986101_15547" annotatedElement="_18_5_3_12e503d9_1543092026091_217766_16748">
+            <body>&lt;p>The Relationships for which this Element is the &lt;tt>owningRelatedElement&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543092209786_718629_16896" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543092209786_772083_16897" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543092869879_744477_17277" name="owner" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isDerived="true" association="_18_5_3_12e503d9_1543092869879_501876_17276">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777537015_379426_15548" annotatedElement="_18_5_3_12e503d9_1543092869879_744477_17277">
+            <body>&lt;p>The owner of this Element, derived as the &lt;code>owningRelatedElement&lt;/code> of the &lt;code>owningRelationship&lt;/code> of this Element, if any.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543092969963_580554_17553" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543092969963_544336_17554" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543092869879_112608_17278" name="ownedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isDerived="true" association="_18_5_3_12e503d9_1543092869879_501876_17276">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777423473_712319_15545" annotatedElement="_18_5_3_12e503d9_1543092869879_112608_17278">
+            <body>&lt;p>The Elements owned by this Element, derived as the &lt;tt>ownedRelatedElements&lt;/tt> of the &lt;tt>ownedRelationships&lt;/tt> of this Element.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543092960424_3_17533" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543092960425_646062_17534" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594150061166_345630_1621" name="documentation" visibility="public" type="_19_0_4_12e503d9_1647722169749_235252_587" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1594145755059_76214_87 _18_5_3_12e503d9_1543092869879_112608_17278" association="_19_0_2_12e503d9_1594150061165_948966_1620">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594156320138_771816_4073" annotatedElement="_19_0_2_12e503d9_1594150061166_345630_1621">
+            <body>&lt;p>The Documentation owned by this Element.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594150090832_92994_1657" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594150090832_924461_1658" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594152527165_702130_2500" name="ownedAnnotation" visibility="public" type="_18_5_3_12e503d9_1543093613150_792705_18263" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543092026091_217766_16748 _18_5_3_12e503d9_1543094430277_599480_18543" association="_19_0_2_12e503d9_1594152527165_731400_2499">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594153177283_451135_2603" annotatedElement="_19_0_2_12e503d9_1594152527165_702130_2500">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Element&lt;/code> that are &lt;code>Annotations&lt;/code>, for which this &lt;code>Element&lt;/code> is the &lt;code>annotatedElement&lt;/code>.&lt;/code></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594152569476_982761_2510" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594152569476_584865_2511" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594154758493_640290_3388" name="textualRepresentation" visibility="public" type="_19_0_2_12e503d9_1594152214531_455349_2448" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1594145755059_76214_87 _18_5_3_12e503d9_1543092869879_112608_17278" association="_19_0_2_12e503d9_1594154758493_626101_3387">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594157210380_483942_4134" annotatedElement="_19_0_2_12e503d9_1594154758493_640290_3388">
+            <body>&lt;p>The &lt;code>TextualRepresentations&lt;/code> that annotate this &lt;code>Element&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594154840347_357827_3450" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594154840347_169294_3451" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594312532679_496267_4310" name="aliasIds" visibility="public" isOrdered="true">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594832266632_27338_480" annotatedElement="_19_0_2_12e503d9_1594312532679_496267_4310">
+            <body>&lt;p>Various alternative identifiers for this Element. Generally, these will be set by tools.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594312548181_579844_4314" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594312548181_654118_4315" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594160442439_915308_4153" name="declaredShortName" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594160807887_856371_4157" annotatedElement="_19_0_2_12e503d9_1594160442439_915308_4153">
+            <body>&lt;p>An optional alternative name for the &lt;code>Element&lt;/code> that is intended to be shorter or in some way more succinct than its primary &lt;code>name&lt;/code>. It may act as a modeler-specified identifier for the &lt;code>Element&lt;/code>, though it is then the responsibility of the modeler to maintain the uniqueness of this identifier within a model or relative to some other context.&lt;/p> 
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594160455952_611606_4155" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594160455952_65422_4156" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674987_737648_43307" name="declaredName" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777458910_836985_15546" annotatedElement="_18_5_3_12e503d9_1533160674987_737648_43307">
+            <body>&lt;p>The declared name of this &lt;code>Element&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678383_292575_44108" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678382_768533_44107" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1673496405504_544235_24" name="shortName" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673496480035_166527_28" annotatedElement="_19_0_4_12e503d9_1673496405504_544235_24">
+            <body>&lt;p>The short name to be used for this &lt;code>Element&lt;/code> during name resolution within its &lt;code>owningNamespace&lt;/code>. This is derived using the &lt;code>effectiveShortName()&lt;/code> operation. By default, it is the same as the &lt;code>declaredShortName&lt;/code>, but this is overridden for certain kinds of &lt;code>Elements&lt;/code> to compute a &lt;code>shortName&lt;/code> even when the &lt;code>declaredName&lt;/code> is null.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1673496417872_221572_26" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1673496417890_287082_27" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617485009541_709355_27528" name="name" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617485138393_351612_27532" annotatedElement="_19_0_4_12e503d9_1617485009541_709355_27528">
+            <body>&lt;p>The name to be used for this &lt;code>Element&lt;/code> during name resolution within its &lt;code>owningNamespace&lt;/code>. This is derived using the &lt;code>effectiveName()&lt;/code> operation. By default, it is the same as the &lt;code>declaredName&lt;/code>, but this is overridden for certain kinds of &lt;code>Elements&lt;/code> to compute a &lt;code>name&lt;/code> even when the &lt;code>declaredName&lt;/code> is null.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617485027713_663217_27530" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617485027716_993146_27531" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1611356604987_900871_594" name="qualifiedName" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611356672067_270116_598" annotatedElement="_19_0_4_12e503d9_1611356604987_900871_594">
+            <body>&lt;p>The full ownership-qualified name of this &lt;code>Element&lt;/code>, represented in a form that is valid according to the KerML textual concrete syntax for qualified names (including use of unrestricted name notation and escaped characters, as necessary). The &lt;code>qualifiedName&lt;/code> is null if this &lt;code>Element&lt;/code> has no &lt;code>owningNamespace&lt;/code> or if there is not a complete ownership chain of named &lt;code>Namespaces&lt;/code> from a root &lt;code>Namespace&lt;/code> to this &lt;code>Element&lt;/code>. If the &lt;code>owningNamespace&lt;/code> has other &lt;code>Elements&lt;/code> with the same name as this one, then the &lt;code>qualifiedName&lt;/code> is null for all such &lt;code>Elements&lt;/code> other than the first.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1650484367717_653313_45" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1650484367736_16403_46" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1662070949317_79713_3658" name="isImpliedIncluded" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1662071558220_644949_3662" annotatedElement="_19_0_4_12e503d9_1662070949317_79713_3658">
+            <body>&lt;p>Whether all necessary implied Relationships have been included in the &lt;code>ownedRelationships&lt;/code> of this Element. This property may be true, even if there are not actually any &lt;code>ownedRelationships&lt;/code> with &lt;code>isImplied = true&lt;/code>, meaning that no such Relationships are actually implied for this Element. However, if it is false, then &lt;code>ownedRelationships&lt;/code> may &lt;em>not&lt;/em> contain any implied Relationships. That is, either &lt;em>all&lt;/em> required implied Relationships must be included, or none of them.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1662071163116_628473_3660" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1665443500960_5561_723" name="isLibraryElement" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665443637667_628082_729" annotatedElement="_19_0_4_12e503d9_1665443500960_5561_723">
+            <body>&lt;p>Whether this Element is contained in the ownership tree of a library model.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1611356867686_604294_599" name="escapedName" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611356951852_452838_603" annotatedElement="_19_0_4_12e503d9_1611356867686_604294_599">
+            <body>&lt;p>Return &lt;code>name&lt;/code>, if that is not null, otherwise the &lt;code>shortName&lt;/code>, if that is not null, otherwise null. If the returned value is non-null, it is returned as-is if it has the form of a basic name, or, otherwise, represented as a restricted name according to the lexical structure of the KerML textual notation (i.e., surrounded by single quote characters and with special characters escaped).&lt;/p></body>
+          </ownedComment>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1611356881535_667940_602" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617485206107_242666_27534" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617485206107_100967_27535" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1673496481627_588588_29" name="effectiveShortName" visibility="public" bodyCondition="_19_0_4_12e503d9_1673496805659_977491_36">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673496772234_91612_35" annotatedElement="_19_0_4_12e503d9_1673496481627_588588_29">
+            <body>&lt;p>Return an effective &lt;code>shortName&lt;/code> for this &lt;code>Element&lt;/code>. By default this is the same as its &lt;code>declaredShortName&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1673496805659_977491_36" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673496805679_712279_37" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>declaredShortName</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673496496290_528020_32" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1673496496302_481712_33" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1673496496304_159211_34" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1617479751670_738886_26879" name="effectiveName" visibility="public" bodyCondition="_19_0_4_12e503d9_1617479821628_475894_26886">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617479789178_733124_26885" annotatedElement="_19_0_4_12e503d9_1617479751670_738886_26879">
+            <body>&lt;p>Return an effective &lt;code>name&lt;/code> for this &lt;code>Element&lt;/code>. By default this is the same as its &lt;code>declaredName&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617479821628_475894_26886" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617479821629_927041_26887" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>declaredName</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617479777114_181395_26882" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617479777118_699464_26883" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617479777118_399346_26884" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665443526567_946990_725" name="libraryNamespace" visibility="public" bodyCondition="_19_0_4_12e503d9_1665444242657_324589_748">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665457801428_485586_774" annotatedElement="_19_0_4_12e503d9_1665443526567_946990_725">
+            <body>&lt;p>By default, return the library Namespace of the &lt;code>owningRelationship&lt;/code> of this Element, if it has one.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665444242657_324589_748" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665444242674_74114_749" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if owningRelationship &lt;> null then owningRelationship.libraryNamespace()
+else null endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665443554087_647504_728" name="" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665526863947_152551_2100" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665526863955_748329_2101" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1740262353378_288259_1574" name="path" visibility="public" bodyCondition="_2022x_2_12e503d9_1740262624325_201749_1590">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740262562787_281064_1589" annotatedElement="_2022x_2_12e503d9_1740262353378_288259_1574">
+            <body>&lt;p>Return a unique description of the location of this &lt;code>Element&lt;/code> in the containment structure rooted in a root &lt;code>Namespace&lt;/code>. If the &lt;code>Element&lt;/code> has a non-null &lt;code>qualifiedName&lt;/code>, then return that. Otherwise, if it has an &lt;code>owningRelationship&lt;/code>, then return the string constructed by appending to the &lt;code>path&lt;/code> of it's &lt;code>owningRelationship&lt;/code> the character &lt;code>/&lt;/code> followed by the string representation of its position in the list of &lt;code>ownedRelatedElements&lt;/code> of the &lt;code>owningRelationship&lt;/code> (indexed starting at 1). Otherwise, return the empty string.&lt;/p>
+
+&lt;p>(Note that this operation is overridden for &lt;code>Relationships&lt;/code> to use &lt;code>owningRelatedElement&lt;/code> when appropriate.)&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1740262624325_201749_1590" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740262624327_551304_1591" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if qualifiedName &lt;> null then qualifiedName
+else if owningRelationship &lt;> null then
+    owningRelationship.path() + '/' + 
+    owningRelationship.ownedRelatedElement->indexOf(self).toString()
+    -- A position index shall be converted to a decimal string representation 
+    -- consisting of only decimal digits, with no sign, leading zeros or leading 
+    -- or trailing whitespace.
+else ''
+endif endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1740262371897_485365_1577" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651703_78535_42198" name="A_ownedRelatedElement_owningRelationship" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674986_59873_43302 _18_5_3_12e503d9_1533160674986_482273_43303"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594152527165_731400_2499" name="A_ownedAnnotation_owningAnnotatedElement" visibility="public" memberEnd="_19_0_2_12e503d9_1594152527165_702130_2500 _19_0_2_12e503d9_1594152527165_104456_2501"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543092026091_319505_16747" name="A_ownedRelationship_owningRelatedElement" visibility="public" memberEnd="_18_5_3_12e503d9_1543092026091_217766_16748 _18_5_3_12e503d9_1543092026091_693018_16749"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651678_873382_42146" name="A_target_targetRelationship" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674961_138197_43179 _18_5_3_12e503d9_1533160674961_537222_43178">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674961_537222_43178" name="targetRelationship" visibility="public" type="_18_5_3_12e503d9_1533160651700_869737_42192" subsettedProperty="_18_5_3_12e503d9_1533160674961_585972_43176" association="_18_5_3_12e503d9_1533160651678_873382_42146">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678358_795197_43944" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678358_128860_43943" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651678_580144_42145" name="A_relatedElement_relationship" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674961_132339_43177 _18_5_3_12e503d9_1533160674961_585972_43176">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674961_585972_43176" name="relationship" visibility="public" type="_18_5_3_12e503d9_1533160651700_869737_42192" isUnique="false" isDerived="true" isDerivedUnion="true" association="_18_5_3_12e503d9_1533160651678_580144_42145">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678358_654272_43940" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678357_455684_43939" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594154758493_626101_3387" name="A_textualRepresentation_representedElement" visibility="public" memberEnd="_19_0_2_12e503d9_1594154758493_640290_3388 _19_0_2_12e503d9_1594154758494_414887_3389"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651700_869737_42192" name="Relationship" visibility="public" isAbstract="true">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1570563047655_342997_9473" annotatedElement="_18_5_3_12e503d9_1533160651700_869737_42192">
+          <body>&lt;p>A &lt;code>Relationship&lt;/code> is an &lt;code>Element&lt;/code> that relates other &lt;code>Element&lt;/code>. Some of its &lt;code>relatedElements&lt;/code> may be owned, in which case those &lt;code>ownedRelatedElements&lt;/code> will be deleted from a model if their &lt;code>owningRelationship&lt;/code> is. A &lt;code>Relationship&lt;/code> may also be owned by another &lt;code>Element&lt;/code>, in which case the &lt;code>ownedRelatedElements&lt;/code> of the &lt;code>Relationship&lt;/code> are also considered to be transitively owned by the &lt;code>owningRelatedElement&lt;/code> of the &lt;code>Relationship&lt;/code>.&lt;/p>
+
+&lt;p>The &lt;code>relatedElements&lt;/code> of a &lt;code>Relationship&lt;/code> are divided into &lt;code>source&lt;/code> and &lt;code>target&lt;/code> &lt;code>Elements&lt;/code>. The &lt;code>Relationship&lt;/code> is considered to be directed from the &lt;code>source&lt;/code> to the &lt;code>target&lt;/code> &lt;code>Elements&lt;/code>. An undirected &lt;code>Relationship&lt;/code> may have either all &lt;code>source&lt;/code> or all &lt;code>target&lt;/code> &lt;code>Elements&lt;/code>.&lt;/p>
+
+&lt;p>A &amp;quot;relationship &lt;code>Element&lt;/code>&amp;quot; in the abstract syntax is generically any &lt;code>Element&lt;/code> that is an instance of either &lt;code>Relationship&lt;/code> or a direct or indirect specialization of &lt;code>Relationship&lt;/code>. Any other kind of &lt;code>Element&lt;/code> is a &amp;quot;non-relationship &lt;code>Element&lt;/code>&amp;quot;. It is a convention of that non-relationship &lt;code>Elements&lt;/code> are &lt;em>only&lt;/em> related via reified relationship &lt;code>Elements&lt;/code>. Any meta-associations directly between non-relationship &lt;code>Elements&lt;/code> must be derived from underlying reified &lt;code>Relationship&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1659467600440_301394_5650" name="deriveRelationshipRelatedElement" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651700_869737_42192">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1659467731915_951127_5662" annotatedElement="_19_0_4_12e503d9_1659467600440_301394_5650">
+            <body>&lt;p>The &lt;code>relatedElements&lt;/code> of a &lt;code>Relationship&lt;/code> consist of all of its &lt;code>source&lt;/code> &lt;code>Elements&lt;/code> followed by all of its &lt;code>target&lt;/code> &lt;code>Elements&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1659467600454_261863_5651" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>relatedElement = source->union(target)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674985_830808_43294" general="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674961_132339_43177" name="relatedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isUnique="false" isDerived="true" association="_18_5_3_12e503d9_1533160651678_580144_42145">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777855977_834334_15554" annotatedElement="_18_5_3_12e503d9_1533160674961_132339_43177">
+            <body>&lt;p>The Elements that are related by this Relationship, derived as the union of the &lt;code>source&lt;/code> and &lt;code>target&lt;/code> Elements of the Relationship.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678358_957096_43942" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678358_131241_43941" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674961_138197_43179" name="target" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" subsettedProperty="_18_5_3_12e503d9_1533160674961_132339_43177" association="_18_5_3_12e503d9_1533160651678_873382_42146">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1584042107507_532617_81" annotatedElement="_18_5_3_12e503d9_1533160674961_138197_43179">
+            <body>&lt;p>The &lt;code>relatedElements&lt;/code> to which this Relationship is considered to be directed.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678358_737514_43946" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678358_166444_43945" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674971_696758_43228" name="source" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" subsettedProperty="_18_5_3_12e503d9_1533160674961_132339_43177" association="_18_5_3_12e503d9_1533160651686_378437_42162">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777878162_405084_15555" annotatedElement="_18_5_3_12e503d9_1533160674971_696758_43228">
+            <body>&lt;p>The &lt;code>relatedElements&lt;/c ode> from which this Relationship is considered to be directed.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678370_519049_44025" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678370_69714_44024" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543092026091_693018_16749" name="owningRelatedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" subsettedProperty="_18_5_3_12e503d9_1533160674961_132339_43177" association="_18_5_3_12e503d9_1543092026091_319505_16747">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777835996_130786_15553" annotatedElement="_18_5_3_12e503d9_1543092026091_693018_16749">
+            <body>&lt;p>The &lt;tt>relatedElement&lt;/tt> of this Relationship that owns the Relationship, if any.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543092084598_164667_16818" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543092084599_958979_16819" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674986_59873_43302" name="ownedRelatedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" aggregation="composite" subsettedProperty="_18_5_3_12e503d9_1533160674961_132339_43177" association="_18_5_3_12e503d9_1533160651703_78535_42198">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583777815621_624336_15552" annotatedElement="_18_5_3_12e503d9_1533160674986_59873_43302">
+            <body>&lt;p>The &lt;tt>relatedElements&lt;/tt> of this Relationship that are owned by the Relationship.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678381_744860_44099" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678381_180076_44098" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1662070829631_521257_3623" name="isImplied" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1662071247096_260535_3661" annotatedElement="_19_0_4_12e503d9_1662070829631_521257_3623">
+            <body>&lt;p>Whether this Relationship was generated by tooling to meet semantic rules, rather than being directly created by a modeler.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1662070848025_333397_3627" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665444136821_848026_742" name="libraryNamespace" visibility="public" bodyCondition="_19_0_4_12e503d9_1665444364755_260224_764" redefinedOperation="_19_0_4_12e503d9_1665443526567_946990_725">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665457855329_132156_775" annotatedElement="_19_0_4_12e503d9_1665444136821_848026_742">
+            <body>&lt;p>Return whether this Relationship has either an &lt;code>owningRelatedElement&lt;/code> or &lt;code>owningRelationship&lt;/code> that is a library element.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665444364755_260224_764" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665444364781_24047_765" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if owningRelatedElement &lt;> null then owningRelatedElement.libraryNamespace()
+else if owningRelationship &lt;> null then owningRelationship.libraryNamespace() 
+else null endif endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665444148521_27399_745" name="" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665526939417_720823_2130" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665526939423_953685_2131" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1740262422101_730962_1585" name="path" visibility="public" bodyCondition="_2022x_2_12e503d9_1740263021905_808357_1605" redefinedOperation="_2022x_2_12e503d9_1740262353378_288259_1574">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740262954343_476405_1604" annotatedElement="_2022x_2_12e503d9_1740262422101_730962_1585">
+            <body>&lt;p>If the &lt;code>owningRelationship&lt;/code> of the &lt;code>Relationship&lt;/code> is null but its &lt;code>owningRelatedElement&lt;/code> is non-null, construct the &lt;code>path&lt;/code> using the position of the &lt;code>Relationship&lt;/code> in the list of &lt;code>ownedRelationships&lt;/code> of its &lt;code>owningRelatedElement&lt;/code>. Otherwise, return the &lt;code>path&lt;/code> of the &lt;code>Relationship&lt;/code> as specified for an &lt;code>Element&lt;/code> in general.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1740263021905_808357_1605" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740263021908_63164_1606" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if owningRelationship = null and owningRelatedElement &lt;> null then
+    owningRelatedElement.path() + '/' + 
+    owningRelatedElement.ownedRelationship->indexOf(self).toString()
+    -- A position index shall be converted to a decimal string representation 
+    -- consisting of only decimal digits, with no sign, leading zeros or leading 
+    -- or trailing whitespace.
+else self.oclAsType(Element).path()
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1740262425123_921007_1588" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651686_378437_42162" name="A_source_sourceRelationship" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674971_696758_43228 _18_5_3_12e503d9_1533160674971_80547_43227">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674971_80547_43227" name="sourceRelationship" visibility="public" type="_18_5_3_12e503d9_1533160651700_869737_42192" subsettedProperty="_18_5_3_12e503d9_1533160674961_585972_43176" association="_18_5_3_12e503d9_1533160651686_378437_42162">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678369_287603_44023" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678369_761498_44022" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594150061165_948966_1620" name="A_documentation_documentedElement" visibility="public" memberEnd="_19_0_2_12e503d9_1594150061166_345630_1621 _19_0_2_12e503d9_1594150061166_948466_1622"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543092869879_501876_17276" name="A_owner_ownedElement" visibility="public" memberEnd="_18_5_3_12e503d9_1543092869879_744477_17277 _18_5_3_12e503d9_1543092869879_112608_17278"/>
+    </packagedElement>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1561108524767_843573_22341" name="Core" visibility="public" URI="">
+    <ownedComment xmi:id="_19_0_4_12e503d9_1597675013597_643410_911" annotatedElement="_18_5_3_12e503d9_1561108524767_843573_22341">
+      <body>The Core layer provides the semantic foundation for KerML.</body>
+    </ownedComment>
+    <packageImport xmi:id="_19_0_4_12e503d9_1597674756924_413557_872" importedPackage="_18_5_3_12e503d9_1562427331290_651623_19809"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1561108792499_574146_22574" name="Types" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651702_280851_42195" name="A_output_typeWithOutput" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674960_365618_43170 _18_5_3_12e503d9_1533160674985_530200_43300">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674985_530200_43300" name="typeWithOutput" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674987_297074_43308" association="_18_5_3_12e503d9_1533160651702_280851_42195">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716466824_295504_1362" annotatedElement="_18_5_3_12e503d9_1533160674985_530200_43300">
+            <body>&lt;p>A Type with a certain &lt;code>input&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678381_758915_44095" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678381_643099_44094" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1562476168385_736828_22105" name="A_endFeature_typeWithEndFeature" visibility="public" memberEnd="_18_5_3_12e503d9_1562476168385_824569_22106 _18_5_3_12e503d9_1562476168386_366266_22107">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1562476168386_366266_22107" name="typeWithEndFeature" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674987_297074_43308" association="_18_5_3_12e503d9_1562476168385_736828_22105">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716472628_404309_1364" annotatedElement="_18_5_3_12e503d9_1562476168386_366266_22107">
+            <body>&lt;p>A Type that has an EndFeatureMembership in which the &lt;code>endFeature&lt;/code> is a &lt;code>memberFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1562477461863_685140_22859" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1562477461866_519282_22860" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651681_269751_42154" name="A_ownedFeature_owningType" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674959_226999_43167 _18_5_3_12e503d9_1533160674965_592215_43200"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651700_34958_42191" name="A_input_typeWithInput" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674960_37384_43169 _18_5_3_12e503d9_1533160674984_142089_43293">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674984_142089_43293" name="typeWithInput" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674987_297074_43308" association="_18_5_3_12e503d9_1533160651700_34958_42191">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716459840_456404_1360" annotatedElement="_18_5_3_12e503d9_1533160674984_142089_43293">
+            <body>&lt;p>A Type with a certain &lt;code>output&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678380_194287_44089" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678380_318508_44088" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651715_913941_42236" name="A_ownedFeatureMembership_owningType" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674960_868417_43171 _18_5_3_12e503d9_1533160674992_418504_43339"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651685_851562_42161" name="A_ownedSpecialization_owningType" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674959_579676_43168 _18_5_3_12e503d9_1533160674971_573157_43226"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651696_992729_42182" name="Specialization" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1570563047665_476267_9478" annotatedElement="_18_5_3_12e503d9_1533160651696_992729_42182">
+          <body>&lt;p>&lt;code>Specialization&lt;/code> is a &lt;code>Relationship&lt;/code> between two &lt;code>Types&lt;/code> that requires all instances of the &lt;code>specific&lt;/code> type to also be instances of the &lt;code>general&lt;/code> Type (i.e., the set of instances of the &lt;code>specific&lt;/code> Type is a &lt;em>subset&lt;/em> of those of the &lt;code>general&lt;/code> Type, which might be the same set).&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597116179769_504170_1954" name="validateSpecificationSpecificNotConjugated" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651696_992729_42182">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1597116252053_658072_1957" annotatedElement="_19_0_4_12e503d9_1597116179769_504170_1954">
+            <body>&lt;p>The &lt;code>specific&lt;/code> &lt;code>Type&lt;/code> of a &lt;code>Specialization&lt;/code> cannot be a conjugated &lt;code>Type&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597116179772_202617_1955" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>not specific.isConjugated</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674982_602153_43279" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674971_573157_43226" name="owningType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543092026091_693018_16749 _18_5_3_12e503d9_1533160674982_253967_43281" association="_18_5_3_12e503d9_1533160651685_851562_42161">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589719447763_538815_21382" annotatedElement="_18_5_3_12e503d9_1533160674971_573157_43226">
+            <body>&lt;p>The &lt;code>Type&lt;/code> that is the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code> of this &lt;code>Specialization&lt;/code> and owns it as its &lt;code>owningRelatedElement&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678369_203554_44021" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678369_562583_44020" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674980_563969_43273" name="general" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_18_5_3_12e503d9_1533160651695_178252_42179">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589719367291_596567_21378" annotatedElement="_18_5_3_12e503d9_1533160674980_563969_43273">
+            <body>&lt;p>A &lt;code>Type&lt;/code> with a superset of all instances of the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code>, which might be the same set.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678377_220379_44068" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678377_184256_44067" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674982_253967_43281" name="specific" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" association="_18_5_3_12e503d9_1533160651699_705396_42190">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589719376701_938448_21379" annotatedElement="_18_5_3_12e503d9_1533160674982_253967_43281">
+            <body>&lt;p>A &lt;code>Type&lt;/code> with a subset of all instances of the &lt;code>general&lt;/code> &lt;code>Type&lt;/code>, which might be the same set.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678378_204803_44074" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678378_264376_44073" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_18_5_3_12e503d9_1533160651677_936694_42144" name="FeatureDirectionKind" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578008021797_483509_876" annotatedElement="_18_5_3_12e503d9_1533160651677_936694_42144">
+          <body>&lt;p>&lt;code>FeatureDirectionKind&lt;/code> enumerates the possible kinds of &lt;code>direction&lt;/code> that a &lt;code>Feature&lt;/code> may be given as a member of a &lt;code>Type&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedLiteral xmi:id="_18_5_3_12e503d9_1533160674960_295035_43173" name="in" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589719194539_191243_21373" annotatedElement="_18_5_3_12e503d9_1533160674960_295035_43173">
+            <body>&lt;p>Values of the &lt;code>Feature&lt;/code> on each instance of its domain are determined externally to that instance and used internally.&lt;/p>
+</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_18_5_3_12e503d9_1533160674961_205104_43175" name="inout" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589719197563_615614_21374" annotatedElement="_18_5_3_12e503d9_1533160674961_205104_43175">
+            <body>&lt;p>Values of the &lt;code>Feature&lt;/code> on each instance are determined either as &lt;em>in&lt;/em> or &lt;em>out&lt;/em> directions, or both.&lt;/p>
+</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_18_5_3_12e503d9_1533160674960_104834_43174" name="out" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589719199764_302583_21375" annotatedElement="_18_5_3_12e503d9_1533160674960_104834_43174">
+            <body>&lt;p>Values of the &lt;code>Feature&lt;/code> on each instance of its domain are determined internally to that instance and used externally.&lt;/p>
+</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651699_705396_42190" name="A_specific_specialization" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674982_253967_43281 _18_5_3_12e503d9_1533160674984_558067_43292">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674984_558067_43292" name="specialization" visibility="public" type="_18_5_3_12e503d9_1533160651696_992729_42182" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227" association="_18_5_3_12e503d9_1533160651699_705396_42190">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589719413061_577099_21381" annotatedElement="_18_5_3_12e503d9_1533160674984_558067_43292">
+            <body>&lt;p>The Specializations with a certain &lt;code>specific&lt;/code> Type.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678380_610252_44087" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678380_324429_44086" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651716_350915_42238" name="A_ownedMemberFeature_owningFeatureMembership" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674993_898044_43344 _18_5_3_12e503d9_1533160674970_68441_43223"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651695_178252_42179" name="A_general_generalization" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674980_563969_43273 _18_5_3_12e503d9_1533160674980_42445_43272">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674980_42445_43272" name="generalization" visibility="public" type="_18_5_3_12e503d9_1533160651696_992729_42182" redefinedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_18_5_3_12e503d9_1533160651695_178252_42179">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589719407284_510134_21380" annotatedElement="_18_5_3_12e503d9_1533160674980_42445_43272">
+            <body>&lt;p>The Specializations with a certain &lt;code>general&lt;code> Type.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678377_285717_44066" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678377_391412_44065" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_71301a1_1537895141427_270492_15579" name="Type" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1565810596706_52412_124006" annotatedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <body>&lt;p>A &lt;code>Type&lt;/code> is a &lt;code>Namespace&lt;/code> that is the most general kind of &lt;code>Element&lt;/code> supporting the semantics of classification. A &lt;code>Type&lt;/code> may be a &lt;code>Classifier&lt;/code> or a &lt;code>Feature&lt;/code>, defining conditions on what is classified by the &lt;code>Type&lt;/code> (see also the description of &lt;code>isSufficient&lt;/code>).&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543189512076_16516_25689" name="deriveTypeOwnedSpecialization" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676415476697_536822_20549" annotatedElement="_18_5_3_12e503d9_1543189512076_16516_25689">
+            <body>&lt;p>The &lt;code>ownedSpecializations&lt;/code> of a &lt;code>Type&lt;/code> are the &lt;code>ownedRelationships&lt;/code> that are &lt;code>Specializations&lt;/code> whose &lt;code>special&lt;/code> &lt;code>Type&lt;/code> is the owning &lt;code>Type&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543189512076_468723_25690" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedSpecialization = ownedRelationship->selectByKind(Specialization)->
+    select(s | s.special = self)
+    </body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597116765461_398606_1964" name="deriveTypeMultiplicity" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1597117009073_87647_1966" annotatedElement="_19_0_4_12e503d9_1597116765461_398606_1964">
+            <body>&lt;p>If a &lt;code>Type&lt;/code> has an owned &lt;code>Multiplicity&lt;/code>, then that is its &lt;code>multiplicity&lt;/code>. Otherwise, if the &lt;code>Type&lt;/code> has an &lt;code>ownedSpecialization&lt;/code>, then its &lt;code>multiplicity&lt;/code> is the &lt;code>multiplicity&lt;/code> of the &lt;code>general&lt;/code> &lt;code>Type&lt;/code> of that &lt;code>Specialization&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597116765461_630773_1965" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>multiplicity = 
+    let ownedMultiplicities: Sequence(Multiplicity) =
+        ownedMember->selectByKind(Multiplicity) in
+    if ownedMultiplicities->isEmpty() then null
+    else ownedMultiplicities->first()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614231132444_259114_420" name="deriveTypeOwnedFeatureMembership" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651079062158_320715_615" annotatedElement="_19_0_4_12e503d9_1614231132444_259114_420">
+            <body>&lt;p>The &lt;code>ownedFeatureMemberships&lt;/code> of a &lt;code>Type&lt;/code> are its &lt;code>ownedMemberships&lt;/code> that are &lt;code>FeatureMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614231132444_763804_421" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedFeatureMembership = ownedRelationship->selectByKind(FeatureMembership)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614231207937_114341_422" name="deriveTypeOwnedConjugator" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676415347057_780278_20547" annotatedElement="_19_0_4_12e503d9_1614231207937_114341_422">
+            <body>&lt;p>The &lt;code>ownedConjugator&lt;/code> of a &lt;code>Type&lt;/code> is the its single &lt;code>ownedRelationship&lt;/code> that is a &lt;code>Conjugation&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614231207937_557374_423" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedConjugator =
+    let ownedConjugators: Sequence(Conjugator) = 
+        ownedRelationship->selectByKind(Conjugation) in
+    if ownedConjugators->isEmpty() then null 
+    else ownedConjugators->at(1) endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1617480306683_520925_26893" name="deriveTypeOutput" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617480382033_93050_26895" annotatedElement="_19_0_4_12e503d9_1617480306683_520925_26893">
+            <body>&lt;p>The &lt;code>outputs&lt;/code> of a &lt;code>Type&lt;/code> are those of its &lt;code>features&lt;/code> that have a direction of &lt;ode>out&lt;/code> or &lt;code>inout&lt;/code> relative to the &lt;code>Type&lt;/code>, taking conjugation into account.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617480306687_387048_26894" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>output = feature->select(f | 
+    let direction: FeatureDirectionKind = directionOf(f) in
+    direction = FeatureDirectionKind::out or
+    direction = FeatureDirectionKind::inout)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1610037650505_904029_1238" name="deriveTypeInput" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617480200540_369906_26892" annotatedElement="_19_0_4_b9102da_1610037650505_904029_1238">
+            <body>&lt;p>The &lt;code>inputs&lt;/code> of a &lt;code>Type&lt;/code> are those of its features that have a direction of &lt;code>in&lt;/code> or &lt;code>inout&lt;/code> relative to the &lt;code>Type&lt;/code>, taking conjugation into account.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1610037650505_807080_1239" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>input = feature->select(f | 
+    let direction: FeatureDirectionKind = directionOf(f) in
+    direction = FeatureDirectionKind::_'in' or
+    direction = FeatureDirectionKind::inout)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1617488770105_548852_28120" name="deriveTypeInheritedMembership" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676415163329_740877_20546" annotatedElement="_19_0_4_12e503d9_1617488770105_548852_28120">
+            <body>&lt;p>The &lt;code>inheritedMemberships&lt;code> of a &lt;code>Type&lt;/code> are determined by the &lt;code>inheritedMemberships()&lt;/code> operation.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617488770107_364978_28121" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>inheritedMembership = inheritedMemberships(Set{}, Set{}, false)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1622136667581_751383_300" name="checkTypeSpecialization" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1667164280667_117402_83" annotatedElement="_19_0_4_b9102da_1622136667581_751383_300">
+            <body>&lt;p>A &lt;code>Type&lt;/code> must directly or indirectly specialize &lt;code>&lt;em>Base::Anything&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1622136667582_3995_301" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Base::Anything')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1624056397953_330096_52" name="deriveTypeDirectedFeature" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676415049955_179898_20545" annotatedElement="_19_0_4_12e503d9_1624056397953_330096_52">
+            <body>&lt;p>The &lt;code>directedFeatures&lt;/code> of a &lt;code>Type&lt;/code> are those &lt;code>features&lt;/code> for which the &lt;code>direction&lt;/code> is non-null.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1624056397954_843327_53" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>directedFeature = feature->select(f | directionOf(f) &lt;> null)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1651078757130_169837_608" name="deriveTypeFeature" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651078846748_799871_610" annotatedElement="_19_0_4_12e503d9_1651078757130_169837_608">
+            <body>&lt;p>The &lt;code>features&lt;/code> of a &lt;code>Type&lt;/code> are the &lt;code>ownedMemberFeatures&lt;/code> of its &lt;code>featureMemberships&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1651078757145_267112_609" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>feature = featureMembership.ownedMemberFeature</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1651078182904_998823_593" name="deriveTypeFeatureMembership" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651078925643_68633_611" annotatedElement="_19_0_4_12e503d9_1651078182904_998823_593">
+            <body>&lt;p>The &lt;code>featureMemberships&lt;/code> of a &lt;code>Type&lt;/code> is the union of the &lt;code>ownedFeatureMemberships&lt;/code> and those &lt;code>inheritedMemberships&lt;/code> that are &lt;code>FeatureMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1651078182923_270790_594" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureMembership = ownedFeatureMembership->union(
+    inheritedMembership->selectByKind(FeatureMembership))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1651078935606_616630_612" name="deriveTypeOwnedFeature" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651078935694_739207_614" annotatedElement="_19_0_4_12e503d9_1651078935606_616630_612">
+            <body>&lt;p>The &lt;code>ownedFeatures&lt;/code> of a &lt;code>Type&lt;/code> are the &lt;code>ownedMemberFeatures&lt;/code> of its &lt;code>ownedFeatureMemberships&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1651078935641_92432_613" name="" visibility="public">
+            <language>English</language>
+            <body>ownedFeature = ownedFeatureMembership.ownedMemberFeature</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1662127600510_243343_1470" name="deriveTypeDifferencingType" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662127618899_260047_1472" annotatedElement="_19_0_4_b9102da_1662127600510_243343_1470">
+            <body>&lt;p>The &lt;code>differencingTypes&lt;/code> of a &lt;code>Type&lt;/code> are the &lt;code>differencingTypes&lt;/code> of its &lt;code>ownedDifferencings&lt;/code>, in the same order.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1662127600511_791742_1471" name="" visibility="public">
+            <language>English</language>
+            <body>differencingType = ownedDifferencing.differencingType</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1662138904746_593338_1492" name="validateTypeIntersectingTypesNotSelf" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662138938425_111233_1494" annotatedElement="_19_0_4_b9102da_1662138904746_593338_1492">
+            <body>&lt;p>A &lt;code>Type&lt;/code> cannot be one of its own &lt;code>intersectingTypes&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1662138904747_554068_1493" name="" visibility="public">
+            <language>English</language>
+            <body>intersectingType->excludes(self)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1662138980451_48297_1495" name="validateTypeDifferencingTypesNotSelf" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662139016352_539183_1497" annotatedElement="_19_0_4_b9102da_1662138980451_48297_1495">
+            <body>&lt;p>A &lt;code>Type&lt;/code> cannot be one of its own &lt;code>differencingTypes&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1662138980451_645801_1496" name="" visibility="public">
+            <language>English</language>
+            <body>differencingType->excludes(self)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1662127045919_67907_1464" name="deriveTypeUnioningType" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662127077117_524079_1466" annotatedElement="_19_0_4_b9102da_1662127045919_67907_1464">
+            <body>&lt;p>The &lt;code>unioningTypes&lt;/code> of a &lt;code>Type&lt;/code> are the &lt;code>unioningTypes&lt;/code> of its &lt;code>ownedUnionings&lt;/code>.&lt;p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1662127045920_519885_1465" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>unioningType = ownedUnioning.unioningType</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1662138827467_939428_1489" name="validateTypeUnioningTypesNotSelf" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662138865825_979532_1491" annotatedElement="_19_0_4_b9102da_1662138827467_939428_1489">
+            <body>&lt;p>A &lt;code>Type&lt;/code> cannot be one of its own &lt;code>unioningTypes&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1662138827467_456640_1490" name="" visibility="public">
+            <language>English</language>
+            <body>unioningType->excludes(self)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1623250779619_239964_677" name="deriveTypeIntersectingType" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662127392109_566144_1469" annotatedElement="_19_0_4_b9102da_1623250779619_239964_677">
+            <body>&lt;p>The &lt;code>intersectingTypes&lt;/code> of a &lt;code>Type&lt;/code> are the &lt;code>intersectingTypes&lt;/code> of its &lt;code>ownedIntersectings&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1623250779619_818731_678" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>intersectingType = ownedIntersecting.intersectingType</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667161166573_66366_59" name="validateTypeAtMostOneConjugator" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695240591220_702648_82" annotatedElement="_19_0_4_12e503d9_1667161166573_66366_59">
+            <body>A &lt;code>Type&lt;/code> must have at most one owned &lt;code>Conjugation&lt;/code> &lt;code>Relationship&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667161166589_215780_60" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedRelationship->selectByKind(Conjugation)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672520841781_207815_272" name="validateTypeOwnedMultiplicity" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672520897565_26416_274" annotatedElement="_19_0_4_12e503d9_1672520841781_207815_272">
+            <body>&lt;p>A &lt;code>Type&lt;/code> may have at most one &lt;code>ownedMember&lt;/code> that is a &lt;code>Multiplicity&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672520841793_649430_273" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMember->selectByKind(Multiplicity)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673477817388_848423_1083" name="deriveTypeEndFeature" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673477893872_37936_1085" annotatedElement="_19_0_4_12e503d9_1673477817388_848423_1083">
+            <body>&lt;p>The &lt;code>endFeatures&lt;/code> of a &lt;code>Type&lt;/code> are all its &lt;code>features&lt;/code> for which &lt;code>isEnd = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673477817406_727803_1084" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>endFeature = feature->select(isEnd)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674247207104_994791_3817" name="deriveTypeOwnedDisjoining" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674247293744_180984_3819" annotatedElement="_19_0_4_12e503d9_1674247207104_994791_3817">
+            <body>&lt;p>The &lt;code>ownedDisjoinings&lt;/code> of a &lt;code>Type&lt;/code> are the &lt;code>ownedRelationships&lt;/code> that are &lt;code>Disjoinings&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674247207116_154037_3818" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedDisjoining =
+    ownedRelationship->selectByKind(Disjoining)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674247402352_312613_3820" name="deriveTypeOwnedUnioning" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674247502786_893900_3822" annotatedElement="_19_0_4_12e503d9_1674247402352_312613_3820">
+            <body>&lt;p>The &lt;code>ownedUnionings&lt;/code> of a &lt;code>Type&lt;/code> are the &lt;code>ownedRelationships&lt;/code> that are &lt;code>Unionings&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674247402369_820410_3821" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedUnioning =
+    ownedRelationship->selectByKind(Unioning)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674247512484_581469_3823" name="deriveTypeOwnedIntersecting" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674247552990_791964_3825" annotatedElement="_19_0_4_12e503d9_1674247512484_581469_3823">
+            <body>&lt;p>The &lt;code>ownedIntersectings&lt;/code> of a &lt;code>Type&lt;/code> are the &lt;code>ownedRelationships&lt;/code> that are &lt;code>Intersectings&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674247512502_882216_3824" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedRelationship->selectByKind(Intersecting)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674247555937_282655_3826" name="deriveTypeOwnedDifferencing" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676415402413_511962_20548" annotatedElement="_19_0_4_12e503d9_1674247555937_282655_3826">
+            <body>&lt;p>The &lt;code>ownedDifferencings&lt;/code> of a &lt;code>Type&lt;/code> are its &lt;code>ownedRelationships&lt;/code> that are &lt;code>Differencings&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674247555942_39326_3827" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedDifferencing =
+    ownedRelationship->selectByKind(Differencing)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676415624786_380529_20550" name="deriveTypeOwnedEndFeature" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676415725510_781454_20552" annotatedElement="_19_0_4_12e503d9_1676415624786_380529_20550">
+            <body>&lt;p>The &lt;code>ownedEndFeatures&lt;/code> of a &lt;code>Type&lt;/code> are all its &lt;code>ownedFeatures&lt;/code> for which &lt;code>isEnd = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676415624804_716911_20551" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedEndFeature = ownedFeature->select(isEnd)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676415869736_417330_20553" name="deriveTypeInheritedFeature" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676416010083_991342_20555" annotatedElement="_19_0_4_12e503d9_1676415869736_417330_20553">
+            <body>&lt;p>The &lt;code>inheritedFeatures&lt;/code> of this &lt;code>Type&lt;/code> are the &lt;code>memberFeatures&lt;/code> of the &lt;code>inheritedMemberships&lt;/code> that are &lt;code>FeatureMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676415869747_398166_20554" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>inheritedFeature = inheritedMemberships->
+    selectByKind(FeatureMembership).memberFeature</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695244152082_457039_126" name="validateTypeOwnedUnioningNotOne" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695244236412_475755_128" annotatedElement="_19_0_4_12e503d9_1695244152082_457039_126">
+            <body>A &lt;code>Type&lt;/code> must not have exactly one &lt;code>ownedUnioning&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695244152096_875875_127" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedUnioning->size() &lt;> 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695244248335_86994_129" name="validateTypeOwnedIntersectingNotOne" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695244248375_902030_131" annotatedElement="_19_0_4_12e503d9_1695244248335_86994_129">
+            <body>A &lt;code>Type&lt;/code> must not have exactly one &lt;code>ownedIntersecting&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695244248368_716302_130" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedIntersecting->size() &lt;> 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695244325000_35263_132" name="validateTypeOwnedDifferencingNotOne" visibility="public" constrainedElement="_18_5_3_71301a1_1537895141427_270492_15579">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695244325026_990310_134" annotatedElement="_19_0_4_12e503d9_1695244325000_35263_132">
+            <body>A &lt;code>Type&lt;/code> must not have exactly one &lt;code>ownedDifferencing&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695244325019_844880_133" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedDifferencing->size() &lt;> 1</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_71301a1_1537895174484_736640_15634" general="_18_5_3_12e503d9_1533160651694_110063_42176"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674959_579676_43168" name="ownedSpecialization" visibility="public" type="_18_5_3_12e503d9_1533160651696_992729_42182" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543092026091_217766_16748 _18_5_3_12e503d9_1533160674984_558067_43292" association="_18_5_3_12e503d9_1533160651685_851562_42161">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589719457467_501186_21383" annotatedElement="_18_5_3_12e503d9_1533160674959_579676_43168">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Specializations&lt;/code>, for which the &lt;code>Type&lt;/code> is the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678357_765995_43930" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678356_489536_43929" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674960_868417_43171" name="ownedFeatureMembership" visibility="public" type="_18_5_3_12e503d9_1533160651715_740575_42237" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_190614_43269 _19_0_4_12e503d9_1651076866512_962346_485" association="_18_5_3_12e503d9_1533160651715_913941_42236">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716310709_657832_1355" annotatedElement="_18_5_3_12e503d9_1533160674960_868417_43171">
+            <body>&lt;p>The &lt;code>ownedMemberships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>FeatureMemberships&lt;/code>, for which the &lt;code>Type&lt;/code> is the &lt;code>owningType&lt;/code>. Each such &lt;code>FeatureMembership&lt;/code> identifies an &lt;code>ownedFeature&lt;/code> of the &lt;code>Type&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678357_857117_43936" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678357_753104_43935" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674959_326391_43166" name="feature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_644335_43267" association="_18_5_3_12e503d9_1533160651704_675458_42200">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716382593_14432_1356" annotatedElement="_18_5_3_12e503d9_1533160674959_326391_43166">
+            <body>&lt;p>The &lt;code>ownedMemberFeatures&lt;/code> of the &lt;code>featureMemberships&lt;/code> of this &lt;code>Type&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678356_458583_43926" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678356_394047_43925" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674959_226999_43167" name="ownedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_259543_43268" association="_18_5_3_12e503d9_1533160651681_269751_42154">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716457305_340194_1359" annotatedElement="_18_5_3_12e503d9_1533160674959_226999_43167">
+            <body>&lt;p>The &lt;code>ownedMemberFeatures&lt;/code> of the &lt;code>ownedFeatureMemberships&lt;/code> of this &lt;code>Type&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678356_62846_43928" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678356_193020_43927" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674960_37384_43169" name="input" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1623952188842_882068_37169" association="_18_5_3_12e503d9_1533160651700_34958_42191">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716463953_199981_1361" annotatedElement="_18_5_3_12e503d9_1533160674960_37384_43169">
+            <body>&lt;p>All &lt;code>features&lt;/code> related to this &lt;code>Type&lt;/code> by &lt;code>FeatureMemberships&lt;/code> that have &lt;code>direction&lt;/code> &lt;code>in&lt;/code> or &lt;code>inout&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678357_859099_43932" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678357_607711_43931" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674960_365618_43170" name="output" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1623952188842_882068_37169" association="_18_5_3_12e503d9_1533160651702_280851_42195">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716469264_840008_1363" annotatedElement="_18_5_3_12e503d9_1533160674960_365618_43170">
+            <body>&lt;p>All &lt;code>features&lt;/code> related to this &lt;code>Type&lt;/code> by &lt;code>FeatureMemberships&lt;/code> that have &lt;code>direction&lt;/code> &lt;code>out&lt;/code> or &lt;code>inout&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678357_327608_43934" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678357_326859_43933" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674959_741353_43165" name="isAbstract" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590439110303_829431_54" annotatedElement="_18_5_3_12e503d9_1533160674959_741353_43165">
+            <body>&lt;p>Indicates whether instances of this &lt;code>Type&lt;/code> must also be instances of at least one of its specialized &lt;code>Types&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_2_12e503d9_1575485925835_681686_1932" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1551972927538_787976_19004" name="inheritedMembership" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674962_198288_43183" association="_18_5_3_12e503d9_1551972927537_986764_19003">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716515376_769042_1377" annotatedElement="_18_5_3_12e503d9_1551972927538_787976_19004">
+            <body>&lt;p>All &lt;code>Memberships&lt;/code> inherited by this &lt;code>Type&lt;/code> via &lt;code>Specialization&lt;/code> or &lt;code>Conjugation&lt;/code>. These are included in the derived union for the &lt;code>memberships&lt;/code> of the &lt;code>Type&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1551972960449_82998_19058" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1551972960450_490673_19059" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1562476168385_824569_22106" name="endFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674959_326391_43166" association="_18_5_3_12e503d9_1562476168385_736828_22105">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716475313_947555_1365" annotatedElement="_18_5_3_12e503d9_1562476168385_824569_22106">
+            <body>&lt;p>All &lt;code>features&lt;/code> of this &lt;code>Type&lt;/code> with &lt;code>isEnd = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1562476243383_523926_22154" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1562476243385_437014_22155" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1563834516278_687758_20652" name="ownedEndFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1562476168385_824569_22106 _18_5_3_12e503d9_1533160674959_226999_43167" association="_18_5_3_12e503d9_1563834516278_736913_20651">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716480065_359212_1367" annotatedElement="_18_5_3_12e503d9_1563834516278_687758_20652">
+            <body>&lt;p>All &lt;code>endFeatures&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>ownedFeatures&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1563834549784_548160_20714" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1563834549784_93849_20715" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_b9102da_1564072709069_937523_30797" name="isSufficient" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1578003376821_848586_834" annotatedElement="_18_5_3_b9102da_1564072709069_937523_30797">
+            <body>&lt;p>Whether all things that meet the classification conditions of this &lt;code>Type&lt;/code> must be classified by the &lt;code>Type&lt;/code>.&lt;/p>
+
+&lt;p>(A &lt;code>Type&lt;/code>&amp;nbsp;gives conditions that must be met by whatever it classifies, but when &lt;code>isSufficient&lt;/code> is false, things may meet those conditions but still not be classified by the &lt;code>Type&lt;/code>. For example, a Type &lt;code>&lt;em>Car&lt;/em>&lt;/code> that is not sufficient could require everything it classifies to have four wheels, but not all four wheeled things would classify as cars. However, if the &lt;code>Type&lt;/code> &lt;code>&lt;em>Car&lt;/em>&lt;/code> were sufficient, it would classify all four-wheeled things.)&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_18_5_3_b9102da_1564072740244_136507_30799" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575482646809_280165_440" name="ownedConjugator" visibility="public" type="_19_0_2_12e503d9_1575482328287_696279_181" aggregation="composite" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1575482490144_309557_300 _18_5_3_12e503d9_1543092026091_217766_16748" association="_19_0_2_12e503d9_1575482646806_372715_439">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590435849920_933567_30" annotatedElement="_19_0_2_12e503d9_1575482646809_280165_440">
+            <body>&lt;p>A &lt;code>Conjugation&lt;/code> owned by this &lt;code>Type&lt;/code> for which the &lt;code>Type&lt;/code> is the &lt;code>originalType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575482732751_478763_500" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575482732752_248371_501" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575485930816_796088_1933" name="isConjugated" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590439160087_502769_55" annotatedElement="_19_0_2_12e503d9_1575485930816_796088_1933">
+            <body>&lt;p>Indicates whether this &lt;code>Type&lt;/code> has an &lt;code>ownedConjugator&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575499020770_15576_2334" name="inheritedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674959_326391_43166" association="_19_0_2_12e503d9_1575499020769_513266_2333">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716485174_339525_1369" annotatedElement="_19_0_2_12e503d9_1575499020770_15576_2334">
+            <body>&lt;p>All the &lt;code>memberFeatures&lt;/code> of the &lt;code>inheritedMemberships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>FeatureMemberships&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575499045638_660399_2344" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575499045638_634515_2345" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1573095852093_324833_5396" name="multiplicity" visibility="public" type="_19_0_2_12e503d9_1573083797505_495205_3879" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_259543_43268" association="_19_0_2_12e503d9_1573095852093_239452_5395">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1578002452525_920351_833" annotatedElement="_19_0_2_12e503d9_1573095852093_324833_5396">
+            <body>&lt;p>An &lt;code>ownedMember&lt;/code> of this &lt;code>Type&lt;/code> that is a &lt;code>Multiplicity&lt;/code>, which constraints the cardinality of the &lt;code>Type&lt;/code>. If there is no such &lt;code>ownedMember&lt;/code>, then the cardinality of this &lt;code>Type&lt;/code> is constrained by all the &lt;code>Multiplicity&lt;/code> constraints applicable to any direct supertypes.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573095905405_210592_5444" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573095905406_240202_5445" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1661974896766_783268_1231" name="unioningType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isOrdered="true" isDerived="true" association="_19_0_4_b9102da_1661974896766_916994_1230">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662061808094_771057_1423" annotatedElement="_19_0_4_b9102da_1661974896766_783268_1231">
+            <body>&lt;p>The interpretations of a &lt;code>Type&lt;/code> with &lt;code>unioningTypes&lt;/code> are asserted to be the same as those of all the &lt;code>unioningTypes&lt;/code> together, which are the &lt;code>Types&lt;/code> derived from the &lt;code>unioningType&lt;/code> of the &lt;code>ownedUnionings&lt;/code> of this &lt;code>Type&lt;/code>. For example, a &lt;code>Classifier&lt;/code> for people might be the union of &lt;code>Classifiers&lt;/code> for all the sexes. Similarly, a feature for people&amp;#39;s children might be the union of features dividing them in the same ways as people in general.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662571327723_792364_3589" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662571327742_655595_3590" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1623242552144_910757_524" name="ownedIntersecting" visibility="public" type="_19_0_4_b9102da_1623187351831_706169_90" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227 _18_5_3_12e503d9_1543092026091_217766_16748" association="_19_0_4_b9102da_1623242552144_490822_523">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623250698868_349238_671" annotatedElement="_19_0_4_b9102da_1623242552144_910757_524">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Intersectings&lt;/code>, have the &lt;code>Type&lt;/code> as their &lt;code>typeIntersected&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662572072645_75189_3665" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662572072659_304254_3666" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1661973922199_584242_1045" name="intersectingType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isOrdered="true" isDerived="true" association="_19_0_4_b9102da_1661973922199_110027_1044">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662062644638_436755_1437" annotatedElement="_19_0_4_b9102da_1661973922199_584242_1045">
+            <body>&lt;p>The interpretations of a &lt;code>Type&lt;/code> with &lt;code>intersectingTypes&lt;/code> are asserted to be those in common among the &lt;code>intersectingTypes&lt;/code>, which are the &lt;code>Types&lt;/code> derived from the &lt;code>intersectingType&lt;/code> of the &lt;code>ownedIntersectings&lt;/code> of this &lt;code>Type&lt;/code>. For example, a &lt;code>Classifier&lt;/code> might be an intersection of &lt;code>Classifiers&lt;/code> for people of a particular sex and of a particular nationality. Similarly, a feature for people&amp;#39;s children of a particular sex might be the intersection of a &lt;code>Feature&lt;/code> for their children and a &lt;code>Classifier&lt;/code> for people of that sex (because the interpretations of the children &lt;code>Feature&lt;/code> that identify those of that sex are also interpretations of the Classifier for that sex).&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662571433620_282786_3641" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662571433622_564412_3642" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1661869978505_968809_460" name="ownedUnioning" visibility="public" type="_19_0_4_b9102da_1661869922775_190651_380" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543092026091_217766_16748 _18_5_3_12e503d9_1533160674971_80547_43227" association="_19_0_4_b9102da_1661869978504_483445_458">
+          <ownedComment xmi:id="_19_0_4_b9102da_1661884212477_970659_995" annotatedElement="_19_0_4_b9102da_1661869978505_968809_460">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Unionings&lt;/code>, having the &lt;code>Type&lt;/code> as their &lt;code>typeUnioned&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662572114314_329688_3721" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662572114328_454976_3722" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1627447519613_145554_370" name="ownedDisjoining" visibility="public" type="_19_0_4_b9102da_1623182941809_239395_557" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543092026091_217766_16748 _19_0_4_b9102da_1623183194914_502526_616" association="_19_0_4_12e503d9_1627447519611_807661_369">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1627447935225_35061_499" annotatedElement="_19_0_4_12e503d9_1627447519613_145554_370">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Disjoinings&lt;/code>, for which the &lt;code>Type&lt;/code> is the &lt;code>typeDisjoined&lt;/code> &lt;code>Type&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1627447593619_382200_380" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1627447593634_500672_381" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1651076866512_962346_485" name="featureMembership" visibility="public" type="_18_5_3_12e503d9_1533160651715_740575_42237" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1651076866500_370361_484">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651077096482_620538_507" annotatedElement="_19_0_4_12e503d9_1651076866512_962346_485">
+            <body>&lt;p>The &lt;code>FeatureMemberships&lt;/code> for &lt;code>features&lt;/code> of this &lt;code>Type&lt;/code>, which include all &lt;code>ownedFeatureMemberships&lt;/code> and those &lt;code>inheritedMemberships&lt;/code> that are &lt;code>FeatureMemberships&lt;/code> (but does &lt;em>not&lt;/em> include any &lt;code>importedMemberships&lt;/code>).&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1651076941400_548332_503" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1651076941416_781768_504" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1661975883472_645501_1372" name="differencingType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isOrdered="true" isDerived="true" association="_19_0_4_b9102da_1661975883472_321005_1371">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662063510191_28811_1447" annotatedElement="_19_0_4_b9102da_1661975883472_645501_1372">
+            <body>&lt;p>The interpretations of a &lt;code>Type&lt;/code> with &lt;code>differencingTypes&lt;/code> are asserted to be those of the first of those &lt;code>Types&lt;/code>, but not including those of the remaining &lt;code>Types&lt;/code>. For example, a &lt;code>Classifier&lt;/code> might be the difference of a &lt;code>Classifier&lt;/code> for people and another for people of a particular nationality, leaving people who are not of that nationality. Similarly, a feature of people might be the difference between a feature for their children and a &lt;code>Classifier&lt;/code> for people of a particular sex, identifying their children not of that sex (because the interpretations of the children &lt;code>Feature&lt;/code> that identify those of that sex are also interpretations of the &lt;code>Classifier&lt;/code> for that sex).&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662571384573_568828_3601" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662571384580_758539_3602" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1661871168454_98082_797" name="ownedDifferencing" visibility="public" type="_19_0_4_b9102da_1661870994364_119372_712" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227 _18_5_3_12e503d9_1543092026091_217766_16748" association="_19_0_4_b9102da_1661871168453_838914_795">
+          <ownedComment xmi:id="_19_0_4_b9102da_1661884627685_649276_1016" annotatedElement="_19_0_4_b9102da_1661871168454_98082_797">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Type&lt;/code> that are &lt;code>Differencings&lt;/code>, having this &lt;code>Type&lt;/code> as their &lt;code>typeDifferenced&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662572153625_413087_3759" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662572153635_756789_3760" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1623952188842_882068_37169" name="directedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674959_326391_43166" association="_19_0_4_12e503d9_1623952188841_993417_37168">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624056072984_30821_39" annotatedElement="_19_0_4_12e503d9_1623952188842_882068_37169">
+            <body>&lt;p>The &lt;code>features&lt;/code> of this &lt;code>Type&lt;/code> that have a non-null &lt;code>direction&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1623952220266_943071_37179" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1623952220275_379958_37180" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1617488022028_275609_27888" name="visibleMemberships" visibility="public" bodyCondition="_19_0_4_12e503d9_1617488675300_8189_28114" redefinedOperation="_18_5_3_12e503d9_1551974328473_571863_19917">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617488408093_384173_28092" annotatedElement="_19_0_4_12e503d9_1617488022028_275609_27888">
+            <body>&lt;p>The visible &lt;code>Memberships&lt;/code> of a &lt;code>Type&lt;/code> include &lt;code>inheritedMemberships&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617488675300_8189_28114" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617488675302_532705_28115" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let visibleMemberships : OrderedSet(Membership) =
+    self.oclAsType(Namespace).
+        visibleMemberships(excluded, isRecursive, includeAll) in
+let visibleInheritedMemberships : OrderedSet(Membership) = 
+    inheritedMemberships(excluded->including(self), Set{}, isRecursive)->
+        select(includeAll or visibility = VisibilityKind::public) in
+visibleMemberships->union(visibleInheritedMemberships)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617488078084_354560_27892" name="excluded" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617488078126_56416_27893" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617488078127_776131_27894" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1622148100500_752590_630" name="isRecursive" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1625090121569_135346_4796" name="includeAll" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617488078129_649743_27895" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617488078178_261702_27896" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617488078178_544170_27897" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1617488409833_345899_28093" name="inheritedMemberships" visibility="public" bodyCondition="_2022x_2_12e503d9_1736635826217_763840_453">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617488536458_277966_28101" annotatedElement="_19_0_4_12e503d9_1617488409833_345899_28093">
+            <body>&lt;p>Return the &lt;code>Memberships&lt;/code> inheritable from supertypes of this &lt;code>Type&lt;/code> with redefined &lt;code>Features&lt;/code> removed. When computing inheritable &lt;code>Memberships&lt;/code>, exclude &lt;code>Imports&lt;/code> of &lt;code>excludedNamespaces&lt;/code>, &lt;code>Specializations&lt;/code> of &lt;code>excludedTypes&lt;/code>, and, if &lt;code>excludeImplied = true&lt;/code>, all implied &lt;code>Specializations&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1736635826217_763840_453" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736635826218_840486_454" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>removeRedefinedFeatures(
+    inheritableMemberships(excludedNamespaces, excludedTypes, excludeImplied))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736635864745_311145_455" name="excludedNamespaces" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736635890461_879896_456" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736635890461_365097_457" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617488476981_788005_28095" name="excludedTypes" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617488476993_198334_28096" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617488476994_311786_28097" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1720280800162_565153_95" name="excludeImplied" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617488476998_292442_28098" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617488477038_615107_28099" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617488477039_460974_28100" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1736634586874_788348_409" name="inheritableMemberships" visibility="public" bodyCondition="_2022x_2_12e503d9_1736634720471_829660_441">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736634764617_70649_443" annotatedElement="_2022x_2_12e503d9_1736634586874_788348_409">
+            <body>&lt;p>Return all the non-&lt;code>private&lt;/code> &lt;code>Memberships&lt;/code> of all the supertypes of this &lt;code>Type&lt;/code>, excluding any supertypes that are this &lt;code>Type&lt;/code> or are in the given set of &lt;code>excludedTypes&lt;/code>. If &lt;code>excludeImplied = true&lt;/code>, then also transitively exclude any supertypes from implied &lt;code>Specializations&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1736634720471_829660_441" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736634720472_4240_442" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let excludingSelf : Set(Type) = excludedType->including(self) in
+supertypes(excludeImplied)->reject(t | excludingSelf->includes(t)).
+    nonPrivateMemberships(excludedNamespaces, excludingSelf, excludeImplied)
+</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634620441_535222_411" name="excludedNamespaces" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736634620489_355451_412" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736634620490_86990_413" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634620490_560114_414" name="excludedTypes" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736634620528_511423_415" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736634620528_564018_416" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634620529_532351_417" name="excludeImplied" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634620572_900304_418" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736634620612_895810_419" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736634620612_861662_420" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1736634620664_429550_421" name="nonPrivateMemberships" visibility="public" bodyCondition="_2022x_2_12e503d9_1736634934381_905651_445">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736634914955_294947_444" annotatedElement="_2022x_2_12e503d9_1736634620664_429550_421">
+            <body>&lt;p>Return the &lt;code>public&lt;/code>, &lt;code>protected&lt;/code> and inherited &lt;code>Memberships&lt;/code> of this &lt;code>Type&lt;/code>. When computing imported &lt;code>Memberships&lt;/code>, exclude the given set of &lt;code>excludedNamespaces&lt;/code>. When computing inherited &lt;code>Memberships&lt;/code>, exclude &lt;code>Types&lt;/code> in the given set of &lt;code>excludedTypes&lt;/code>. If &lt;code>excludeImplied = true&lt;/code>, then also exclude any supertypes from implied &lt;code>Specializations&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1736634934381_905651_445" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736634934381_628238_446" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let publicMemberships : OrderedSet(Membership) = 
+    membershipsOfVisibility(VisibilityKind::public, excludedNamespaces) in
+let protectedMemberships : OrderedSet(Membership) = 
+    membershipsOfVisibility(VisibilityKind::protected, excludedNamespaces) in
+let inheritedMemberships : OrderedSet(Membership) =
+    inheritedMemberships(excludedNamespaces, excludedTypes, excludeImplied) in
+publicMemberships->
+    union(protectedMemberships)->
+    union(inheritedMemberships)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634638305_547926_423" name="excludedNamespaces" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736634638345_229994_424" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736634638345_130430_425" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634638346_478311_426" name="excludedTypes" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736634638367_246759_427" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736634638367_17715_428" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634638368_670351_429" name="excludeImplied" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634638391_705387_430" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736634638430_219765_431" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736634638430_503285_432" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1736634638481_340870_433" name="removeRedefinedFeatures" visibility="public" bodyCondition="_2022x_2_12e503d9_1736635077450_401942_448">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736635031046_790055_447" annotatedElement="_2022x_2_12e503d9_1736634638481_340870_433">
+            <body>&lt;p>Return a subset of &lt;code>memberships&lt;/code>, removing those &lt;code>Memberships&lt;/code> whose &lt;code>memberElements&lt;/code> are &lt;code>Features&lt;/code> and for which either of the following two conditions holds:&lt;/p>
+
+&lt;ol>
+	&lt;li>The &lt;code>memberElement&lt;/code> of the &lt;code>Membership&lt;/code> is included in redefined &lt;code>Features&lt;/code> of another &lt;code>Membership&lt;/code> in &lt;code>memberships&lt;/code>.&lt;/li>
+	&lt;li>One of the redefined &lt;code>Features&lt;/code> of the &lt;code>Membership&lt;/code> is a directly &lt;code>redefinedFeature&lt;/code> of an &lt;code>ownedFeature&lt;/code> of this &lt;code>Type&lt;/code>.&lt;/li>
+&lt;/ol>
+
+&lt;p>For this purpose, the redefined &lt;code>Features&lt;/code> of a &lt;code>Membership&lt;/code> whose &lt;code>memberElement&lt;/code> is a &lt;code>Feature&lt;/code> includes the &lt;code>memberElement&lt;/code> and all &lt;code>Features&lt;/code> directly or indirectly redefined by the &lt;code>memberElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1736635077450_401942_448" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736635077451_145514_449" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let reducedMemberships : Sequence(Membership) =
+    memberships->reject(mem1 |
+        memberships->excluding(mem1)->
+            exists(mem2 | allRedefinedFeaturesOf(mem2)->
+                includes(mem1.memberElement))) in
+let redefinedFeatures : Set(Feature) = 
+    ownedFeature.redefinition.redefinedFeature->asSet() in
+reducedMemberships->reject(mem | allRedefinedFeaturesOf(mem)->
+    exists(feature | redefinedFeatures->includes(feature)))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634658123_886129_435" name="memberships" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736634658171_802940_436" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736634658171_377084_437" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634658171_826775_438" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736634658194_418380_439" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736634658194_344004_440" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1736633860803_493015_50" name="allRedefinedFeaturesOf" visibility="public" bodyCondition="_2022x_2_12e503d9_1736633940954_289288_56">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736633949707_683848_58" annotatedElement="_2022x_2_12e503d9_1736633860803_493015_50">
+            <body>&lt;p>If the &lt;code>memberElement&lt;/code> of the given &lt;code>membership&lt;/code> is a &lt;code>Feature&lt;/code>, then return all &lt;code>Features&lt;/code> directly or indirectly redefined by the &lt;code>memberElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1736633940954_289288_56" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736633940955_695149_57" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if not membership.memberElement.oclIsType(Feature) then Set{} 
+else membership.memberElement.oclAsType(Feature).allRedefinedFeatures()
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1740201778320_799579_1390" name="membership" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152"/>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736633865581_567924_53" name="" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736633865626_461902_54" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736633865626_959780_55" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_2_12e503d9_1575498149455_550668_2262" name="directionOf" visibility="public" bodyCondition="_19_0_4_12e503d9_1617479911224_674366_26888">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1575498337790_276082_2282" annotatedElement="_19_0_2_12e503d9_1575498149455_550668_2262">
+            <body>&lt;p>If the given &lt;code>feature&lt;/code> is a &lt;code>feature&lt;/code> of this &lt;code>Type&lt;/code>, then return its direction relative to this &lt;code>Type&lt;/code>, taking conjugation into account.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617479911224_674366_26888" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617479911226_627279_26889" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>directionOfExcluding(f, Set{})</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_2_12e503d9_1575498188659_987972_2266" name="feature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+          <ownedParameter xmi:id="_19_0_2_12e503d9_1575498188688_104046_2267" name="" visibility="public" type="_18_5_3_12e503d9_1533160651677_936694_42144" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575498188703_821938_2268" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575498188704_309200_2269" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1705638990666_805681_1023" name="directionOfExcluding" visibility="public" bodyCondition="_19_0_4_12e503d9_1705639197205_568229_1036">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1705639167811_5540_1034" annotatedElement="_19_0_4_12e503d9_1705638990666_805681_1023">
+            <body>&lt;p>Return the direction of the given &lt;code>feature&lt;/code> relative to this &lt;code>Type&lt;/code>, excluding a given set of &lt;code>Types&lt;/code> from the search of supertypes of this &lt;code>Type&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1705639197205_568229_1036" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1705639197219_706376_1037" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let excludedSelf : Set(Type) = excluded->including(self) in 
+if feature.owningType = self then feature.direction
+else
+    let directions : Sequence(FeatureDirectionKind) =
+        supertypes(false)->excluding(excludedSelf).
+        directionOfExcluding(feature, excludedSelf)->
+        select(d | d &lt;> null) in
+    if directions->isEmpty() then null
+ else
+    let direction : FeatureDirectionKind = directions->first() in
+    if not isConjugated then direction
+    else if direction = FeatureDirectionKind::_'in' then FeatureDirectionKind::out
+    else if direction = FeatureDirectionKind::out then FeatureDirectionKind::_'in'
+    else direction
+    endif endif endif   endif
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1705639026126_60714_1025" name="feature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1705639031362_987688_1026" name="excluded" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1705639039564_799845_1027" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1705639039566_569329_1028" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1705639039569_482873_1029" name="" visibility="public" type="_18_5_3_12e503d9_1533160651677_936694_42144" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1705639057274_142363_1031" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1705639057276_32339_1032" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1736634542559_470008_403" name="supertypes" visibility="public" bodyCondition="_2022x_2_12e503d9_1736635198149_144612_451">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736635167570_865905_450" annotatedElement="_2022x_2_12e503d9_1736634542559_470008_403">
+            <body>&lt;p>If this &lt;code>Type&lt;/code> is conjugated, then return just the &lt;code>originalType&lt;/code> of the &lt;code>Conjugation&lt;/code>. Otherwise, return the &lt;code>general&lt;/code> &lt;code>Types&lt;/code> from all &lt;code>ownedSpecializations&lt;/code> of this type, if &lt;code>excludeImplied = false&lt;/code>, or all non-implied &lt;code>ownedSpecializations&lt;/code>, if &lt;code>excludeImplied = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1736635198149_144612_451" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736635198150_804226_452" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if isConjugated then Sequence{conjugator.originalType}
+else if not excludeImplied then ownedSpecialization.general
+else ownedSpecialization->reject(isImplied).general
+endif
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634586749_503455_405" name="excludeImplied" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736634586792_876838_406" name="" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736634586827_61375_407" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736634586827_309500_408" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_2_b9102da_1591815015580_819415_116" name="allSupertypes" visibility="public" bodyCondition="_19_0_4_12e503d9_1617488226436_712869_28070">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617480568405_57905_26896" annotatedElement="_19_0_2_b9102da_1591815015580_819415_116">
+            <body>&lt;p>Return this &lt;code>Type&lt;/code> and all &lt;code>Types&lt;/code> that are directly or transitively supertypes of this &lt;code>Type&lt;/code> (as determined by the &lt;code>supertypes&lt;/code> operation with &lt;code>excludeImplied = false&lt;/code>).&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617488226436_712869_28070" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617488226439_27644_28071" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>OrderedSet{self}->closure(supertypes(false))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_2_b9102da_1591815054959_96255_118" name="result" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_b9102da_1591823048013_257027_123" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_b9102da_1591823048014_439116_124" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669936278703_702562_722" name="specializes" visibility="public" bodyCondition="_19_0_4_12e503d9_1669936373900_341742_727">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669936339932_57773_726" annotatedElement="_19_0_4_12e503d9_1669936278703_702562_722">
+            <body>&lt;p>Check whether this &lt;code>Type&lt;/code> is a direct or indirect specialization of the given &lt;code>supertype&lt;code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1669936373900_341742_727" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669936373912_182945_728" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if isConjugated then 
+    ownedConjugator.originalType.specializes(supertype)
+else
+    allSupertypes()->includes(supertype)
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669936305606_306049_724" name="supertype" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669936305627_944100_725" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669853286245_658209_437" name="specializesFromLibrary" visibility="public" bodyCondition="_19_0_4_12e503d9_1669853459769_326407_442">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669853424043_330671_441" annotatedElement="_19_0_4_12e503d9_1669853286245_658209_437">
+            <body>&lt;p>Check whether this &lt;code>Type&lt;/code> is a direct or indirect specialization of the named library &lt;code>Type&lt;/code>. &lt;code>libraryTypeName&lt;/code> must conform to the syntax of a KerML qualified name and must resolve to a &lt;code>Type&lt;/code> in global scope.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1669853459769_326407_442" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669853459784_112739_443" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let mem : Membership = resolveGlobal(libraryTypeName) in
+mem &lt;> null and mem.memberElement.oclIsKindOf(Type) and
+specializes(mem.memberElement.oclAsType(Type))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669853336297_275506_439" name="libraryTypeName" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669853336333_669716_440" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1737750539612_666533_25" name="isCompatibleWith" visibility="public" bodyCondition="_2022x_2_12e503d9_1740170107523_425128_26">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740173758739_811256_141" annotatedElement="_2022x_2_12e503d9_1737750539612_666533_25">
+            <body>&lt;p>By default, this &lt;code>Type&lt;/code> is compatible with an &lt;code>otherType&lt;/code> if it directly or indirectly specializes the &lt;code>otherType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1740170107523_425128_26" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740170107524_591813_27" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>specializes(otherType)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1737750551572_669259_27" name="otherType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579"/>
+          <ownedParameter xmi:id="_2024x_2_12e503d9_1777504517975_439257_19" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1734675461007_474236_370" name="multiplicities" visibility="public" bodyCondition="_2022x_2_12e503d9_1734675552474_266840_382">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734675528870_65826_381" annotatedElement="_2022x_2_12e503d9_1734675461007_474236_370">
+            <body>&lt;p>Return the owned or inherited &lt;code>Multiplicities&lt;/code> for this &lt;code>Type&lt;./code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1734675552474_266840_382" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734675552475_168002_383" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if multiplicity &lt;> null then OrderedSet{multiplicity}
+else 
+    ownedSpecialization.general->closure(t |
+        if t.multiplicity &lt;> null then OrderedSet{}
+        else ownedSpecialization.general
+    )->select(multiplicity &lt;> null).multiplicity->asOrderedSet()
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1734675481258_397612_372" name="" visibility="public" type="_19_0_2_12e503d9_1573083797505_495205_3879" isOrdered="true" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1734675481259_452079_373" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1734675481259_891579_374" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651704_675458_42200" name="A_typeWithFeature_feature" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674987_297074_43308 _18_5_3_12e503d9_1533160674959_326391_43166">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674987_297074_43308" name="typeWithFeature" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674980_717955_43271" association="_18_5_3_12e503d9_1533160651704_675458_42200">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716440121_619037_1357" annotatedElement="_18_5_3_12e503d9_1533160674987_297074_43308">
+            <body>&lt;p>A Type that owns or inherits a FeatureMembership Relationship with the &lt;code>feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678383_617853_44110" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678383_749690_44109" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651715_740575_42237" name="FeatureMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1570563047668_604308_9481" annotatedElement="_18_5_3_12e503d9_1533160651715_740575_42237">
+          <body>&lt;p>A &lt;code>FeatureMembership&lt;/code> is an &lt;code>OwningMembership&lt;/code> between an &lt;code>ownedMemberFeature&lt;/code> and an &lt;code>owningType&lt;/code>. If the &lt;code>ownedMemberFeature&lt;/code> has &lt;code>isVariable = false&lt;/code>, then the &lt;code>FeatureMembership&lt;/code> implies that the &lt;code>owningType&lt;/code> is also a &lt;code>featuringType&lt;/code> of the &lt;code>ownedMemberFeature&lt;/code>. If the &lt;code>ownedMemberFeature&lt;/code> has &lt;code>isVariable = true&lt;/code>, then the &lt;code>FeatureMembership&lt;/code> implies that the &lt;code>ownedMemberFeature&lt;/code> is featured by the &lt;em>&lt;code>snapshots&lt;/code>&lt;/em> of the &lt;code>owningType&lt;/code>, which must specialize the Kernel Semantic Library base class &lt;em>&lt;code>Occurrence&lt;/code>&lt;/em>.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674963_269375_43189" general="_19_0_4_12e503d9_1648180804650_933390_31"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674992_418504_43339" name="owningType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674965_193857_43197" subsettedProperty="_19_0_4_12e503d9_1651076866524_738482_486" association="_18_5_3_12e503d9_1533160651715_913941_42236">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716522578_213902_1378" annotatedElement="_18_5_3_12e503d9_1533160674992_418504_43339">
+            <body>&lt;p>The &lt;code>Type&lt;/code> that owns this &lt;code>FeatureMembership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678384_577605_44118" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678384_939594_44117" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674993_898044_43344" name="ownedMemberFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" aggregation="composite" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674965_501750_43196" association="_18_5_3_12e503d9_1533160651716_350915_42238">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716506120_915268_1374" annotatedElement="_18_5_3_12e503d9_1533160674993_898044_43344">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that this &lt;code>FeatureMembership&lt;/code> relates to its &lt;code>owningType&lt;/code>, making it an &lt;code>ownedFeature&lt;/code> of the &lt;code>owningType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678384_249557_44124" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678384_562404_44123" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1551972927537_986764_19003" name="A_inheritedMembership_inheritingType" visibility="public" memberEnd="_18_5_3_12e503d9_1551972927538_787976_19004 _18_5_3_12e503d9_1551972927538_959968_19005">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1551972927538_959968_19005" name="inheritingType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674962_531296_43182" association="_18_5_3_12e503d9_1551972927537_986764_19003">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716508658_408831_1375" annotatedElement="_18_5_3_12e503d9_1551972927538_959968_19005">
+            <body>&lt;p>The Type that inherits the &lt;code>inheritedMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1551972984070_819955_19084" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1551972984070_532940_19085" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1563834516278_736913_20651" name="A_ownedEndFeature_endOwningType" visibility="public" memberEnd="_18_5_3_12e503d9_1563834516278_687758_20652 _18_5_3_12e503d9_1563834516279_920295_20653"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575499020769_513266_2333" name="A_inheritedFeature_inheritingType" visibility="public" memberEnd="_19_0_2_12e503d9_1575499020770_15576_2334 _19_0_2_12e503d9_1575499020770_342160_2335">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1575499020770_342160_2335" name="inheritingType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674987_297074_43308" association="_19_0_2_12e503d9_1575499020769_513266_2333">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716482640_818826_1368" annotatedElement="_19_0_2_12e503d9_1575499020770_342160_2335">
+            <body>&lt;p>A Type that has an &lt;code>inheritedMembership&lt;/code> with the &lt;code>inheritedFeature&lt;/code> as its &lt;code>memberFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575499102868_718180_2350" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575499102868_226727_2351" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575482646806_372715_439" name="A_ownedConjugator_owningType" visibility="public" memberEnd="_19_0_2_12e503d9_1575482646809_280165_440 _19_0_2_12e503d9_1575482646809_778895_441"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575482354186_812186_236" name="A_originalType_conjugation" visibility="public" memberEnd="_19_0_2_12e503d9_1575482354187_108424_237 _19_0_2_12e503d9_1575482354188_693124_238">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1575482354188_693124_238" name="conjugation" visibility="public" type="_19_0_2_12e503d9_1575482328287_696279_181" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_2_12e503d9_1575482354186_812186_236">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590438062424_329453_34" annotatedElement="_19_0_2_12e503d9_1575482354188_693124_238">
+            <body>&lt;p>The Conjugations with a certain Type as the &lt;code>originalType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575482556223_586667_377" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575482556224_97744_378" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1575482328287_696279_181" name="Conjugation" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578005810933_291709_850" annotatedElement="_19_0_2_12e503d9_1575482328287_696279_181">
+          <body>&lt;p>&lt;code>Conjugation&lt;/code> is a &lt;code>Relationship&lt;/code> between two types in which the &lt;code>conjugatedType&lt;/code> inherits all the &lt;code>Features&lt;/code> of the &lt;code>originalType&lt;/code>, but with all &lt;code>input&lt;/code> and &lt;code>output&lt;/code> &lt;code>Features&lt;/code> reversed. That is, any &lt;code>Features&lt;/code> with a &lt;code>direction&lt;/code> &lt;em>in&lt;/em> relative to the &lt;code>originalType&lt;/code> are considered to have an effective &lt;code>direction&lt;/code> of &lt;em>out&lt;/em> relative to the &lt;code>conjugatedType&lt;/code> and, similarly, &lt;code>Features&lt;/code> with &lt;code>direction&lt;/code> &lt;em>out&lt;/em> in the &lt;code>originalType&lt;/code> are considered to have an effective &lt;code>direction&lt;/code> of &lt;em>in&lt;/em> in the &lt;code>conjugatedType&lt;/code>. &lt;code>Features&lt;/code> with &lt;code>direction&lt;/code> &lt;em>inout&lt;/em>, or with no &lt;code>direction&lt;/code>, in the &lt;code>originalType&lt;/code>, are inherited without change.&lt;/p>
+
+&lt;p>A &lt;code>Type&lt;/code> may participate as a &lt;code>conjugatedType&lt;/code> in at most one &lt;code>Conjugation&lt;/code> relationship, and such a &lt;code>Type&lt;/code> may not also be the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code> in any &lt;code>Specialization&lt;/code> relationship.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_2_12e503d9_1575482453196_338646_287" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575482354187_108424_237" name="originalType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_19_0_2_12e503d9_1575482354186_812186_236">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590438260516_468717_35" annotatedElement="_19_0_2_12e503d9_1575482354187_108424_237">
+            <body>&lt;p>The &lt;code>Type&lt;/code> to be conjugated.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575482444891_942059_269" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575482444899_304429_270" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575482490143_721644_299" name="conjugatedType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" association="_19_0_2_12e503d9_1575482490143_208211_298">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590438391182_258358_36" annotatedElement="_19_0_2_12e503d9_1575482490143_721644_299">
+            <body>&lt;p>The &lt;code>Type&lt;/code> that is the result of applying &lt;code>Conjugation&lt;/code> to the &lt;code>originalType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575482519436_774901_353" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575482519437_110421_354" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575482646809_778895_441" name="owningType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1575482490143_721644_299 _18_5_3_12e503d9_1543092026091_693018_16749" association="_19_0_2_12e503d9_1575482646806_372715_439">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590438409239_451906_37" annotatedElement="_19_0_2_12e503d9_1575482646809_778895_441">
+            <body>&lt;p>The &lt;code>conjugatedType&lt;/code> of this &lt;code>Conjugation&lt;/code> that is also its &lt;code>owningRelatedElement&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575482755361_150027_534" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575482755362_263673_535" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575482490143_208211_298" name="A_conjugatedType_conjugator" visibility="public" memberEnd="_19_0_2_12e503d9_1575482490143_721644_299 _19_0_2_12e503d9_1575482490144_309557_300">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1575482490144_309557_300" name="conjugator" visibility="public" type="_19_0_2_12e503d9_1575482328287_696279_181" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227" association="_19_0_2_12e503d9_1575482490143_208211_298">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590436504885_940091_31" annotatedElement="_19_0_2_12e503d9_1575482490144_309557_300">
+            <body>&lt;p>The Conjugation corresponding to the &lt;code>conjugatedType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575482587498_891023_397" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575482587499_430896_398" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1573083797505_495205_3879" name="Multiplicity" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1573231042350_846076_1685" annotatedElement="_19_0_2_12e503d9_1573083797505_495205_3879">
+          <body>&lt;p>A &lt;code>Multiplicity&lt;/code> is a &lt;code>Feature&lt;/code> whose co-domain is a set of natural numbers giving the allowed cardinalities of each &lt;code>typeWithMultiplicity&lt;/code>. The &lt;em>cardinality&lt;/em> of a &lt;code>Type&lt;/code> is defined as follows, depending on whether the &lt;code>Type&lt;/code> is a &lt;code>Classifier&lt;/code> or &lt;code>Feature&lt;/code>.
+&lt;ul>
+&lt;li>&lt;code>Classifier&lt;/code> – The number of basic instances of the &lt;code>Classifier&lt;/code>, that is, those instances representing things, which are not instances of any subtypes of the &lt;code>Classifier&lt;/code> that are &lt;code>Features&lt;/code>.
+&lt;li>&lt;code>Features&lt;/code> – The number of instances with the same featuring instances. In the case of a &lt;code>Feature&lt;/code> with a &lt;code>Classifier&lt;/code> as its &lt;code>featuringType&lt;/code>, this is the number of values of &lt;code>Feature&lt;/code> for each basic instance of the &lt;code>Classifier&lt;/code>. Note that, for non-unique &lt;code>Features&lt;/code>, all duplicate values are included in this count.&lt;/li>
+&lt;/ul>
+
+&lt;p>&lt;code>Multiplicity&lt;/code> co-domains (in models) can be specified by &lt;code>Expression&lt;/code> that might vary in their results. If the &lt;code>typeWithMultiplicity&lt;/code> is a &lt;code>Classifier&lt;/code>, the domain of the &lt;code>Multiplicity&lt;/code> shall be &lt;em>&lt;code>Base::Anything&lt;/code>&lt;/em>.  If the &lt;code>typeWithMultiplicity&lt;/code> is a &lt;code>Feature&lt;/code>,  the &lt;code>Multiplicity&lt;/code> shall have the same domain as the &lt;code>typeWithMultiplicity&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667787624186_673883_2230" name="checkMultiplicityTypeFeaturing" visibility="public" constrainedElement="_19_0_2_12e503d9_1573083797505_495205_3879">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672521337347_143062_277" annotatedElement="_19_0_4_12e503d9_1667787624186_673883_2230">
+            <body>&lt;p>If the &lt;code>owningNamespace&lt;/code> of a &lt;code>Multiplicity&lt;/code> is a &lt;code>Feature&lt;/code>, then the &lt;code>Multiplicity&lt;/code> must have the same &lt;code>featuringTypes&lt;/code> as that &lt;code>Feature&lt;/code>. Otherwise, it must have no &lt;code>featuringTypes&lt;/code> (meaning that it is implicitly featured by the base &lt;code>Classifier&lt;/code> &lt;em>&lt;code>Anything&lt;/code>&lt;/em>).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667787624194_383758_2231" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if owningNamespace &lt;> null and owningNamespace.oclIsKindOf(Feature) then
+    featuringType = 
+        owningNamespace.oclAsType(Feature).featuringType
+else
+    featuringType->isEmpty()
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1669849165626_68370_263" name="checkMultiplicitySpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1573083797505_495205_3879">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669849190724_36975_265" annotatedElement="_19_0_4_12e503d9_1669849165626_68370_263">
+            <body>&lt;p>A &lt;code>Multiplicity&lt;/code> must directly or indirectly specialize the &lt;code>Feature&lt;/code> &lt;code>&lt;em>Base::naturals&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669849165646_441010_264" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Base::naturals')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1573095817296_586719_5343" general="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1623183201865_967078_628" name="A_disjoiningType_disjoinedTypeDisjoining" visibility="public" memberEnd="_19_0_4_b9102da_1623183201866_537160_629 _19_0_4_b9102da_1623183201866_176194_630">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1623183201866_176194_630" name="disjoinedTypeDisjoining" visibility="public" type="_19_0_4_b9102da_1623182941809_239395_557" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_4_b9102da_1623183201865_967078_628">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623185170859_485865_714" annotatedElement="_19_0_4_b9102da_1623183201866_176194_630">
+            <body>&lt;p>The Disjoinings that identify this Type as their &lt;code>disjoiningType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1627447805028_884504_449" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1623183388799_411895_664" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_b9102da_1623182941809_239395_557" name="Disjoining" visibility="public">
+        <ownedComment xmi:id="_19_0_4_b9102da_1623185435418_166544_717" annotatedElement="_19_0_4_b9102da_1623182941809_239395_557">
+          <body>&lt;p>A &lt;code>Disjoining&lt;/code> is a &lt;code>Relationship&lt;/code> between &lt;code>Types&lt;/code> asserted to have interpretations that are not shared (disjoint) between them, identified as &lt;code>typeDisjoined&lt;/code> and &lt;code>disjoiningType&lt;/code>. For example, a &lt;code>Classifier&lt;/code> for mammals is disjoint from a &lt;code>Classifier&lt;/code> for minerals, and a &lt;code>Feature&lt;/code> for people&amp;#39;s parents is disjoint from a &lt;code>Feature&lt;/code> for their children.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_b9102da_1623183111011_555030_606" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1623183194914_955906_617" name="typeDisjoined" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" association="_19_0_4_b9102da_1623183194914_466953_615">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623185818399_14967_720" annotatedElement="_19_0_4_b9102da_1623183194914_955906_617">
+            <body>&lt;p>&lt;code>Type&lt;/code> asserted to be disjoint with the &lt;code>disjoiningType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1623183212215_585800_641" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1623183212216_127372_642" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1623183201866_537160_629" name="disjoiningType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_19_0_4_b9102da_1623183201865_967078_628">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623185911042_119641_721" annotatedElement="_19_0_4_b9102da_1623183201866_537160_629">
+            <body>&lt;p>&lt;code>Type&lt;/code> asserted to be disjoint with the &lt;code>typeDisjoined&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1623183209584_153663_637" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1623183209584_459096_638" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1627447519614_499771_371" name="owningType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543092026091_693018_16749 _19_0_4_b9102da_1623183194914_955906_617" association="_19_0_4_12e503d9_1627447519611_807661_369">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1630355043335_139171_20194" annotatedElement="_19_0_4_12e503d9_1627447519614_499771_371">
+            <body>&lt;p>A &lt;code>typeDisjoined&lt;/code> that is also an &lt;code>owningRelatedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1627447646764_486768_396" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1627447646765_214426_397" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1623952188841_993417_37168" name="A_directedFeature_typeWithDirectedFeature" visibility="public" memberEnd="_19_0_4_12e503d9_1623952188842_882068_37169 _19_0_4_12e503d9_1623952188842_831269_37170">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1623952188842_831269_37170" name="typeWithDirectedFeature" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674987_297074_43308" association="_19_0_4_12e503d9_1623952188841_993417_37168">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1623953193820_755023_37189" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1623953193827_77805_37190" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1623183194914_466953_615" name="A_disjoiningTypeDisjoining_typeDisjoined" visibility="public" memberEnd="_19_0_4_b9102da_1623183194914_502526_616 _19_0_4_b9102da_1623183194914_955906_617">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1623183194914_502526_616" name="disjoiningTypeDisjoining" visibility="public" type="_19_0_4_b9102da_1623182941809_239395_557" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227" association="_19_0_4_b9102da_1623183194914_466953_615">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623185142014_463554_713" annotatedElement="_19_0_4_b9102da_1623183194914_502526_616">
+            <body>&lt;p>The Disjoinings that identify this Type as their &lt;code>typeDisjoined&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1627447802091_630557_444" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1623183383296_717032_660" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1627447519611_807661_369" name="A_ownedDisjoining_owningType" visibility="public" memberEnd="_19_0_4_12e503d9_1627447519613_145554_370 _19_0_4_12e503d9_1627447519614_499771_371"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1651076866500_370361_484" name="A_featureMembership_type" visibility="public" memberEnd="_19_0_4_12e503d9_1651076866512_962346_485 _19_0_4_12e503d9_1651076866524_738482_486">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1651076866524_738482_486" name="type" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" association="_19_0_4_12e503d9_1651076866500_370361_484">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651078547249_858437_605" annotatedElement="_19_0_4_12e503d9_1651076866524_738482_486">
+            <body>&lt;p>A Type that owns or inherits the &lt;code>featureMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1651076928514_792757_499" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1651076928543_297416_500" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1661871173117_168827_808" name="A_differencingType_differencedDifferencing" visibility="public" memberEnd="_19_0_4_b9102da_1661871173117_978241_809 _19_0_4_b9102da_1661871173118_259564_810">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1661871173118_259564_810" name="differencedDifferencing" visibility="public" type="_19_0_4_b9102da_1661870994364_119372_712" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_4_b9102da_1661871173117_168827_808">
+          <ownedComment xmi:id="_19_0_4_b9102da_1661884638825_695177_1017" annotatedElement="_19_0_4_b9102da_1661871173118_259564_810">
+            <body>&lt;p>The Differencings that identify this Type as their &lt;code>differencingType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1661871224260_790435_846" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1661871224260_651790_847" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1661974896766_916994_1230" name="A_unioningType_unionedType" visibility="public" memberEnd="_19_0_4_b9102da_1661974896766_783268_1231 _19_0_4_b9102da_1661974896766_972718_1232">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1661974896766_972718_1232" name="unionedType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" association="_19_0_4_b9102da_1661974896766_916994_1230">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662061784508_948253_1422" annotatedElement="_19_0_4_b9102da_1661974896766_972718_1232">
+            <body>&lt;p>The Types that include this one among their &lt;code>unioningTypes&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662571347045_509451_3595" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662571347053_678587_3596" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1661869982082_181533_471" name="A_unioningType_unionedUnioning" visibility="public" memberEnd="_19_0_4_b9102da_1661869982082_280210_472 _19_0_4_b9102da_1661869982082_488511_473">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1661869982082_488511_473" name="unionedUnioning" visibility="public" type="_19_0_4_b9102da_1661869922775_190651_380" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_4_b9102da_1661869982082_181533_471">
+          <ownedComment xmi:id="_19_0_4_b9102da_1661884230942_385383_996" annotatedElement="_19_0_4_b9102da_1661869982082_488511_473">
+            <body>&lt;p>The Unionings that identify all these Types as their &lt;code>unioningType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1661870367854_692671_536" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1661870367854_723000_537" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1661973922199_110027_1044" name="A_intersectingType_intersectedType" visibility="public" memberEnd="_19_0_4_b9102da_1661973922199_584242_1045 _19_0_4_b9102da_1661973922200_334858_1046">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1661973922200_334858_1046" name="intersectedType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" association="_19_0_4_b9102da_1661973922199_110027_1044">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662062611453_99670_1436" annotatedElement="_19_0_4_b9102da_1661973922200_334858_1046">
+            <body>&lt;p>The Types that include this one among their &lt;code>intersectingTypes&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662571430304_945750_3637" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662571430322_416772_3638" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1661869978504_483445_458" name="A_typeUnioned_ownedUnioning" visibility="public" memberEnd="_19_0_4_b9102da_1661869978504_423347_459 _19_0_4_b9102da_1661869978505_968809_460"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1661975883472_321005_1371" name="A_differencingType_differencedType" visibility="public" memberEnd="_19_0_4_b9102da_1661975883472_645501_1372 _19_0_4_b9102da_1661975883472_557357_1373">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1661975883472_557357_1373" name="differencedType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" association="_19_0_4_b9102da_1661975883472_321005_1371">
+          <ownedComment xmi:id="_19_0_4_b9102da_1662063486591_81729_1446" annotatedElement="_19_0_4_b9102da_1661975883472_557357_1373">
+            <body>&lt;p>The Types that include this one among their &lt;code>differencingTypes&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662571388897_617607_3605" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662571388907_5429_3606" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_b9102da_1661870994364_119372_712" name="Differencing" visibility="public">
+        <ownedComment xmi:id="_19_0_4_b9102da_1661884581978_350551_1012" annotatedElement="_19_0_4_b9102da_1661870994364_119372_712">
+          <body>&lt;p>&lt;code>Differencing&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its &lt;code>differencingType&lt;/code> one of the &lt;code>differencingTypes&lt;/code> of its &lt;code>typeDifferenced&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_b9102da_1661871019584_738867_737" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1661871168453_175911_796" name="typeDifferenced" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" subsettedProperty="_18_5_3_12e503d9_1543092026091_693018_16749" association="_19_0_4_b9102da_1661871168453_838914_795">
+          <ownedComment xmi:id="_19_0_4_b9102da_1661884607373_171252_1013" annotatedElement="_19_0_4_b9102da_1661871168453_175911_796">
+            <body>&lt;p>&lt;code>Type&lt;/code> with interpretations partly determined by &lt;code>differencingType&lt;/code>, as described in &lt;code>Type::differencingType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662572149608_854529_3751" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662572149615_253087_3752" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1661871173117_978241_809" name="differencingType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_19_0_4_b9102da_1661871173117_168827_808">
+          <ownedComment xmi:id="_19_0_4_b9102da_1661884613246_532966_1014" annotatedElement="_19_0_4_b9102da_1661871173117_978241_809">
+            <body>&lt;p>&lt;code>Type&lt;/code> that partly determines interpretations of &lt;code>typeDifferenced&lt;/code>, as described in &lt;code>Type::differencingType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1661871205348_997746_834" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1661871205348_179460_835" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1661871168453_838914_795" name="A_typeDifferenced_ownedDifferencing" visibility="public" memberEnd="_19_0_4_b9102da_1661871168453_175911_796 _19_0_4_b9102da_1661871168454_98082_797"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1623242559520_62665_536" name="A_intersectingType_intersectedIntersecting" visibility="public" memberEnd="_19_0_4_b9102da_1623242559520_591868_537 _19_0_4_b9102da_1623242559521_980623_538">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1623242559521_980623_538" name="intersectedIntersecting" visibility="public" type="_19_0_4_b9102da_1623187351831_706169_90" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_4_b9102da_1623242559520_62665_536">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623250707556_836190_672" annotatedElement="_19_0_4_b9102da_1623242559521_980623_538">
+            <body>&lt;p>The Intersectings that identify this Type as their &lt;code>intersectingType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1661869482013_511565_217" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1623242591006_109434_558" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_b9102da_1661869922775_190651_380" name="Unioning" visibility="public">
+        <ownedComment xmi:id="_19_0_4_b9102da_1661884035263_43381_989" annotatedElement="_19_0_4_b9102da_1661869922775_190651_380">
+          <body>&lt;p>&lt;code>Unioning&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its &lt;code>unioningType&lt;/code> one of the &lt;code>unioningTypes&lt;/code> of its &lt;code>typeUnioned&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_b9102da_1661869930215_816844_405" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1661869978504_423347_459" name="typeUnioned" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" subsettedProperty="_18_5_3_12e503d9_1543092026091_693018_16749" association="_19_0_4_b9102da_1661869978504_483445_458">
+          <ownedComment xmi:id="_19_0_4_b9102da_1661884047812_215693_992" annotatedElement="_19_0_4_b9102da_1661869978504_423347_459">
+            <body>&lt;p>&lt;code>Type&lt;/code> with interpretations partly determined by &lt;code>unioningType&lt;/code>, as described in &lt;code>Type::unioningType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662572119675_259868_3729" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662572119681_119591_3730" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1661869982082_280210_472" name="unioningType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_19_0_4_b9102da_1661869982082_181533_471">
+          <ownedComment xmi:id="_19_0_4_b9102da_1661884052918_980611_993" annotatedElement="_19_0_4_b9102da_1661869982082_280210_472">
+            <body>&lt;p>&lt;code>Type&lt;/code> that partly determines interpretations of &lt;code>typeUnioned&lt;/code>, as described in &lt;code>Type::unioningType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1661870354517_352936_528" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1661870354517_663483_529" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1623242552144_490822_523" name="A_ownedIntersecting_typeIntersected" visibility="public" memberEnd="_19_0_4_b9102da_1623242552144_910757_524 _19_0_4_b9102da_1623242552145_149730_525"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_b9102da_1623187351831_706169_90" name="Intersecting" visibility="public">
+        <ownedComment xmi:id="_19_0_4_b9102da_1623250689132_377181_670" annotatedElement="_19_0_4_b9102da_1623187351831_706169_90">
+          <body>&lt;p>&lt;code>Intersecting&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its &lt;code>intersectingType&lt;/code> one of the &lt;code>intersectingTypes&lt;/code> of its &lt;code>typeIntersected&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_b9102da_1661868956183_363082_54" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1623242552145_149730_525" name="typeIntersected" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" subsettedProperty="_18_5_3_12e503d9_1543092026091_693018_16749" association="_19_0_4_b9102da_1623242552144_490822_523">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623250402717_847242_666" annotatedElement="_19_0_4_b9102da_1623242552145_149730_525">
+            <body>&lt;p>&lt;code>Type&lt;/code> with interpretations partly determined by &lt;code>intersectingType&lt;/code>, as described in &lt;code>Type::intersectingType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1662572081229_548242_3675" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1662572081231_851861_3676" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1623242559520_591868_537" name="intersectingType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_19_0_4_b9102da_1623242559520_62665_536">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623250573947_96256_667" annotatedElement="_19_0_4_b9102da_1623242559520_591868_537">
+            <body>&lt;p>&lt;code>Type&lt;/code> that partly determines interpretations of &lt;code>typeIntersected&lt;/code>, as described in &lt;code>Type::intersectingType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1623242571774_15840_549" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1623242571774_443163_550" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1561109154308_486424_22742" name="Classifiers" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543189084042_937087_25406" name="A_subclassifier_subclassification" visibility="public" memberEnd="_18_5_3_12e503d9_1543189084042_772698_25407 _18_5_3_12e503d9_1543189084042_435794_25408">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1543189084042_435794_25408" name="subclassification" visibility="public" type="_18_5_3_12e503d9_1543188778639_872842_24973" subsettedProperty="_18_5_3_12e503d9_1533160674984_558067_43292" association="_18_5_3_12e503d9_1543189084042_937087_25406">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590946767366_539057_61" annotatedElement="_18_5_3_12e503d9_1543189084042_435794_25408">
+            <body>&lt;p>The Subclassifications with a certain &lt;code>subclassifier&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543189138175_955745_25481" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543189138175_791207_25482" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543189170642_287417_25505" name="A_owningClassifier_ownedSubclassification" visibility="public" memberEnd="_18_5_3_12e503d9_1543189170642_857401_25506 _18_5_3_12e503d9_1543189170643_419862_25507"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1543188778639_872842_24973" name="Subclassification" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1570563047664_764753_9476" annotatedElement="_18_5_3_12e503d9_1543188778639_872842_24973">
+          <body>&lt;p>&lt;code>Subclassification&lt;/code> is &lt;code>Specialization&lt;/code> in which both the &lt;code>specific&lt;/code> and &lt;code>general&lt;/code> &lt;code>Types&lt;/code> are &lt;code>Classifier&lt;/code>. This means all instances of the specific &lt;code>Classifier&lt;/code> are also instances of the general &lt;code>Classifier&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_18_5_3_12e503d9_1543188807609_970428_25017" general="_18_5_3_12e503d9_1533160651696_992729_42182"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543188934635_627507_25283" name="superclassifier" visibility="public" type="_18_5_3_12e503d9_1533160651676_375105_42143" redefinedProperty="_18_5_3_12e503d9_1533160674980_563969_43273" association="_18_5_3_12e503d9_1543188934635_488592_25282">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590946692024_268612_59" annotatedElement="_18_5_3_12e503d9_1543188934635_627507_25283">
+            <body>&lt;p>The more &lt;code>general&lt;/code> Classifier in this &lt;code>Subclassification&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543189061398_831263_25384" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543189061398_737594_25385" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543189084042_772698_25407" name="subclassifier" visibility="public" type="_18_5_3_12e503d9_1533160651676_375105_42143" redefinedProperty="_18_5_3_12e503d9_1533160674982_253967_43281" association="_18_5_3_12e503d9_1543189084042_937087_25406">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590946686145_646909_58" annotatedElement="_18_5_3_12e503d9_1543189084042_772698_25407">
+            <body>&lt;p>The more specific &lt;code>Classifier&lt;/code> in this &lt;code>Subclassification&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543189107768_336354_25449" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543189107768_97289_25450" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543189170642_857401_25506" name="owningClassifier" visibility="public" type="_18_5_3_12e503d9_1533160651676_375105_42143" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_573157_43226" association="_18_5_3_12e503d9_1543189170642_287417_25505">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590946864175_47605_63" annotatedElement="_18_5_3_12e503d9_1543189170642_857401_25506">
+            <body>&lt;p>The &lt;code>Classifier&lt;/code> that owns this &lt;code>Subclassification&lt;/code> relationship, which must also be its &lt;code>subclassifier&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543189363011_901068_25628" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543189363011_435768_25629" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651676_375105_42143" name="Classifier" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1570563047667_809668_9480" annotatedElement="_18_5_3_12e503d9_1533160651676_375105_42143">
+          <body>&lt;p>A &lt;code>Classifier&lt;/code> is a &lt;code>Type&lt;/code> that classifies:&lt;/p>
+
+&lt;ul>
+	&lt;li>Things (in the universe) regardless of how &lt;code>Features&lt;/code> relate them. (These are interpreted semantically as sequences of exactly one thing.)&lt;/li>
+	&lt;li>How the above things are related by &lt;code>Features.&lt;/code> (These are interpreted semantically as sequences of multiple things, such that the last thing in the sequence is also classified by the &lt;code>Classifier&lt;/code>. Note that this means that a &lt;code>Classifier&lt;/code> modeled as specializing a &lt;code>Feature&lt;/code> cannot classify anything.)&lt;/li>
+&lt;/ul>
+
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543189853023_966589_25747" name="deriveClassifierOwnedSubclassification" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651676_375105_42143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676479251035_406095_12" annotatedElement="_18_5_3_12e503d9_1543189853023_966589_25747">
+            <body>&lt;p>The &lt;code>ownedSubclassifications&lt;/code> of a &lt;code>Classifier&lt;/code> are its &lt;code>ownedSpecializations&lt;/code> that are &lt;code>Subclassifications&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543189853023_177236_25748" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedSubclassification = 
+    ownedSpecialization->selectByKind(Subclassification)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1604527289611_489451_464" name="validateClassifierMultiplicityDomain" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651676_375105_42143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604527430977_342300_466" annotatedElement="_19_0_4_12e503d9_1604527289611_489451_464">
+            <body>&lt;p>If a &lt;code>Classifier&lt;/code> has a &lt;code>multiplicity&lt;/code>, then the &lt;code>multiplicity&lt;/code> must have no &lt;code>featuringTypes&lt;/code> (meaning that its domain is implicitly &lt;em>Base::Anything&lt;/em>).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1604527289613_399185_465" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>multiplicity &lt;> null implies multiplicity.featuringType->isEmpty()</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674959_767992_43163" general="_18_5_3_71301a1_1537895141427_270492_15579"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543189170643_419862_25507" name="ownedSubclassification" visibility="public" type="_18_5_3_12e503d9_1543188778639_872842_24973" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674959_579676_43168" association="_18_5_3_12e503d9_1543189170642_287417_25505">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590946848251_122595_62" annotatedElement="_18_5_3_12e503d9_1543189170643_419862_25507">
+            <body>&lt;p>The &lt;code>ownedSpecializations&lt;/code> of this &lt;code>Classifier&lt;/code> that are &lt;code>Subclassifications&lt;/code>, for which this &lt;code>Classifier&lt;/code> is the &lt;code>subclassifier&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543189219404_110430_25548" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543189219404_431465_25549" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543188934635_488592_25282" name="A_superclassifier_superclassification" visibility="public" memberEnd="_18_5_3_12e503d9_1543188934635_627507_25283 _18_5_3_12e503d9_1543188934635_516142_25284">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1543188934635_516142_25284" name="superclassification" visibility="public" type="_18_5_3_12e503d9_1543188778639_872842_24973" subsettedProperty="_18_5_3_12e503d9_1533160674980_42445_43272" association="_18_5_3_12e503d9_1543188934635_488592_25282">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590946742296_198269_60" annotatedElement="_18_5_3_12e503d9_1543188934635_516142_25284">
+            <body>&lt;p>The Subclassifications with a certain &lt;code>superclassifier&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543189010657_408219_25356" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543189010657_156891_25357" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1561108949391_787902_22671" name="Features" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651690_251835_42168" name="Redefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578007689401_518304_873" annotatedElement="_18_5_3_12e503d9_1533160651690_251835_42168">
+          <body>&lt;p>&lt;code>Redefinition&lt;/code> is a kind of &lt;code>Subsetting&lt;/code> that requires the &lt;code>redefinedFeature&lt;/code> and the &lt;code>redefiningFeature&lt;/code> to have the same values (on each instance of the domain of the &lt;code>redefiningFeature&lt;/code>). This means any restrictions on the &lt;code>redefiningFeature&lt;/code>, such as &lt;code>type&lt;/code> or &lt;code>multiplicity&lt;/code>, also apply to the &lt;code>redefinedFeature&lt;/code> (on each instance of the domain of the &lt;code>redefiningFeature&lt;/code>), and vice versa. The &lt;code>redefinedFeature&lt;/code> might have values for instances of the domain of the &lt;code>redefiningFeature&lt;/code>, but only as instances of the domain of the &lt;code>redefinedFeature&lt;/code> that happen to also be instances of the domain of the &lt;code>redefiningFeature&lt;/code>. This is supported by the constraints inherited from &lt;code>Subsetting&lt;/code> on the domains of the &lt;code>redefiningFeature&lt;/code> and &lt;code>redefinedFeature&lt;/code>. However, these constraints are narrowed for &lt;code>Redefinition&lt;/code> to require the &lt;code>owningTypes&lt;/code> of the &lt;code>redefiningFeature&lt;/code> and &lt;code>redefinedFeature&lt;/code> to be different and the &lt;code>redefinedFeature&lt;/code> to not be inherited into the &lt;code>owningNamespace&lt;/code> of the &lt;code>redefiningFeature&lt;/code>.This enables the &lt;code>redefiningFeature&lt;/code> to have the same name as the &lt;code>redefinedFeature&lt;/code>, if desired.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676760023046_128972_9" name="validateRedefinitionFeaturingTypes" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651690_251835_42168">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676760178080_678029_11" annotatedElement="_19_0_4_12e503d9_1676760023046_128972_9">
+            <body>&lt;p>The &lt;code>redefiningFeature&lt;/code> of a &lt;code>Redefinition&lt;/code> must have at least one &lt;code>featuringType&lt;/code> that is not also a &lt;code>featuringType&lt;/code> of the &lt;code>redefinedFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676760023060_786385_10" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let anythingType: Type =
+    redefiningFeature.resolveGlobal('Base::Anything').modelElement.oclAsType(Type) in 
+-- Including &quot;Anything&quot; accounts for implicit featuringType of Features
+-- with no explicit featuringType.
+let redefiningFeaturingTypes: Set(Type) =
+    if redefiningFeature.isVariable then Set{redefiningFeature.owningType}
+    else redefiningFeature.featuringTypes->asSet()->including(anythingType) 
+    endif in
+let redefinedFeaturingTypes: Set(Type) =
+    if redefinedFeature.isVariable then Set{redefinedFeature.owningType}
+    else redefinedFeature.featuringTypes->asSet()->including(anythingType)
+    endif in
+redefiningFeaturingTypes &lt;> redefinedFeaturingType</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695244482489_896411_141" name="validateRedefinitionDirectionConformance" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651690_251835_42168">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695244594322_338692_143" annotatedElement="_19_0_4_12e503d9_1695244482489_896411_141">
+            <body>&lt;p>If the &lt;code>redefinedFeature&lt;/code> of a &lt;code>Redefinition&lt;/code> has a direction of &lt;code>in&lt;/code> or &lt;code>out&lt;/code> (relative to any &lt;code>featuringType&lt;/code> of the &lt;code>redefiningFeature&lt;/code> or the &lt;code>owningType&lt;/code>, if the &lt;code>redefiningFeature&lt;/code> has &lt;code>isVariable = true&lt;/code>), then the &lt;code>redefiningFeature&lt;/code> must have the same &lt;code>direction&lt;/code>. If the &lt;code>redefinedFeature&lt;/code> has a direction of &lt;code>inout&lt;/code>, then the &lt;code>redefiningFeature&lt;/code> must have a non-null &lt;code>direction&lt;/code>. (Note: the direction of the &lt;code>redefinedFeature&lt;/code> relative to a &lt;code>featuringType&lt;/code> of the &lt;code>redefiningFeature&lt;/code> is the direction it would have if it had been inherited and not redefined.)&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695244482519_342035_142" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let featuringTypes : Sequence(Type) =
+    if redefiningFeature.isVariable then Sequence{redefiningFeature.owningType}
+    else redefiningFeature.featuringType
+    endif in
+featuringTypes->forAll(t |
+    let direction : FeatureDirectionKind = t.directionOf(redefinedFeature) in
+    ((direction = FeatureDirectionKind::_'in' or 
+      direction = FeatureDirectionKind::out) implies
+         redefiningFeature.direction = direction)
+    and 
+    (direction = FeatureDirectionKind::inout implies
+        redefiningFeature.direction &lt;> null))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740200857783_345036_1324" name="validateRedefinitionEndConformance" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651690_251835_42168">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740200920121_818447_1326" annotatedElement="_2022x_2_12e503d9_1740200857783_345036_1324">
+            <body>&lt;p>If the redefinedFeature of a Redefinition has isEnd = true, then the redefiningFeature must have isEnd = true.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740200857786_322853_1325" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>redefinedFeature.isEnd implies redefiningFeature.isEnd</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674973_792005_43244" general="_18_5_3_12e503d9_1533160651710_980688_42209"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674958_414216_43160" name="redefiningFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674967_140305_43206" association="_18_5_3_12e503d9_1533160651675_261056_42142">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947288255_601855_124" annotatedElement="_18_5_3_12e503d9_1533160674958_414216_43160">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is redefining the &lt;code>redefinedFeature&lt;/code> of this &lt;code>Redefinition&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678356_507925_43924" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678356_534998_43923" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674973_199798_43245" name="redefinedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674961_393191_43181" association="_18_5_3_12e503d9_1533160651694_581596_42175">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947275903_681663_123" annotatedElement="_18_5_3_12e503d9_1533160674973_199798_43245">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is redefined by the &lt;code>redefiningFeature&lt;/code> of this &lt;code>Redefinition&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678371_126163_44033" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678371_550108_44032" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543180520184_318941_21130" name="A_type_typingByType" visibility="public" memberEnd="_18_5_3_12e503d9_1543180520185_480887_21131 _18_5_3_12e503d9_1543180520185_90900_21132">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1543180520185_90900_21132" name="typingByType" visibility="public" type="_18_5_3_12e503d9_1543180339807_437641_20928" subsettedProperty="_18_5_3_12e503d9_1533160674980_42445_43272" association="_18_5_3_12e503d9_1543180520184_318941_21130">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590948260682_792600_156" annotatedElement="_18_5_3_12e503d9_1543180520185_90900_21132">
+            <body>&lt;p>The FeatureTyping relating this Type to a Feature.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543182006041_196848_22166" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543182006041_36517_22167" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651689_153588_42166" name="A_typedFeature_type" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674973_102139_43242 _18_5_3_12e503d9_1533160674969_376003_43216">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674973_102139_43242" name="typedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" association="_18_5_3_12e503d9_1533160651689_153588_42166">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590948297416_324150_157" annotatedElement="_18_5_3_12e503d9_1533160674973_102139_43242">
+            <body>&lt;p>The Features for which a certain Type is a &lt;code>type&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678370_849139_44029" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678370_579699_44028" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543180501615_77733_21099" name="A_typing_typedFeature" visibility="public" memberEnd="_18_5_3_12e503d9_1543180501615_804591_21100 _18_5_3_12e503d9_1543180501615_13273_21101">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1543180501615_804591_21100" name="typing" type="_18_5_3_12e503d9_1543180339807_437641_20928" subsettedProperty="_18_5_3_12e503d9_1533160674984_558067_43292" association="_18_5_3_12e503d9_1543180501615_77733_21099">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590948240008_107809_155" annotatedElement="_18_5_3_12e503d9_1543180501615_804591_21100">
+            <body>&lt;p>The FeatureTypings for which a certain Feature is the &lt;code>typedFeature&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1544197822349_517766_21166" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1544197822349_267783_21167" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651690_504107_42169" name="A_ownedRedefinition_owningFeature" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674970_161813_43220 _18_5_3_12e503d9_1533160674974_101491_43246">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674974_101491_43246" name="owningFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674987_236250_43311" association="_18_5_3_12e503d9_1533160651690_504107_42169">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947316929_434488_127" annotatedElement="_18_5_3_12e503d9_1533160674974_101491_43246">
+            <body>&lt;p>The Feature that owns this Redefinition relationship, which must also be its &lt;code>redefiningFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678371_229697_44035" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678371_331267_44034" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651694_581596_42175" name="A_redefinedFeature_redefining" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674973_199798_43245 _18_5_3_12e503d9_1533160674977_384541_43258">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674977_384541_43258" name="redefining" visibility="public" type="_18_5_3_12e503d9_1533160651690_251835_42168" subsettedProperty="_18_5_3_12e503d9_1533160674961_265412_43180" association="_18_5_3_12e503d9_1533160651694_581596_42175">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947540984_62994_137" annotatedElement="_18_5_3_12e503d9_1533160674977_384541_43258">
+            <body>&lt;p>The Redefinitions with a certain Feature as the &lt;code>redefinedFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678373_779052_44045" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678373_185813_44044" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651683_439767_42157" name="A_subsettingFeature_subsetting" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674967_140305_43206 _18_5_3_12e503d9_1533160674966_718145_43205">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674966_718145_43205" name="subsetting" visibility="public" type="_18_5_3_12e503d9_1533160651710_980688_42209" subsettedProperty="_18_5_3_12e503d9_1533160674984_558067_43292" association="_18_5_3_12e503d9_1533160651683_439767_42157">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947390664_621075_131" annotatedElement="_18_5_3_12e503d9_1533160674966_718145_43205">
+            <body>&lt;p>The Subsettings with a certain Feature as the &lt;code>subsettingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678364_244651_43987" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678364_92635_43986" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651684_893483_42160" name="Feature" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1570563047657_999962_9474" annotatedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <body>&lt;p>A &lt;code>Feature&lt;/code> is a &lt;code>Type&lt;/code> that classifies relations between multiple things (in the universe). The domain of the relation is the intersection of the &lt;code>featuringTypes&lt;/code> of the &lt;code>Feature&lt;/code>. (The domain of a &lt;code>Feature&lt;/code> with no &lt;code>featuringTyps&lt;/code> is implicitly the most general &lt;code>Type&lt;/code> &lt;em>&lt;code>Base::Anything&lt;/code>&lt;/em> from the Kernel Semantic Library.) The co-domain of the relation is the intersection of the &lt;code>types&lt;/code> of the &lt;code>Feature&lt;/code>.
+
+&lt;p>In the simplest cases, the &lt;code>featuringTypes&lt;/code> and &lt;code>types&lt;/code> are &lt;code>Classifiers&lt;/code> and the &lt;code>Feature&lt;/code> relates two things, one from the domain and one from the range. Examples include cars paired with wheels, people paired with other people, and cars paired with numbers representing the car length.&lt;/p>
+
+&lt;p>Since &lt;code>Features&lt;/code> are &lt;code>Types&lt;/code>, their &lt;code>featuringTypes&lt;/code> and &lt;code>types&lt;/code> can be &lt;code>Features&lt;/code>. In this case, the &lt;code>Feature&lt;/code> effectively classifies relations between relations, which can be interpreted as the sequence of things related by the domain &lt;code>Feature&lt;/code> concatenated with the sequence of things related by the co-domain &lt;code>Feature&lt;/code>.&lt;/p>
+
+&lt;p>The &lt;em>values&lt;/em> of a &lt;code>Feature&lt;/code> for a given instance of its domain are all the instances of its co-domain that are related to that domain instance by the &lt;code>Feature&lt;/code>. The values of a &lt;code>Feature&lt;/code> with &lt;code>chainingFeatures&lt;/code> are the same as values of the last &lt;code>Feature&lt;/code> in the chain, which can be found by starting with values of the first &lt;code>Feature&lt;/code>, then using those values as domain instances to obtain valus of the second &lt;code>Feature&lt;/code>, and so on, to values of the last &lt;code>Feature&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543190482925_385200_25975" name="deriveFeatureOwnedRedefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676482059007_515859_45" annotatedElement="_18_5_3_12e503d9_1543190482925_385200_25975">
+            <body>&lt;p>The &lt;code>ownedRedefinitions&lt;/code> of a &lt;code>Feature&lt;/code> are its &lt;code>ownedSubsettings&lt;/code> that are &lt;code>Redefinitions&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543190482925_817999_25976" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedRedefinition = ownedSubsetting->selectByKind(Redefinition)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543184759109_452140_23552" name="deriveFeatureOwnedTypeFeaturing" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676483176284_740790_49" annotatedElement="_18_5_3_12e503d9_1543184759109_452140_23552">
+            <body>&lt;p>The &lt;code>ownedTypeFeaturings&lt;/code> of a &lt;code>Feature&lt;/code> are its &lt;code>ownedRelationships&lt;/code> that are &lt;code>TypeFeaturings&lt;/code> and which have the &lt;code>Feature&lt;/code> as their &lt;code>featureOfType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543184759110_222083_23553" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedTypeFeaturing = ownedRelationship->selectByKind(TypeFeaturing)->
+    select(tf | tf.featureOfType = self)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543190291310_799399_25962" name="deriveFeatureOwnedSubsetting" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676482107369_57448_46" annotatedElement="_18_5_3_12e503d9_1543190291310_799399_25962">
+            <body>&lt;p>The &lt;code>ownedSubsettings&lt;/code> of a &lt;code>Feature&lt;/code> are its &lt;code>ownedSpecializations&lt;/code> that are &lt;code>Subsettings&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543190291310_43224_25963" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedSubsetting = ownedSpecialization->selectByKind(Subsetting)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543184488522_996718_23537" name="deriveFeatureOwnedTyping" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676483208659_625992_50" annotatedElement="_18_5_3_12e503d9_1543184488522_996718_23537">
+            <body>&lt;p>The &lt;code>ownedTypings&lt;/code> of a &lt;code>Feature&lt;/code> are its &lt;code>ownedSpecializations&lt;/code> that are &lt;code>FeatureTypings&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543184488523_800440_23538" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedTyping = ownedGeneralization->selectByKind(FeatureTyping)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543184327159_137422_23528" name="deriveFeatureType" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1623452586925_796852_4354" annotatedElement="_18_5_3_12e503d9_1543184327159_137422_23528">
+            <body>&lt;p>The &lt;code>types&lt;/code> of a &lt;code>Feature&lt;/code> are the union of the &lt;code>types&lt;/code> of its &lt;code>typings&lt;/code> and the &lt;code>types&lt;/code> of the &lt;code>Features&lt;/code> it subsets, with all redundant supertypes removed. If the &lt;code>Feature&lt;/code> has &lt;code>chainingFeatures&lt;/code>, then the union also includes the types of the last &lt;code>chainingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543184327159_650486_23529" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>type = 
+    let types : OrderedSet(Types) = OrderedSet{self}->
+        -- Note: The closure operation automatically handles circular relationships.
+        closure(typingFeatures()).typing.type->asOrderedSet() in
+    types->reject(t1 | types->exist(t2 | t2 &lt;> t1 and t2.specializes(t1)))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1604527452810_809924_469" name="validateFeatureMultiplicityDomain" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604527709864_345885_471" annotatedElement="_19_0_4_12e503d9_1604527452810_809924_469">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has a &lt;code>multiplicity&lt;/code>, then the &lt;code>featuringTypes&lt;/code> of the &lt;code>multiplicity&lt;/code> must be the same as those of the &lt;code>Feature&lt;/code> itself.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1604527452817_408497_470" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>multiplicity &lt;> null implies multiplicity.featuringType = featuringType </body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1610037589481_100442_1236" name="checkFeatureSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1623452618681_48775_4355" annotatedElement="_19_0_4_b9102da_1610037589481_100442_1236">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> must directly or indirectly specialize &lt;code>&lt;em>Base::things&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1610037589482_878511_1237" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Base::things')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1622131287999_478724_292" name="validateFeatureChainingFeaturesNotSelf" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1623452116797_303482_4353" annotatedElement="_19_0_4_b9102da_1622131287999_478724_292">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> cannot be one of its own &lt;code>chainingFeatures&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1622131288000_498151_293" name="" visibility="public">
+            <language>English</language>
+            <body>chainingFeature->excludes(self)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1623418658402_178499_103" name="deriveFeatureOwnedFeatureChaining" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1623451843382_106274_4351" annotatedElement="_19_0_4_b9102da_1623418658402_178499_103">
+            <body>&lt;p>The &lt;code>ownedFeatureChainings&lt;/code> of a &lt;code>Feature&lt;/code> are the &lt;code>ownedRelationships&lt;/code> that are &lt;code>FeatureChainings&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1623418658403_662213_104" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedFeatureChaining = ownedRelationship->selectByKind(FeatureChaining)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1622130582704_279006_286" name="deriveFeatureChainingFeature" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1623452037641_607364_4352" annotatedElement="_19_0_4_b9102da_1622130582704_279006_286">
+            <body>&lt;p>The &lt;code>chainingFeatures&lt;/code> of a &lt;code>Feature&lt;/code> are the &lt;code>chainingFeatures&lt;/code> of its &lt;code>ownedFeatureChainings&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1622130582705_29322_287" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>chainingFeature = ownedFeatureChaining.chainingFeature</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1635435276365_449067_449" name="validateFeatureChainingFeatureNotOne" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1691615920174_282914_37" annotatedElement="_19_0_4_b9102da_1635435276365_449067_449">
+            <body>A &lt;code>Feature&lt;/code> must have either no &lt;code>chainingFeatures&lt;/code> or more than one.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1635435276367_870168_450" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>chainingFeature->size() &lt;> 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772027185_490268_2163" name="checkFeatureEndRedefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671149028371_540990_101315" annotatedElement="_19_0_4_12e503d9_1667772027185_490268_2163">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has &lt;code>isEnd = true&lt;/code> and an &lt;code>owningType&lt;/code> that is not empty, then, for each direct supertype of its &lt;code>owningType&lt;/code>, it must redefine the &lt;code>endFeature&lt;/code> at the same position, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772027192_194798_2164" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isEnd and owningType &lt;> null implies
+    let i : Integer = 
+        owningType.ownedEndFeature->indexOf(self) in
+    owningType.ownedSpecialization.general->
+        forAll(supertype |
+             supertype.endFeature->size() >= i implies
+                redefines(supertype.endFeature->at(i))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772232605_999996_2173" name="checkFeatureValuationSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671165922566_550743_101328" annotatedElement="_19_0_4_12e503d9_1667772232605_999996_2173">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has a &lt;code>FeatureValue&lt;/code>, no &lt;code>ownedSpecializations&lt;/code> that are not implied, and is not directed, then it must specialize the &lt;code>result&lt;/code> of the &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> of the &lt;code>FeatureValue&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772232612_651122_2174" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>direction = null and
+ownedSpecializations->forAll(isImplied) implies
+    ownedMembership->
+        selectByKind(FeatureValue)->
+        forAll(fv | specializes(fv.value.result))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772005626_580804_2161" name="checkFeatureEndSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671149138090_480336_101316" annotatedElement="_19_0_4_12e503d9_1667772005626_580804_2161">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has &lt;code>isEnd = true&lt;/code> and an &lt;code>owningType&lt;/code> that is an &lt;code>Association&lt;/code> or a &lt;code>Connector&lt;/code>, then it must directly or indirectly specialize &lt;code>&lt;em>Links::Link::participant&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772005634_297830_2162" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isEnd and owningType &lt;> null and
+(owningType.oclIsKindOf(Association) or
+ owningType.oclIsKindOf(Connector)) implies
+    specializesFromLibrary('Links::Link::participant')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667771961448_27347_2159" name="checkFeatureSubobjectSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671148523708_460502_101314" annotatedElement="_19_0_4_12e503d9_1667771961448_27347_2159">
+            <body>&lt;p>A composite &lt;code>Feature&lt;/code> typed by a &lt;code>Structure&lt;/code>, and whose &lt;code>ownedType&lt;/code> is a &lt;code>Structure&lt;/code> or another &lt;code>Feature&lt;/code> typed by a &lt;code>Structure&lt;/code> must directly or indirectly specialize &lt;em>&lt;code>Objects::Object::subobjects&lt;/code>&lt;/em>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667771961456_739013_2160" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and
+ownedTyping.type->includes(oclIsKindOf(Structure)) and
+owningType &lt;> null and
+(owningType.oclIsKindOf(Structure) or
+ owningType.type->includes(oclIsKindOf(Structure))) implies
+    specializesFromLibrary('Occurrence::Occurrence::suboccurrences')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667163785102_646604_77" name="checkFeatureOccurrenceSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1667164177897_113275_82" annotatedElement="_19_0_4_12e503d9_1667163785102_646604_77">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has an &lt;code>ownedTyping&lt;/code> relationship to a &lt;code>Class&lt;/code>, then it must directly or indirectly specialize &lt;code>&lt;em>Occurrences::occurrences&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667163785115_496486_78" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedTyping.type->exists(selectByKind(Class)) implies
+    specializesFromLibrary('Occurrences::occurrences')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667771933574_389958_2157" name="checkFeatureSuboccurrenceSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671148464495_207580_101313" annotatedElement="_19_0_4_12e503d9_1667771933574_389958_2157">
+            <body>&lt;p>A composite &lt;code>Feature&lt;/code> that has an &lt;code>ownedTyping&lt;/code> relationship to a &lt;code>Class&lt;/code>, and whose &lt;code>ownedType&lt;/code> is a &lt;code>Class&lt;/code> or another &lt;code>Feature&lt;/code> typed by a &lt;code>Class&lt;/code>, must directly or indirectly specialize &lt;em>&lt;code>Occurrences::Occurrence::suboccurrences&lt;/code>&lt;/em>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667771933591_806306_2158" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and
+ownedTyping.type->includes(oclIsKindOf(Class)) and
+owningType &lt;> null and
+(owningType.oclIsKindOf(Class) or
+ owningType.oclIsKindOf(Feature) and
+    owningType.oclAsType(Feature).type->
+        exists(oclIsKindOf(Class))) implies
+    specializesFromLibrary('Occurrence::Occurrence::suboccurrences')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667163972060_996554_79" name="checkFeatureDataValueSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1667164145533_240211_81" annotatedElement="_19_0_4_12e503d9_1667163972060_996554_79">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has an &lt;code>ownedTyping&lt;/code> relationship to a &lt;code>DataType&lt;/code>, then it must directly or indirectly specialize &lt;code>&lt;em>Base::dataValues&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667163972079_780840_80" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedTyping.type->exists(selectByKind(DataType)) implies
+    specializesFromLibrary('Base::dataValues')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772148952_772482_2171" name="checkFeatureFlowFeatureRedefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671149390429_797901_101317" annotatedElement="_19_0_4_12e503d9_1667772148952_772482_2171">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> is the first &lt;code>ownedFeature&lt;/code> of a first or second &lt;code>FlowEnd&lt;/code>, then it must directly or indirectly specialize either &lt;em>&lt;code>Transfers::Transfer::source::sourceOutput&lt;/code>&lt;/em> or &lt;em>&lt;code>Transfers::Transfer::target::targetInput&lt;/code>&lt;/em>, respectively, from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772148955_315874_2172" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+owningType.oclIsKindOf(FlowEnd) and
+owningType.ownedFeature->at(1) = self implies
+    let flowType : Type = owningType.owningType in
+    flowType &lt;> null implies
+        let i : Integer = 
+            flowType.ownedFeature.indexOf(owningType) in
+        (i = 1 implies 
+            redefinesFromLibrary('Transfers::Transfer::source::sourceOutput')) and
+        (i = 2 implies
+            redefinesFromLibrary('Transfers::Transfer::target::targetInput'))
+                 </body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772037892_273130_2165" name="checkFeatureParameterRedefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671164471197_881456_101320" annotatedElement="_19_0_4_12e503d9_1667772037892_273130_2165">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> is a &lt;code>parameter&lt;/code> of an &lt;code>owningType&lt;/code> that is a &lt;code>Behavior&lt;/code> or &lt;code>Step&lt;/code>, but &lt;em>not&lt;/em>
+&lt;/p>
+&lt;ul>
+    &lt;li>A &lt;code>result&lt;/code> &lt;code>parameter&lt;/code>&lt;/li>
+    &lt;li>A &lt;code>parameter&lt;/code> of an &lt;code>InvocationExpression&lt;/code>, with at least one non-implied &lt;code>ownedRedefinition&lt;/code>&lt;/li>
+&lt;/ul>
+&lt;p>then, for each direct supertype of its &lt;code>owningType&lt;/code> that is also a &lt;code>Behavior&lt;/code> or &lt;code>Step&lt;/code>, it must redefine the &lt;code>parameter&lt;/code> at the same position, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772037902_907660_2166" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(Behavior) or
+ owningType.oclIsKindOf(Step) and
+    (owningType.oclIsKindOf(InvocationExpression) implies
+        not ownedRedefinition->exists(not isImplied)))
+implies
+    let ownerParameters : Sequence(Feature) =
+        owningType.ownedFeature->select(direction &lt;> null)->
+            reject(owningFeatureMembership.
+                oclIsKindOf(ReturnParameterMembership)) in
+    ownerParameters->includes(self) implies
+        let i : Integer = ownerParameters.indexof(self) in
+        owningType.ownedSpecialization.general->
+            forAll(supertype |
+                supertype.oclIsKindOf(Behavior) or 
+                    supertype.oclIsKindOf(Step) 
+                implies
+                    let ownedParameters : Sequence(Feature) =
+                        supertype.ownedFeature->select(direction &lt;> null)->
+                            reject(owningFeatureMembership.
+                                oclIsKindOf(ReturnParameterMembership)) in
+                    ownedParameters->size() >= i implies
+                        redefines(ownedParameters->at(i)))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1671148048995_888108_101310" name="checkFeatureObjectSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671148133235_801729_101312" annotatedElement="_19_0_4_12e503d9_1671148048995_888108_101310">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has an &lt;code>ownedTyping&lt;/code> relationship to a &lt;code>Structure&lt;/code>, then it must directly or indirectly specialize &lt;code>&lt;em>Objects::objects&lt;/em>&lt;/code> from the Kernel Semantics Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1671148049005_753928_101311" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedTyping.type->exists(selectByKind(Structure)) implies
+    specializesFromLibrary('Objects::objects')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1671165189300_469507_101324" name="checkFeatureResultRedefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671165264378_463824_101326" annotatedElement="_19_0_4_12e503d9_1671165189300_469507_101324">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> is a &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of an &lt;code>owningType&lt;/code> that is a &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code>, then, for each direct supertype of its &lt;code>owningType&lt;/code> that is also a &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code>, it must redefine the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1671165189306_430411_101325" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(Function) and
+    self = owningType.oclAsType(Function).result or
+ owningType.oclIsKindOf(Expression) and
+    self = owningType.oclAsType(Expression).result) implies
+    owningType.ownedSpecialization.general->
+        select(oclIsKindOf(Function) or oclIsKindOf(Expression))->
+        forAll(supertype |
+            redefines(
+                if superType.oclIsKindOf(Function) then
+                    superType.oclAsType(Function).result
+                else
+                    superType.oclAsType(Expression).result
+                endif)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674246815371_82521_3812" name="deriveFeatureOwnedFeatureInverting" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674246908528_484526_3814" annotatedElement="_19_0_4_12e503d9_1674246815371_82521_3812">
+            <body>&lt;p>The &lt;code>ownedFeatureInvertings&lt;/code> of a &lt;code>Feature&lt;/code> are its &lt;code>ownedRelationships&lt;/code> that are &lt;code>FeatureInvertings&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674246815390_56753_3813" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedFeatureInverting = ownedRelationship->selectByKind(FeatureInverting)->
+    select(fi | fi.featureInverted = self)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676485174924_26886_65" name="deriveFeatureFeaturingType" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1691615742131_773721_36" annotatedElement="_19_0_4_12e503d9_1676485174924_26886_65">
+            <body>The &lt;code>featuringTypes&lt;/code> of a &lt;code>Feature&lt;/code> include the &lt;code>featuringTypes&lt;/code> of all the &lt;code>typeFeaturings&lt;/code> of the &lt;code>Feature&lt;/code>. If the &lt;code>Feature&lt;/code> has &lt;code>chainingFeatures&lt;/code>, then its &lt;code>featuringTypes&lt;/code> also include the &lt;code>featuringTypes&lt;/code> of the first &lt;code>chainingFeature&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676485174946_858365_66" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featuringType =
+    let featuringTypes : OrderedSet(Type) = 
+        typeFeaturing.type->asOrderedSet() in
+    if chainingFeature->isEmpty() then featuringTypes
+    else
+        featuringTypes->
+            union(chainingFeature->first().featuringType)->
+            asOrderedSet()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676485496013_998987_67" name="deriveFeatureOwnedReferenceSubsetting" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676485693691_258630_69" annotatedElement="_19_0_4_12e503d9_1676485496013_998987_67">
+            <body>&lt;p>The &lt;code>ownedReferenceSubsetting&lt;/code> of a &lt;code>Feature&lt;/code> is the first
+&lt;code>ownedSubsetting&lt;/code> that is a &lt;code>ReferenceSubsetting&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676485496026_570881_68" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedReferenceSubsetting =
+    let referenceSubsettings : OrderedSet(ReferenceSubsetting) =
+        ownedSubsetting->selectByKind(ReferenceSubsetting) in
+    if referenceSubsettings->isEmpty() then null
+    else referenceSubsettings->first() endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676485698592_981796_70" name="validateFeatureOwnedReferenceSubsetting" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676485900341_82547_72" annotatedElement="_19_0_4_12e503d9_1676485698592_981796_70">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> must have at most one &lt;code>ownedSubsetting&lt;/code> that is an &lt;code>ReferenceSubsetting&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676485698604_912688_71" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedSubsetting->selectByKind(ReferenceSubsetting)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695244382690_367775_137" name="validateFeatureChainingFeatureConformance" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695244458568_758828_139" annotatedElement="_19_0_4_12e503d9_1695244382690_367775_137">
+            <body>&lt;p>Each &lt;code>chainingFeature&lt;/code> (other than the first) must be featured within the previous &lt;code>chainingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695244382705_156687_138" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>Sequence{2..chainingFeature->size()}->forAll(i |
+    chainingFeature->at(i).isFeaturedWithin(chainingFeature->at(i-1)))
+</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1705640712382_908773_1065" name="checkFeaturePortionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1705640871228_870227_1067" annotatedElement="_19_0_4_12e503d9_1705640712382_908773_1065">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has &lt;code>isPortion = true&lt;/code>, an &lt;code>ownedTyping &lt;/code> relationship to a &lt;code>Class&lt;/code>, and an &lt;code>owningType&lt;/code> that is a &lt;code>Class&lt;/code> or another &lt;code>Feature&lt;/code> typed by a &lt;code>Class&lt;/code>, then it must directly or indirectly specialize &lt;em>&lt;code>Occurrences::Occurrence::portions&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1705640712402_597778_1066" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isPortion and
+ownedTyping.type->includes(oclIsKindOf(Class)) and
+owningType &lt;> null and
+(owningType.oclIsKindOf(Class) or
+ owningType.oclIsKindOf(Feature) and
+    owningType.oclAsType(Feature).type->
+        exists(oclIsKindOf(Class))) implies
+    specializesFromLibrary('Occurrence::Occurrence::portions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1720273275425_893616_15" name="deriveFeatureFeatureTarget" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720274225511_720182_23" annotatedElement="_2022x_2_12e503d9_1720273275425_893616_15">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has no &lt;code>chainingFeatures&lt;/code>, then its &lt;code>featureTarget&lt;/code> is the &lt;code>Feature&lt;/code> itself, otherwise the &lt;code>featureTarget&lt;/code> is the last of the &lt;code>chainingFeatures&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1720273275432_710112_16" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureTarget = if chainingFeature->isEmpty() then self else chainingFeature->last() endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734674713378_499226_347" name="deriveFeatureOwnedCrossSubsetting" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734674789148_492982_349" annotatedElement="_2022x_2_12e503d9_1734674713378_499226_347">
+            <body>&lt;p>The &lt;code>ownedCrossSubsetting&lt;/code> of a &lt;code>Feature&lt;/code> is the &lt;code>ownedSubsetting&lt;/code> that is a &lt;code>CrossSubsetting&lt;/code>, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734674713378_156874_348" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedCrossSubsetting =
+    let crossSubsettings: Sequence(CrossSubsetting) = 
+        ownedSubsetting->selectByKind(CrossSubsetting) in
+    if crossSubsettings->isEmpty() then null
+    else crossSubsettings->first()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734674956612_635435_362" name="validateFeatureEndMultiplicity" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734675010362_646975_364" annotatedElement="_2022x_2_12e503d9_1734674956612_635435_362">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has &lt;code>isEnd = true&lt;/code>, then it must have multiplicity &lt;code>1..1&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734674956613_944340_363" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isEnd implies 
+    multiplicities().allSuperTypes()->flatten()->
+    selectByKind(MultiplicityRange)->exists(hasBounds(1,1))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734674886755_604038_359" name="validateFeatureCrossFeatureType" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734674951657_944253_361" annotatedElement="_2022x_2_12e503d9_1734674886755_604038_359">
+            <body>&lt;p>The &lt;code>crossFeature&lt;/code> of a &lt;code>Feature&lt;/code> must have the same &lt;code>types&lt;/code> as the &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734674886756_941010_360" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>crossFeature &lt;> null implies
+    crossFeature.type->asSet() = type->asSet()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734675032208_855275_365" name="validateFeatureOwnedCrossSubsetting" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734675082822_231542_367" annotatedElement="_2022x_2_12e503d9_1734675032208_855275_365">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> must have at most one &lt;code>ownedSubsetting&lt;/code> that is a &lt;code>CrossSubsetting&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734675032209_201315_366" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedSubsetting->selectByKind(CrossSubsetting)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734674603673_964582_344" name="deriveFeatureCrossFeature" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734674704744_767341_346" annotatedElement="_2022x_2_12e503d9_1734674603673_964582_344">
+            <body>&lt;p>The &lt;code>crossFeature&lt;/code> of a &lt;code>Feature&lt;/code> is the second &lt;code>chainingFeature&lt;/code> of the &lt;code>crossedFeature&lt;/code> of the &lt;code>ownedCrossSubsetting&lt;/code> of the &lt;code>Feature&lt;/code>, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734674603673_962734_345" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>crossFeature =
+    if ownedCrossSubsetting = null then null
+    else 
+        let chainingFeatures: Sequence(Feature) = 
+            ownedCrossSubsetting.crossedFeature.chainingFeature in
+        if chainingFeatures->size() &lt; 2 then null
+        else chainingFeatures->at(2)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734674472411_384347_338" name="checkFeatureOwnedCrossFeatureSpecialization" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734674525708_944033_340" annotatedElement="_2022x_2_12e503d9_1734674472411_384347_338">
+            <body>&lt;p>If this &lt;code>Feature&lt;/code> is the &lt;code>ownedCrossFeature&lt;/code> of an end &lt;code>Feature&lt;/code>, then it must directly or indirectly specialize the &lt;code>types&lt;/code> of its owning end &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734674472412_653823_339" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isOwnedCrossFeature() implies
+    owner.oclAsType(Feature).type->forAll(t | self.specializes(t))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734674378633_359543_335" name="checkFeatureOwnedCrossFeatureRedefinitionSpecialization" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734674455244_640902_337" annotatedElement="_2022x_2_12e503d9_1734674378633_359543_335">
+            <body>&lt;p>If this &lt;code>Feature&lt;/code> is the &lt;code>ownedCrossFeature&lt;/code> of an end &lt;code>Feature&lt;/code>, then, for any end &lt;code>Feature&lt;/code> that is redefined by the owning end &lt;code>Feature&lt;/code> of this &lt;code>Feature&lt;/code>, this &lt;code>Feature&lt;/code> must subset the &lt;code>crossFeature&lt;/code> of the redefined end &lt;code>Feature&lt;/code>, if this exists.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734674378635_481703_336" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isOwnedCrossFeature() implies
+    ownedSubsetting.subsettedFeature->includesAll(
+        owner.oclAsType(Feature).ownedRedefinition.redefinedFeature->
+            select(crossFeature &lt;> null).crossFeature)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734674792608_124567_350" name="validateFeatureCrossFeatureSpecialization" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734674854378_823619_352" annotatedElement="_2022x_2_12e503d9_1734674792608_124567_350">
+            <body>&lt;p>If this &lt;code>Feature&lt;/code> has a &lt;code>crossFeature&lt;/code>, then, for any &lt;code>Feature&lt;/code> that is redefined by this &lt;code>Feature&lt;/code>, the &lt;code>crossFeature&lt;/code> must specialize the &lt;code>crossFeature&lt;/code> of the redefined end &lt;code>Feature&lt;/code>, if this exists.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734674792608_525401_351" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>crossFeature &lt;> null implies
+    ownedRedefinition.redefinedFeature.crossFeature->
+            forAll(f | f &lt;> null implies crossFeature.specializes(f))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734674233947_870039_332" name="checkFeatureCrossingSpecialization" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734674329812_664282_334" annotatedElement="_2022x_2_12e503d9_1734674233947_870039_332">
+            <body>&lt;p>If this &lt;code>Feature&lt;/code> has &lt;code>isEnd = true&lt;/code> and &lt;code>ownedCrossFeature&lt;/code> returns a non-null value, then the &lt;code>crossFeature&lt;/code> of the &lt;code>Feature&lt;/code> must be the &lt;code>Feature&lt;/code> returned from &lt;code>ownedCrossFeature&lt;/code> (which implies that this &lt;code>Feature&lt;/code> has an appropriate &lt;code>ownedCrossSubsetting&lt;/code> to realize this).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734674233947_559892_333" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedCrossFeature() &lt;> null implies
+    crossFeature = ownedCrossFeature()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734674528893_12991_341" name="checkFeatureOwnedCrossFeatureTypeFeaturing" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734674588905_4399_343" annotatedElement="_2022x_2_12e503d9_1734674528893_12991_341">
+            <body>&lt;p>If this &lt;code>Feature&lt;/code> is the &lt;code>ownedCrossFeature&lt;/code> of an end &lt;code>Feature&lt;/code>, then it must have &lt;code>featuringTypes&lt;/code> consistent with the crossing from other end &lt;code>Features&lt;/code> of the &lt;code>owningType&lt;/code> of its end &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734674528893_215932_342" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isOwnedCrossFeature() implies
+    let otherEnds : OrderedSet(Feature) = 
+        owner.oclAsType(Feature).owningType.endFeature->excluding(self) in
+    if (otherEnds->size() = 1) then
+        featuringType = otherEnds->first().type
+    else
+        featuringType->size() = 1 and
+        featuringType->first().isCartesianProduct() and
+        featuringType->first().asCartesianProduct() = otherEnds.type and
+        featuringType->first().allSupertypes()->includesAll(
+            owner.oclAsType(Feature).ownedRedefinition.redefinedFeature->
+               select(crossFeature() &lt;> null).crossFeature().featuringType)      
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740171737421_126923_130" name="validateFeaturePortionNotVariable" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740171737423_576373_131" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isPortion implies not isVariable</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740171342924_934775_105" name="validateFeatureEndNoDirection" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740171411721_646121_111" annotatedElement="_2022x_2_12e503d9_1740171342924_934775_105">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> with &lt;code>isEnd = true&lt;/code> must have no direction.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740171342925_54694_106" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isEnd implied direction = null</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740171016104_35712_68" name="checkFeatureFeatureMembershipTypeFeaturing" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740171107560_362236_80" annotatedElement="_2022x_2_12e503d9_1740171016104_35712_68">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> is owned via a &lt;code>FeatureMembership&lt;/code>, then it must have a &lt;code>featuringType&lt;/code> for which the operation &lt;code>isFeaturingType&lt;/code> returns true.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740171016106_424437_69" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningFeatureMembership &lt;> null implies
+    featuringTypes->exists(t | isFeaturingType(t))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740171168063_552839_87" name="validateFeatureConstantIsVariable" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740171246425_89577_95" annotatedElement="_2022x_2_12e503d9_1740171168063_552839_87">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> with &lt;code>isConstant = true&lt;/code> must have &lt;code>isVariable = true&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740171168063_409412_88" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isConstant implies isVariable</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740171615400_77816_127" name="validateFeatureIsVariable" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740171695654_222973_129" annotatedElement="_2022x_2_12e503d9_1740171615400_77816_127">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> with &lt;code>isVariable = true&lt;/code> must have an &lt;code>owningType&lt;/code> that directly or indirectly specializes the &lt;code>Class&lt;/code> &lt;em>&lt;code>Occurrences::Occurrence&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740171615401_648228_128" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isVariable implies
+    owningType &lt;> null and 
+    owningType.specializes('Occurrences::Occurrence')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740171493852_84077_120" name="validateFeatureEndNotDerivedAbstractCompositeOrPortion" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740171563995_628332_126" annotatedElement="_2022x_2_12e503d9_1740171493852_84077_120">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> with &lt;code>isEnd = true&lt;/code> must have all of &lt;code>isDerived = false&lt;/code>, &lt;code>isAbstract = false&lt;/code>, &lt;code>isComposite = false&lt;/code>, and &lt;code>isPortion = false&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740171493854_507851_121" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isEnd implies not (isDerived or isAbstract or isComposite or isPortion)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740171250999_49414_96" name="validateFeatureEndIsConstant" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651684_893483_42160">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740171293911_524649_104" annotatedElement="_2022x_2_12e503d9_1740171250999_49414_96">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> with &lt;code>isEnd = true&lt;/code> and &lt;code>isVariable = true&lt;/code> must have &lt;code>isConstant = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740171251001_527628_97" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isEnd and isVariable implies isConstant</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674959_62968_43161" general="_18_5_3_71301a1_1537895141427_270492_15579"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674965_592215_43200" name="owningType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674987_297074_43308 _18_5_3_12e503d9_1533160674986_474739_43306 _19_0_4_12e503d9_1603905619975_304385_743" association="_18_5_3_12e503d9_1533160651681_269751_42154">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716454505_428623_1358" annotatedElement="_18_5_3_12e503d9_1533160674965_592215_43200">
+            <body>&lt;p>The &lt;code>Type&lt;/code> that is the &lt;code>owningType&lt;/code> of the &lt;code>owningFeatureMembership&lt;/code> of this &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678363_754342_43977" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678363_896413_43976" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674968_321342_43214" name="isUnique" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590948063816_286967_147" annotatedElement="_18_5_3_12e503d9_1533160674968_321342_43214">
+            <body>&lt;p>Whether or not values for this &lt;code>Feature&lt;/code> must have no duplicates or not.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_18_5_3_12e503d9_1533160678366_231340_44000" name="" visibility="public" value="true"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674969_728225_43215" name="isOrdered" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590948044178_252787_146" annotatedElement="_18_5_3_12e503d9_1533160674969_728225_43215">
+            <body>&lt;p>Whether an order exists for the values of this &lt;code>Feature&lt;/code> or not.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_18_5_3_12e503d9_1533160678366_803475_44001" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674969_376003_43216" name="type" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isOrdered="true" isDerived="true" association="_18_5_3_12e503d9_1533160651689_153588_42166">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590948084944_347540_148" annotatedElement="_18_5_3_12e503d9_1533160674969_376003_43216">
+            <body>&lt;p>&lt;code>Types&lt;/code> that restrict the values of this &lt;code>Feature&lt;/code>, such that the values must be instances of all the &lt;code>types&lt;/code>. The types of a &lt;code>Feature&lt;/code> are derived from its &lt;code>typings&lt;/code> and the &lt;code>types&lt;/code> of its &lt;code>subsettings&lt;/code>. If the &lt;code>Feature&lt;/code> is chained, then the &lt;code>types&lt;/code> of the last &lt;code>Feature&lt;/code> in the chain are also &lt;code>types&lt;/code> of the chained &lt;code>Feature&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678367_179983_44003" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678367_477896_44002" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674970_161813_43220" name="ownedRedefinition" visibility="public" type="_18_5_3_12e503d9_1533160651690_251835_42168" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674970_472382_43221" association="_18_5_3_12e503d9_1533160651690_504107_42169">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947577614_118674_139" annotatedElement="_18_5_3_12e503d9_1533160674970_161813_43220">
+            <body>&lt;p>The &lt;code>ownedSubsettings&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>Redefinitions&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>redefiningFeature&lt;/code>.&lt;/p>
+
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678368_636803_44011" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678368_661546_44010" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674970_472382_43221" name="ownedSubsetting" visibility="public" type="_18_5_3_12e503d9_1533160651710_980688_42209" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674959_579676_43168 _18_5_3_12e503d9_1533160674966_718145_43205" association="_18_5_3_12e503d9_1533160651707_68561_42204">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947410159_78880_132" annotatedElement="_18_5_3_12e503d9_1533160674970_472382_43221">
+            <body>&lt;p>The &lt;code>ownedSpecializations&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>Subsettings&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>subsettingFeature&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678368_641076_44013" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678368_708484_44012" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674970_68441_43223" name="owningFeatureMembership" visibility="public" type="_18_5_3_12e503d9_1533160651715_740575_42237" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674972_622493_43236" association="_18_5_3_12e503d9_1533160651716_350915_42238">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716500896_621582_1373" annotatedElement="_18_5_3_12e503d9_1533160674970_68441_43223">
+            <body>&lt;p>The &lt;code>FeatureMembership&lt;/code> that owns this &lt;code>Feature&lt;/code> as an &lt;code>ownedMemberFeature&lt;/code>, determining its &lt;code>owningType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678369_191399_44017" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678369_850689_44016" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674970_331870_43224" name="isComposite" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947723751_831225_144" annotatedElement="_18_5_3_12e503d9_1533160674970_331870_43224">
+            <body>&lt;p>Whether the &lt;code>Feature&lt;/code> is a composite &lt;code>feature&lt;/code> of its &lt;code>featuringType&lt;/code>. If so, the values of the &lt;code>Feature&lt;/code> cannot exist after its featuring instance no longer does and cannot be values of another composite feature that is not on the same featuring instance.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1624312468776_990399_6689" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1562475749426_705395_21984" name="isEnd" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947839344_781302_145" annotatedElement="_18_5_3_12e503d9_1562475749426_705395_21984">
+            <body>&lt;p>Whether or not this &lt;code>Feature&lt;/code> is an end &lt;code>Feature&lt;/code>. An end &lt;code>Feature&lt;/code> always has multiplicity 1, mapping each of its domain instances to a single co-domain instance. However, it may have a &lt;code>crossFeature&lt;/code>, in which case values of the &lt;code>crossFeature&lt;/code> must be the same as those found by navigation across instances of the &lt;code>owningType&lt;/code> from values of other end &lt;code>Features&lt;/code> to values of this Feature. If the &lt;code>owningType&lt;/code> has &lt;em>n&lt;/em> end &lt;code>Features&lt;/code>, then the multiplicity, ordering, and uniqueness declared for the &lt;code>crossFeature&lt;/code> of any one of these end &lt;code>Features&lt;/code> constrains the cardinality, ordering, and uniqueness of the collection of values of that &lt;code>Feature&lt;/code> reached by navigation when the values of the other &lt;em>n-1&lt;/em> end &lt;code>Features&lt;/code> are held fixed.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1624312459599_764021_6688" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1563834516279_920295_20653" name="endOwningType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1562476168386_366266_22107 _18_5_3_12e503d9_1533160674965_592215_43200" association="_18_5_3_12e503d9_1563834516278_736913_20651">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716477504_159116_1366" annotatedElement="_18_5_3_12e503d9_1563834516279_920295_20653">
+            <body>&lt;p>The &lt;code>Type&lt;/code> that is related to this &lt;code>Feature&lt;/code> by an &lt;code>EndFeatureMembership&lt;/code> in which the &lt;code>Feature&lt;/code> is an &lt;code>ownedMemberFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1563834606051_921557_20748" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1563834606052_898095_20749" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596597427751_965862_42" name="ownedTyping" visibility="public" type="_18_5_3_12e503d9_1543180339807_437641_20928" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674959_579676_43168 _18_5_3_12e503d9_1543180501615_804591_21100" association="_19_0_2_12e503d9_1596597427751_777297_41">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596601456787_151559_333" annotatedElement="_19_0_2_12e503d9_1596597427751_965862_42">
+            <body>&lt;p>The &lt;code>ownedSpecializations&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>FeatureTypings&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>typedFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596597554444_237721_52" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596597554445_47125_53" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1603905619975_304385_743" name="featuringType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1603905619974_658872_742">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603918498171_540163_1442" annotatedElement="_19_0_4_12e503d9_1603905619975_304385_743">
+            <body>&lt;p>&lt;code>Types&lt;/code> that feature this &lt;code>Feature&lt;/code>, such that any instance in the domain of the &lt;code>Feature&lt;/code> must be classified by all of these &lt;code>Types&lt;/code>, including at least all the &lt;code>featuringTypes&lt;/code> of its &lt;code>typeFeaturings&lt;/code>.  If the &lt;code>Feature&lt;/code> is chained, then the &lt;code>featuringTypes&lt;/code> of the first &lt;code>Feature&lt;/code> in the chain are also &lt;code>featuringTypes&lt;/code> of the chained &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603905639743_518041_753" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603905639743_875502_754" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1603905673975_310948_762" name="ownedTypeFeaturing" visibility="public" type="_19_0_4_12e503d9_1603904809245_349502_510" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1603904928950_196800_580 _18_5_3_12e503d9_1543092026091_217766_16748" association="_19_0_4_12e503d9_1603905673975_713647_761">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603918073082_104086_1437" annotatedElement="_19_0_4_12e503d9_1603905673975_310948_762">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>TypeFeaturings&lt;/code> and for which the &lt;code>Feature&lt;/code> is the &lt;code>featureOfType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603905680128_846398_770" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603905680128_446349_771" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674992_500504_43341" name="isDerived" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590441474959_193706_60" annotatedElement="_18_5_3_12e503d9_1533160674992_500504_43341">
+            <body>&lt;p>Whether the values of this &lt;code>Feature&lt;/code> can always be computed from the values of other &lt;code>Features&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_18_5_3_12e503d9_1533160678384_504805_44119" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1619792219511_543311_445" name="chainingFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isUnique="false" isDerived="true" association="_19_0_4_b9102da_1619792219510_862475_444">
+          <ownedComment xmi:id="_19_0_4_b9102da_1619793117017_690850_474" annotatedElement="_19_0_4_b9102da_1619792219511_543311_445">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that are chained together to determine the values of this &lt;code>Feature&lt;/code>, derived from the &lt;code>chainingFeatures&lt;/code> of the &lt;code>ownedFeatureChainings&lt;/code> of this &lt;code>Feature&lt;/code>, in the same order. The values of a &lt;code>Feature&lt;/code> with &lt;code>chainingFeatures&lt;/code> are the same as values of the last &lt;code>Feature&lt;/code> in the chain, which can be found by starting with the values of the first &lt;code>Feature&lt;/code> (for each instance of the domain of the original &lt;code>Feature&lt;/code>), then using each of those as domain instances to find the values of the second &lt;code>Feature&lt;/code> in chainingFeatures, and so on, to values of the last &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1653691070763_501922_19626" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1619792288691_860607_462" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1653567738671_359235_43" name="ownedFeatureInverting" visibility="public" type="_19_0_4_b9102da_1623178487957_761743_77" aggregation="composite" isDerived="true" subsettedProperty="_19_0_4_b9102da_1623178838861_768019_145 _18_5_3_12e503d9_1543092026091_217766_16748" association="_19_0_4_b9102da_1653567738670_491133_42">
+          <ownedComment xmi:id="_19_0_4_b9102da_1653570709793_991538_100" annotatedElement="_19_0_4_b9102da_1653567738671_359235_43">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>FeatureInvertings&lt;/code> and for which the &lt;code>Feature&lt;/code> is the &lt;code>featureInverted&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1653690856551_540080_19583" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1653690856567_289360_19584" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1622125589880_791465_72" name="ownedFeatureChaining" visibility="public" type="_19_0_4_b9102da_1622124560789_965972_39" isOrdered="true" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543092026091_217766_16748 _18_5_3_12e503d9_1533160674971_80547_43227" association="_19_0_4_b9102da_1622125589880_742459_71">
+          <ownedComment xmi:id="_19_0_4_b9102da_1622552868711_8507_311" annotatedElement="_19_0_4_b9102da_1622125589880_791465_72">
+            <body>&lt;p>The &lt;code>ownedRelationships&lt;/code> of this &lt;code>Feature&lt;/code> that are &lt;code>FeatureChainings&lt;/code>, for which the &lt;code>Feature&lt;/code> will be the &lt;code>featureChained&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1653691052244_314151_19615" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1622125604996_764684_85" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_b9102da_1559231981638_234817_22063" name="isPortion" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590441811886_48205_63" annotatedElement="_18_5_3_b9102da_1559231981638_234817_22063">
+            <body>&lt;p>Whether the values of this &lt;code>Feature&lt;/code> are contained in the space and time of instances of the domain of the &lt;code>Feature&lt;/code> and represent the same thing as those instances.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_18_5_3_b9102da_1559232006184_846417_22065" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1725998273002_23711_212" name="isVariable" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1737173906240_582339_529" annotatedElement="_2022x_2_12e503d9_1725998273002_23711_212">
+            <body>&lt;p>Whether the value of this &lt;code>Feature&lt;/code> might vary over time. That is, whether the &lt;code>Feature&lt;/code> may have a different value for each &lt;em>&lt;code>snapshot&lt;/code>&lt;/em> of an &lt;code>owningType&lt;/code> that is an &lt;em>&lt;code>Occurrence&lt;/code>&lt;/em>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_2022x_2_12e503d9_1736899461394_503038_103" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674993_300560_43342" name="isConstant" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590441517611_725926_61" annotatedElement="_18_5_3_12e503d9_1533160674993_300560_43342">
+            <body>&lt;p>If &lt;code>isVariable&lt;/code> is true, then whether the value of this &lt;code>Feature&lt;/code> nevertheless does not change over all &lt;code>&lt;em>snapshots&lt;/em>&lt;/code> of its &lt;code>owningType&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_18_5_3_12e503d9_1533160678384_530686_44120" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1661555161564_247405_255" name="ownedReferenceSubsetting" visibility="public" type="_19_0_4_12e503d9_1661554793960_500657_60" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674970_472382_43221" association="_19_0_4_12e503d9_1661555161559_640609_254">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661874776376_717914_288" annotatedElement="_19_0_4_12e503d9_1661555161564_247405_255">
+            <body>&lt;p>The one &lt;code>ownedSubsetting&lt;/code> of this &lt;code>Feature&lt;/code>, if any, that is a &lt;code>ReferenceSubsetting&lt;/code>, for which the &lt;code>Feature&lt;/code> is the &lt;code>referencingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661555186231_778875_265" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661555186233_974872_266" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1715790852907_110671_19" name="featureTarget" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" association="_2022x_2_12e503d9_1715790852907_371270_18">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735842473639_561229_106" annotatedElement="_2022x_2_12e503d9_1715790852907_110671_19">
+            <body>&lt;p>The last of the &lt;code>chainingFeatures&lt;/code> of this &lt;code>Feature&lt;/code>, if it has any. Otherwise, this &lt;code>Feature&lt;/code> itself.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1715791010449_719750_42" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1715791010450_793628_43" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1689616227528_355910_218" name="crossFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" association="_19_0_4_b9102da_1689616227528_569877_217">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720898474003_367217_80" annotatedElement="_19_0_4_b9102da_1689616227528_355910_218">
+            <body>&lt;p>The second &lt;code>chainingFeature&lt;/code> of the &lt;code>crossedFeature&lt;/code> of the &lt;code>ownedCrossSubsetting&lt;/code> of this &lt;code>Feature&lt;/code>, if it has one. Semantically, the values of the &lt;code>crossFeature&lt;/code> of an end &lt;code>Feature&lt;/code> must include all values of the end &lt;code>Feature&lt;/code> obtained when navigating from values of the other end &lt;code>Features&lt;/code> of the same &lt;code>owningType&lt;/code>.
+&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1689616237134_675424_226" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1689616237135_483748_227" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674994_447677_43347" name="direction" visibility="public" type="_18_5_3_12e503d9_1533160651677_936694_42144">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590442047514_501894_65" annotatedElement="_18_5_3_12e503d9_1533160674994_447677_43347">
+            <body>&lt;p>Indicates how values of this &lt;code>Feature&lt;/code> are determined or used (as specified for the &lt;code>FeatureDirectionKind&lt;/code>).&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678385_364939_44128" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678385_474057_44127" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1689616916594_145818_277" name="ownedCrossSubsetting" visibility="public" type="_19_0_4_b9102da_1689616180239_998062_127" aggregation="composite" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674970_472382_43221" association="_19_0_4_b9102da_1689616916594_935780_276">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720898567816_967650_81" annotatedElement="_19_0_4_b9102da_1689616916594_145818_277">
+            <body>&lt;p>The one &lt;code>ownedSubsetting&lt;/code> of this &lt;code>Feature&lt;/code>, if any, that is a &lt;code>CrossSubsetting}, for which the &lt;code>Feature&lt;/code> is the &lt;code>crossingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1689617199653_99148_293" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1689617199654_430810_294" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_2_12e503d9_1575498794224_359414_2309" name="directionFor" visibility="public" bodyCondition="_19_0_4_12e503d9_1597116602194_739323_1959">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1597116716082_984618_1963" annotatedElement="_19_0_2_12e503d9_1575498794224_359414_2309">
+            <body>&lt;p>Return the &lt;code>directionOf&lt;/code> this &lt;code>Feature&lt;/code> relative to the given &lt;code>type&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1597116602194_739323_1959" name="directionForBody" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597116602195_500061_1960" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>type.directionOf(self)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_2_12e503d9_1575498834682_179957_2312" name="type" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579"/>
+          <ownedParameter xmi:id="_19_0_2_12e503d9_1575498834683_595668_2313" name="" visibility="public" type="_18_5_3_12e503d9_1533160651677_936694_42144" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1597116610826_364697_1961" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1597116610826_533340_1962" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1673497248141_745053_59" name="effectiveShortName" visibility="public" bodyCondition="_19_0_4_12e503d9_1673497248169_554475_60" redefinedOperation="_19_0_4_12e503d9_1673496481627_588588_29">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673497248171_603893_62" annotatedElement="_19_0_4_12e503d9_1673497248141_745053_59">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has no &lt;code>declaredShortName&lt;/code> or &lt;code>declaredName&lt;/code>, then its effective &lt;code>shortName&lt;/code> is given by the effective &lt;code>shortName&lt;/code> of the &lt;code>Feature&lt;/code> returned by the &lt;code>namingFeature()&lt;/code> operation, if any.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1673497248169_554475_60" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673497248172_642465_63" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if declaredShortName &lt;> null or declaredName &lt;> null then
+    declaredShortName
+else
+    let namingFeature : Feature = namingFeature() in
+    if namingFeature = null then
+        null
+    else
+        namingFeature.effectiveShortName()
+    endif
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673497248171_433271_61" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1673497248178_420589_65" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1673497248175_40285_64" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1617481011732_134883_26907" name="effectiveName" visibility="public" bodyCondition="_19_0_4_12e503d9_1617481373044_811811_26946" redefinedOperation="_19_0_4_12e503d9_1617479751670_738886_26879">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617481256714_116201_26945" annotatedElement="_19_0_4_12e503d9_1617481011732_134883_26907">
+            <body>&lt;p>If a &lt;code>Feature&lt;/code> has no &lt;code>declaredName&lt;/code> or &lt;code>declaredShortName&lt;/code>
+, then its effective &lt;code>name&lt;/code> is given by the effective &lt;code>name&lt;/code> of the &lt;code>Feature&lt;/code> returned by the &lt;code>namingFeature()&lt;/code> operation, if any.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617481373044_811811_26946" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617481373045_773780_26947" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if declaredShortName &lt;> null or declaredName &lt;> null then
+    declaredName
+else
+    let namingFeature : Feature = namingFeature() in
+    if namingFeature = null then
+        null
+    else
+        namingFeature.effectiveName()
+    endif
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617481018504_824763_26911" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617481018513_511308_26912" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617481018515_954903_26913" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1617481077092_765416_26920" name="namingFeature" visibility="public" bodyCondition="_19_0_4_12e503d9_1617481123094_77379_26939">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617481446585_400913_26948" annotatedElement="_19_0_4_12e503d9_1617481077092_765416_26920">
+            <body>&lt;p>By default, the naming &lt;code>Feature&lt;/code> of a &lt;code>Feature&lt;/code> is given by its first &lt;code>redefinedFeature&lt;/code> of its first &lt;code>ownedRedefinition&lt;/code>, if any.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617481123094_77379_26939" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617481123096_534644_26940" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if ownedRedefinition->isEmpty() then
+    null
+else
+    ownedRedefinition->at(1).redefinedFeature
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617481088895_587007_26926" name="" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617481088914_84025_26927" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617481088914_101292_26928" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1736636237695_906138_474" name="supertypes" visibility="public" bodyCondition="_2022x_2_12e503d9_1736636546151_826567_484" redefinedOperation="_2022x_2_12e503d9_1736634542559_470008_403">
+          <ownedRule xmi:id="_2022x_2_12e503d9_1736636546151_826567_484" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736636546152_982018_485" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let supertypes : OrderedSet(Type) = 
+    self.oclAsType(Type).supertypes(excludeImplied) in
+if featureTarget = self then supertypes
+else supertypes->append(featureTarget)
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736636277849_971777_476" name="excludeImplied" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736636277851_561386_477" name="" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736636277899_919995_478" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736636277899_885711_479" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1672445536523_765107_167" name="redefines" visibility="public" bodyCondition="_19_0_4_12e503d9_1672446126792_781798_187">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672445798194_708778_175" annotatedElement="_19_0_4_12e503d9_1672445536523_765107_167">
+            <body>&lt;p>Check whether this &lt;code>Feature&lt;/code> &lt;em>directly&lt;/em> redefines the given &lt;code>redefinedFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1672446126792_781798_187" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672446126812_151157_188" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>ownedRedefinition.redefinedFeature->includes(redefinedFeature)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1672445580447_460547_169" name="redefinedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1672445580490_142347_170" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1672445633015_291151_171" name="redefinesFromLibrary" visibility="public" bodyCondition="_19_0_4_12e503d9_1672446176951_704958_189">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672446076591_208390_186" annotatedElement="_19_0_4_12e503d9_1672445633015_291151_171">
+            <body>&lt;p>Check whether this &lt;code>Feature&lt;/code> &lt;em>directly&lt;/em> redefines the named library &lt;code>Feature&lt;/code>. &lt;code>libraryFeatureName&lt;/code> must conform to the syntax of a KerML qualified name and must resolve to a &lt;code>Feature&lt;/code> in global scope.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1672446176951_704958_189" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672446176965_847322_190" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let mem: Membership = resolveGlobal(libraryFeatureName) in
+mem &lt;> null and mem.memberElement.oclIsKindOf(Feature) and
+redefines(mem.memberElement.oclAsType(Feature))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1672445662824_787821_173" name="libraryFeatureName" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1672445662858_758601_174" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1673307129991_896716_1042" name="subsetsChain" visibility="public" bodyCondition="_19_0_4_12e503d9_1673307505221_669196_1048">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673307321580_236364_1047" annotatedElement="_19_0_4_12e503d9_1673307129991_896716_1042">
+            <body>&lt;p>Check whether this &lt;code>Feature&lt;/code> directly or indirectly specializes a &lt;code>Feature&lt;/code> whose last two &lt;code>chainingFeatures&lt;/code> are the given &lt;code>Features&lt;/code> &lt;code>first&lt;/code> and &lt;code>second&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1673307505221_669196_1048" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673307505240_208574_1049" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>allSuperTypes()->selectAsKind(Feature)->
+    exists(f | let n: Integer = f.chainingFeature->size() in
+        n >= 2 and
+        f.chainingFeature->at(n-1) = first and
+        f.chainingFeature->at(n) = second)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673307200767_549376_1044" name="first" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673307200793_843938_1045" name="second" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673307200796_199702_1046" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1737751379866_877724_33" name="isCompatibleWith" visibility="public" bodyCondition="_2022x_2_12e503d9_1740170571481_233489_40" redefinedOperation="_2022x_2_12e503d9_1737750539612_666533_25">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740170533863_272872_39" annotatedElement="_2022x_2_12e503d9_1737751379866_877724_33">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> is compatible with an &lt;code>otherType&lt;/code> if it either directly or indirectly specializes the &lt;code>otherType&lt;/code> or if the &lt;code>otherType&lt;/code> is also a &lt;code>Feature&lt;/code> and all of the following are true.&lt;/p>
+&lt;ol>
+	&lt;li>Neither this &lt;code>Feature&lt;/code> or the &lt;code>otherType&lt;/code> have any &lt;code>ownedFeatures&lt;/code>.&lt;/li>
+	&lt;li>This &lt;code>Feature&lt;/code> directly or indirectly redefines a &lt;code>Feature&lt;/code> that is also directly or indirectly redefined by the &lt;code>otherType&lt;/code>.&lt;/li>
+	&lt;li>This &lt;code>Feature&lt;/code> can access the &lt;code>otherType&lt;/code>.
+&lt;/li>&lt;/ol></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1740170571481_233489_40" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740170571484_123512_41" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>specializes(otherType) or
+    supertype.oclIsKindOf(Feature) and
+    ownedFeature->isEmpty() and
+    otherType.ownedFeature->isEmpty() and
+    ownedRedefinitions.allRedefinedFeatures()->exists(f |  
+        otherType.oclAsType(Feature).allRedefinedFeatures()->includes(f)) and
+    canAccess(otherType.oclAsType(Feature))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1737751393568_57801_35" name="otherType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579"/>
+          <ownedParameter xmi:id="_2024x_2_12e503d9_1777504395227_665116_3" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1695241608366_676415_109" name="typingFeatures" visibility="public" bodyCondition="_19_0_4_12e503d9_1695241707371_443689_116">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1700585610444_514444_140" annotatedElement="_19_0_4_12e503d9_1695241608366_676415_109">
+            <body>&lt;p>Return the &lt;code>Features&lt;/code> used to determine the &lt;code>types&lt;/code> of this &lt;code>Feature&lt;/code> (other than this &lt;code>Feature&lt;/code> itself). If this &lt;code>Feature&lt;/code> is &lt;em>not&lt;/em> conjugated, then the &lt;code>typingFeatures&lt;/code> consist of all subsetted &lt;code>Features&lt;/code>, &lt;em>except&lt;/em> from &lt;code>CrossSubsetting&lt;/code>, and the last &lt;code>chainingFeature&lt;/code> (if any). If this &lt;code>Feature&lt;/code> &lt;em>is&lt;/em> conjugated, then the &lt;code>typingFeatures&lt;/code> are only its &lt;code>originalType&lt;/code> (if the &lt;code>originalType&lt;/code> is a &lt;code>Feature&lt;/code>).&lt;/p>
+
+&lt;p>&lt;strong>Note.&lt;/strong> &lt;code>CrossSubsetting&lt;/code> is excluded from the determination of the &lt;code>type&lt;/code> of a &lt;code>Feature&lt;/code> in order to avoid circularity in the construction of implied &lt;code>CrossSubsetting&lt;/code> relationships. The &lt;code>validateFeatureCrossFeatureType&lt;/code> requires that the &lt;code>crossFeature&lt;/code> of a &lt;code>Feature&lt;/code> have the same &lt;code>type&lt;/code> as the &lt;code>Feature&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1695241707371_443689_116" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695241707395_541307_117" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if not isConjugated then
+    let subsettedFeatures : OrderedSet(Feature) = 
+        subsetting->reject(s | s.oclIsKindOf(CrossSubsetting)).subsettedFeatures in 
+    if chainingFeature->isEmpty() or
+       subsettedFeature->includes(chainingFeature->last())
+    then subsettedFeatures
+    else subsettedFeatures->append(chainingFeature->last())
+    endif
+else if conjugator.originalType.oclIsKindOf(Feature) then
+    OrderedSet{conjugator.originalType.oclAsType(Feature)}
+else OrderedSet{}
+endif endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1695241635727_467290_110" name="" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1695241656143_890038_113" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1695241656152_632393_114" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1734673432851_119526_277" name="asCartesianProduct" visibility="public" bodyCondition="_2022x_2_12e503d9_1734673670913_525479_296">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734673649310_415157_295" annotatedElement="_2022x_2_12e503d9_1734673432851_119526_277">
+            <body>&lt;p>If &lt;code>isCartesianProduct&lt;/code> is true, then return the list of &lt;code>Types&lt;/code> whose Cartesian product can be represented by this &lt;code>Feature&lt;/code>. (If &lt;code>isCartesianProduct&lt;/code> is not true, the operation will still return a valid value, it will just not represent anything useful.)&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1734673670913_525479_296" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734673670914_117494_297" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>featuringType->select(t | t.owner &lt;> self)->
+    union(featuringType->select(t | t.owner = self)->
+        selectByKind(Feature).asCartesianProduct())->
+    union(type)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1734673484406_237356_279" name="" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isOrdered="true" isUnique="false" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1734673484409_513115_280" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1734673484409_384417_281" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1734673681074_183275_298" name="isCartesianProduct" visibility="public" bodyCondition="_2022x_2_12e503d9_1734673790111_781430_302">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734673758185_15822_301" annotatedElement="_2022x_2_12e503d9_1734673681074_183275_298">
+            <body>&lt;p>Check whether this &lt;code>Feature&lt;/code> can be used to represent a Cartesian product of &lt;code>Types&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1734673790111_781430_302" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734673790112_468975_303" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>type->size() = 1 and
+featuringType.size() = 1 and
+(featuringType.first().owner = self implies
+    featuringType.first().oclIsKindOf(Feature) and
+    featuringType.first().oclAsType(Feature).isCartesianProduct())</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1734673710364_17004_300" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1734673834814_593731_304" name="isOwnedCrossFeature" visibility="public" bodyCondition="_2022x_2_12e503d9_1734673917297_519325_312">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734673901286_694181_311" annotatedElement="_2022x_2_12e503d9_1734673834814_593731_304">
+            <body>&lt;p>Return whether this &lt;code>Feature&lt;/code> is an owned cross &lt;code>Feature&lt;/code> of an end &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1734673917297_519325_312" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734673917297_323685_313" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>owningNamespace &lt;> null and 
+owningNamespace.oclIsKindOf(Feature) and 
+owningNamespace.oclAsType(Feature).ownedCrossFeature() = self</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1734673852194_945438_306" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1734673931282_837421_314" name="ownedCrossFeature" visibility="public" bodyCondition="_2022x_2_12e503d9_1734674066018_775009_320">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734674026505_761479_319" annotatedElement="_2022x_2_12e503d9_1734673931282_837421_314">
+            <body>&lt;p>If this &lt;code>Feature&lt;/code> is an end &lt;code>Feature&lt;/code> of its &lt;code>owningType&lt;/code>, then return the first &lt;code>ownedMember&lt;/code> of the &lt;code>Feature&lt;/code> that is a &lt;code>Feature&lt;/code>, but not a &lt;code>Multiplicity&lt;/code> or a &lt;code>MetadataFeature&lt;/code>, and whose &lt;code>owningMembership&lt;/code> is &lt;em>not&lt;/em> a &lt;code>FeatureMembership&lt;/code>. If this exists, it is the &lt;code>crossFeature&lt;/code> of the end &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1734674066018_775009_320" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734674066018_691992_321" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if not isEnd or owningType = null then null
+else
+    let ownedMemberFeatures: Sequence(Feature) =
+        ownedMember->selectByKind(Feature)->
+            reject(oclIsKindOf(Multiplicity) or 
+                   oclIsKindOf(MetadataFeature) or
+                   oclIsKindOf(FeatureValue))->
+            reject(owningMembership.oclIsKindOf(FeatureMembership)) in
+    if ownedMemberFeatures.isEmpty() then null
+    else ownedMemberFeatures->first()
+    endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1734673952638_506403_316" name="" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1734673952640_9352_317" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1734673952640_315148_318" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1736636209494_814367_468" name="allRedefinedFeatures" visibility="public" bodyCondition="_2022x_2_12e503d9_1736636324253_398505_480">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736636359063_299841_482" annotatedElement="_2022x_2_12e503d9_1736636209494_814367_468">
+            <body>&lt;p>Return this &lt;code>Feature&lt;/code> and all the &lt;code>Features&lt;/code> that are directly or indirectly &lt;code>Redefined&lt;/code> by this &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1736636324253_398505_480" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736636324253_282642_481" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>ownedRedefinition.redefinedFeature->
+    closure(ownedRedefinition.redefinedFeature)->
+    asOrderedSet()->prepend(self)
+</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736636237608_385336_471" name="" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1736636237655_702411_472" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1736636237655_116072_473" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1604674919006_535618_66" name="isFeaturedWithin" visibility="public" bodyCondition="_19_0_4_12e503d9_1604675399418_182900_74">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604675067493_700905_71" annotatedElement="_19_0_4_12e503d9_1604674919006_535618_66">
+            <body>&lt;p>Return if the &lt;code>featuringTypes&lt;/code> of this &lt;code>Feature&lt;/code> are compatible with the given &lt;code>type&lt;/code>. If &lt;code>type&lt;/code> is null, then check if this &lt;code>Feature&lt;/code> is explicitly or implicitly featured by &lt;em>&lt;code>Base::Anything&lt;/code>&lt;/em>. If this &lt;code>Feature&lt;/code> has &lt;code>isVariable = true&lt;/code>, then also consider it to be featured within its &lt;code>owningType&lt;/code>. If this &lt;code>Feature&lt;/code> is a feature chain whose first &lt;code>chainingFeature&lt;/code> has &lt;code>isVariable = true&lt;/code>, then also consider it to be featured within the &lt;code>owningType&lt;/code> of its first &lt;code>chainingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1604675399418_182900_74" name="isFeaturedWithIn_Body" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1604675399418_366656_75" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if type = null then
+    featuringType->forAll(f | f = resolveGlobal('Base::Anything').memberElement)
+else
+    featuringType->forAll(f | type.isCompatibleWith(f)) or
+    isVariable and type.specializes(owningType) or
+    chainingFeature->notEmpty() and chainingFeature->first().isVariable and
+        type.specializes(chainingFeature->first().owningType)
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1604676926324_437307_77" name="type" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1604676927074_853023_78" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1604676927076_169410_79" name="" visibility="public" value="1"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1604676927087_430779_80" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1740170155795_813938_30" name="canAccess" visibility="public" bodyCondition="_2022x_2_12e503d9_1740170444410_440504_37">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740170415559_385079_36" annotatedElement="_2022x_2_12e503d9_1740170155795_813938_30">
+            <body>&lt;p>A &lt;code>Feature&lt;/code> can access another &lt;code>feature&lt;/code> if the other &lt;code>feature&lt;/code> is featured within one of the direct or indirect &lt;code>featuringTypes&lt;/code> of this &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1740170444410_440504_37" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740170444413_304615_38" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let anythingType: Element =
+    subsettingFeature.resolveGlobal('Base::Anything').memberElement in
+let allFeaturingTypes : Sequence(Type) =
+    featuringTypes->closure(t |
+        if not t.oclIsKindOf(Feature) then Sequence{}
+        else
+            let featuringTypes : OrderedSet(Type) = t.oclAsType(Feature).featuringType in
+            if featuringTypes->isEmpty() then Sequence{anythingType}
+            else featuringTypes
+            endif 
+        endif) in
+allFeaturingTypes->exists(t | feature.isFeaturedWithin(t))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1740170196176_881525_32" name="feature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1740170196180_545428_33" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1737173468114_471695_499" name="isFeaturingType" visibility="public" bodyCondition="_2022x_2_12e503d9_1740170728076_409658_48">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1737173974409_761652_530" annotatedElement="_2022x_2_12e503d9_1737173468114_471695_499">
+            <body>&lt;p>Return whether the given &lt;code>type&lt;/code> must be a &lt;code>featuringType&lt;/code> of this &lt;code>Feature&lt;/code>. If this &lt;code>Feature&lt;/code> has &lt;code>isVariable = false&lt;/code>, then return true if the &lt;code>type&lt;/code> is the &lt;code>owningType&lt;/code> of the &lt;code>Feature&lt;/code>. If &lt;code>isVariable = true&lt;/code>, then return true if the &lt;code>type&lt;/code> is a &lt;code>Feature&lt;/code> representing the &lt;em>&lt;code>snapshots&lt;/code>&lt;/em> of the &lt;code>owningType&lt;/code> of this &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1740170728076_409658_48" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740170728080_46482_49" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>owningType &lt;> null and
+if not isVariable then type = owningType
+else if owningType = resolveGlobal('Occurrences::Occurrence').memberElement then
+    type = resolveGlobal('Occurrences::Occurrence::snapshots').memberElement 
+else 
+    type.oclIsKindOf(Feature) and
+    let feature : Feature = type.oclAsType(Feature) in
+    feature.featuringType->includes(owningType) and
+    feature.redefinesFromLibrary('Occurrences::Occurrence::snapshots')
+endif
+</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1737173493551_571287_503" name="type" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579"/>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1737173493552_459505_504" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1543180339807_437641_20928" name="FeatureTyping" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578006731721_913952_872" annotatedElement="_18_5_3_12e503d9_1543180339807_437641_20928">
+          <body>&lt;p>&lt;code>FeatureTyping&lt;/code> is &lt;code>Specialization&lt;/code> in which the &lt;code>specific&lt;/code> &lt;code>Type&lt;/code> is a &lt;code>Feature&lt;/code>. This means the set of instances of the (specific) &lt;code>typedFeature&lt;/code> is a subset of the set of instances of the (general) &lt;code>type&lt;/code>. In the simplest case, the &lt;code>type&lt;/code> is a &lt;code>Classifier&lt;/code>, whereupon the &lt;code>typedFeature&lt;/code> has values that are instances of the &lt;code>Classifier&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_18_5_3_12e503d9_1543180474889_772695_21066" general="_18_5_3_12e503d9_1533160651696_992729_42182"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543180501615_13273_21101" name="typedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674982_253967_43281" association="_18_5_3_12e503d9_1543180501615_77733_21099">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590948198111_164282_153" annotatedElement="_18_5_3_12e503d9_1543180501615_13273_21101">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that has a &lt;code>type&lt;/code> determined by this &lt;code>FeatureTyping&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1544197843692_758272_21190" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1544197843692_316626_21191" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543180520185_480887_21131" name="type" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674980_563969_43273" association="_18_5_3_12e503d9_1543180520184_318941_21130">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590948217096_105778_154" annotatedElement="_18_5_3_12e503d9_1543180520185_480887_21131">
+            <body>&lt;p>The &lt;code>Type&lt;/code> that is being applied by this &lt;code>FeatureTyping&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543181242709_610094_21822" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543181242709_630577_21823" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596597427753_801746_43" name="owningFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_573157_43226" subsettedProperty="_18_5_3_12e503d9_1543180501615_13273_21101" association="_19_0_2_12e503d9_1596597427751_777297_41">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596601330850_95814_332" annotatedElement="_19_0_2_12e503d9_1596597427753_801746_43">
+            <body>&lt;p>A &lt;code>typedFeature&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>FeatureTyping&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596597584019_170948_58" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596597584019_908053_59" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651710_980688_42209" name="Subsetting" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578006266476_63016_871" annotatedElement="_18_5_3_12e503d9_1533160651710_980688_42209">
+          <body>&lt;p>&lt;code>Subsetting&lt;/code> is &lt;code>Specialization&lt;/code> in which the &lt;code>specific&lt;/code> and &lt;code>general&lt;/code> &lt;code>Types&lt;/code> are &lt;code>Features&lt;/code>. This means all values of the &lt;code>subsettingFeature&lt;/code> (on instances of its domain, i.e., the intersection of its &lt;code>featuringTypes&lt;/code>) are values of the &lt;code>subsettedFeature&lt;/code> on instances of its domain. To support this the domain of the &lt;code>subsettingFeature&lt;/code> must be the same or specialize (at least indirectly) the domain of the &lt;code>subsettedFeature&lt;/code> (via &lt;code>Specialization&lt;/code>), and the co-domain (intersection of the &lt;code>types&lt;/code>) of the &lt;code>subsettingFeature&lt;/code> must specialize the co-domain of the &lt;code>subsettedFeature&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676759603629_749517_2" name="validateSubsettingFeaturingTypes" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651710_980688_42209">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676759894047_779984_4" annotatedElement="_19_0_4_12e503d9_1676759603629_749517_2">
+            <body>&lt;p>The &lt;code>subsettedFeature&lt;/code> must be accessible by the &lt;code>subsettingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676759603681_223634_3" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>subsettingFeature.canAccess(subsettedFeature)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695244718473_810693_145" name="validateSubsettingUniquenessConformance" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651710_980688_42209">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695244969966_150731_147" annotatedElement="_19_0_4_12e503d9_1695244718473_810693_145">
+            <body>&lt;p>If the &lt;code>subsettedFeature&lt;/code> of a &lt;code>Subsetting&lt;/code> has &lt;code>isUnique = true&lt;/code>, then the &lt;code>subsettingFeature&lt;/code> must have &lt;code>isUnique = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695244718491_65036_146" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>subsettedFeature.isUnique implies subsettingFeature.isUnique</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740669855987_864197_883" name="validateSubsettingConstantConformance" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651710_980688_42209">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740669976914_79522_885" annotatedElement="_2022x_2_12e503d9_1740669855987_864197_883">
+            <body>&lt;p>If the &lt;code>subsettedFeature&lt;/code> of a &lt;code>Subsetting&lt;/code> has &lt;code>isConstant = true&lt;/code> and the &lt;code>subsettingFeature&lt;/code> has &lt;code>isVariable = true&lt;/code>, then the &lt;code>subsettingFeature&lt;/code> must have &lt;code>isConstant = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740669855990_653363_884" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>subsettedFeature.isConstant and subsettingFeature.isVariable implies 
+    subsettingFeature.isConstant
+</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674982_895611_43280" general="_18_5_3_12e503d9_1533160651696_992729_42182"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674961_393191_43181" name="subsettedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674980_563969_43273" association="_18_5_3_12e503d9_1533160651678_637684_42147">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947082960_212733_88" annotatedElement="_18_5_3_12e503d9_1533160674961_393191_43181">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is subsetted by the &lt;code>subsettingFeature&lt;/code> of this &lt;code>Subsetting&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678359_627571_43950" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678359_574539_43949" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674967_140305_43206" name="subsettingFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674982_253967_43281" association="_18_5_3_12e503d9_1533160651683_439767_42157">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947135768_716013_89" annotatedElement="_18_5_3_12e503d9_1533160674967_140305_43206">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is a subset of the &lt;code>subsettedFeature&lt;/code> of this &lt;code>Subsetting&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678364_577588_43989" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678364_558630_43988" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674987_236250_43311" name="owningFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_573157_43226" subsettedProperty="_18_5_3_12e503d9_1533160674967_140305_43206" association="_18_5_3_12e503d9_1533160651707_68561_42204">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947219999_723875_122" annotatedElement="_18_5_3_12e503d9_1533160674987_236250_43311">
+            <body>&lt;p>A &lt;code>subsettingFeature&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>Subsetting&lt;/code>.&lt;/p>
+
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678383_693394_44114" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678383_21226_44113" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651675_261056_42142" name="A_redefiningFeature_redefinition" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674958_414216_43160 _18_5_3_12e503d9_1533160674957_897831_43159">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674957_897831_43159" name="redefinition" visibility="public" type="_18_5_3_12e503d9_1533160651690_251835_42168" subsettedProperty="_18_5_3_12e503d9_1533160674966_718145_43205" association="_18_5_3_12e503d9_1533160651675_261056_42142">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947562304_6663_138" annotatedElement="_18_5_3_12e503d9_1533160674957_897831_43159">
+            <body>&lt;p>The Redefinitions with a certain Feature as the &lt;code>redefiningFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678355_368121_43922" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678355_617989_43921" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651707_68561_42204" name="A_owningFeature_ownedSubsetting" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674987_236250_43311 _18_5_3_12e503d9_1533160674970_472382_43221"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651678_637684_42147" name="A_subsettedFeature_supersetting" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674961_393191_43181 _18_5_3_12e503d9_1533160674961_265412_43180">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674961_265412_43180" name="supersetting" visibility="public" type="_18_5_3_12e503d9_1533160651710_980688_42209" subsettedProperty="_18_5_3_12e503d9_1533160674980_42445_43272" association="_18_5_3_12e503d9_1533160651678_637684_42147">
+          <ownedComment xmi:id="_19_0_2_59601fc_1590947372780_899438_130" annotatedElement="_18_5_3_12e503d9_1533160674961_265412_43180">
+            <body>&lt;p>The Subsettings with a certain Feature as the &lt;code>subsettedFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678359_880830_43948" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678358_239444_43947" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1573095852093_239452_5395" name="A_multiplicity_typeWithMultiplicity" visibility="public" memberEnd="_19_0_2_12e503d9_1573095852093_324833_5396 _19_0_2_12e503d9_1573095852093_460793_5397">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1573095852093_460793_5397" name="typeWithMultiplicity" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674980_717955_43271" association="_19_0_2_12e503d9_1573095852093_239452_5395">
+          <ownedComment xmi:id="_19_0_2_59601fc_1589716487792_451950_1370" annotatedElement="_19_0_2_12e503d9_1573095852093_460793_5397">
+            <body>&lt;p>A &lt;code>Type&lt;/code> that has the &lt;code>multiplicity&lt;/code> as an &lt;code>ownedMember&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573095953176_735502_5485" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573095953177_833875_5486" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596597427751_777297_41" name="A_ownedTyping_owningFeature" visibility="public" memberEnd="_19_0_2_12e503d9_1596597427751_965862_42 _19_0_2_12e503d9_1596597427753_801746_43"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1603904928950_330995_578" name="A_featureOfType_typeFeaturing" visibility="public" memberEnd="_19_0_4_12e503d9_1603904928950_912234_579 _19_0_4_12e503d9_1603904928950_196800_580">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1603904928950_196800_580" name="typeFeaturing" visibility="public" type="_19_0_4_12e503d9_1603904809245_349502_510" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227" association="_19_0_4_12e503d9_1603904928950_330995_578">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603917973822_792315_1436" annotatedElement="_19_0_4_12e503d9_1603904928950_196800_580">
+            <body>&lt;p>The &lt;code>TypeFeaturings&lt;/code> for which a certain &lt;code>Feature&lt;/code> is the &lt;code>featureOfType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603905110515_680801_616" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603905110519_742849_617" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1603905619974_658872_742" name="A_featuringType_featureOfType" visibility="public" memberEnd="_19_0_4_12e503d9_1603905619975_304385_743 _19_0_4_12e503d9_1603905619976_564919_744">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1603905619976_564919_744" name="featureOfType" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" association="_19_0_4_12e503d9_1603905619974_658872_742">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603918723126_394377_1443" annotatedElement="_19_0_4_12e503d9_1603905619976_564919_744">
+            <body>&lt;p>The Features for which a certain Type is a &lt;code>featuringType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603907249421_141508_1230" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603907249421_230973_1231" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1603904809245_349502_510" name="TypeFeaturing" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1603917834791_365135_1432" annotatedElement="_19_0_4_12e503d9_1603904809245_349502_510">
+          <body>&lt;p>A &lt;code>TypeFeaturing&lt;/code> is a &lt;code>Featuring&lt;/code> &lt;code>Relationship&lt;/code> in which the &lt;code>featureOfType&lt;/code> is the &lt;code>source&lt;/code> and the &lt;code>featuringType&lt;/code> is the &lt;code>target&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_12e503d9_1661981088014_944707_379" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1603904928950_912234_579" name="featureOfType" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" association="_19_0_4_12e503d9_1603904928950_330995_578">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603917941028_738378_1435" annotatedElement="_19_0_4_12e503d9_1603904928950_912234_579">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is featured by the &lt;code>featuringType&lt;/code>. It is the &lt;code>source&lt;/code> of the &lt;code>TypeFeaturing&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603904936221_233357_589" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603904936223_326326_590" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1603904945024_8186_598" name="featuringType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_19_0_4_12e503d9_1603904945024_814598_597">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603917858161_832546_1433" annotatedElement="_19_0_4_12e503d9_1603904945024_8186_598">
+            <body>&lt;p>The &lt;code>Type&lt;/code> that features the &lt;code>featureOfType&lt;/code>. It is the &lt;code>target&lt;/code> of the &lt;code>TypeFeaturing&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603904970794_430004_608" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603904970794_607162_609" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1603905673976_689994_763" name="owningFeatureOfType" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543092026091_693018_16749 _19_0_4_12e503d9_1603904928950_912234_579" association="_19_0_4_12e503d9_1603905673975_713647_761">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603918149102_510665_1439" annotatedElement="_19_0_4_12e503d9_1603905673976_689994_763">
+            <body>&lt;p>A &lt;code>featureOfType&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>TypeFeaturing&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603905737695_301696_778" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603905737695_136423_779" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1603905673975_713647_761" name="A_ownedTypeFeaturing_owningFeatureOfType" visibility="public" memberEnd="_19_0_4_12e503d9_1603905673975_310948_762 _19_0_4_12e503d9_1603905673976_689994_763"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1603904945024_814598_597" name="A_featuringType_typeFeaturingOfType" visibility="public" memberEnd="_19_0_4_12e503d9_1603904945024_8186_598 _19_0_4_12e503d9_1603904945024_761150_599">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1603904945024_761150_599" name="typeFeaturingOfType" visibility="public" type="_19_0_4_12e503d9_1603904809245_349502_510" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_4_12e503d9_1603904945024_814598_597">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603917876607_340460_1434" annotatedElement="_19_0_4_12e503d9_1603904945024_761150_599">
+            <body>&lt;p>The &lt;code>TypeFeaturings&lt;/code> for which a certain &lt;code>Type&lt;/code> is the &lt;code>featuringType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603905179625_138912_639" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603905179626_573540_640" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1622125589880_742459_71" name="A_ownedFeatureChaining_featureChained" visibility="public" memberEnd="_19_0_4_b9102da_1622125589880_791465_72 _19_0_4_b9102da_1622125589880_897608_73"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1625459008756_956040_5416" name="EndFeatureMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1625459136705_645979_5442" annotatedElement="_19_0_4_12e503d9_1625459008756_956040_5416">
+          <body>&lt;p>&lt;code>EndFeatureMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that requires its &lt;code>memberFeature&lt;/code> be owned and have &lt;code>isEnd = true&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1625459687429_872447_5599" name="validateEndFeatureMembershipIsEnd" visibility="public" constrainedElement="_19_0_4_12e503d9_1625459008756_956040_5416">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1625459750463_527268_5607" annotatedElement="_19_0_4_12e503d9_1625459687429_872447_5599">
+            <body>&lt;p>The &lt;code>ownedMemberFeature&lt;/code> of an &lt;code>EndFeatureMembership&lt;/code> must be an end &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1625459687432_949300_5600" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMemberFeature.isEnd</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1625459024931_801144_5441" general="_18_5_3_12e503d9_1533160651715_740575_42237"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1625459277304_568293_5526" name="ownedMemberFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" aggregation="composite" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674993_898044_43344" association="_19_0_4_12e503d9_1625459277303_785076_5525">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1625459379365_71632_5536" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1625459379366_243542_5537" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1622125799011_2804_116" name="A_chainingFeature_chainedFeatureChaining" visibility="public" memberEnd="_19_0_4_b9102da_1622125799011_772669_117 _19_0_4_b9102da_1622125799012_832677_118">
+        <ownedComment xmi:id="_19_0_4_b9102da_1622553808560_77333_314" annotatedElement="_19_0_4_b9102da_1622125799011_2804_116">
+          <body>&lt;p>Relationship for chainedFeatures.&lt;/p></body>
+        </ownedComment>
+        <ownedEnd xmi:id="_19_0_4_b9102da_1622125799012_832677_118" name="chainedFeatureChaining" visibility="public" type="_19_0_4_b9102da_1622124560789_965972_39" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_4_b9102da_1622125799011_2804_116">
+          <ownedComment xmi:id="_19_0_4_b9102da_1622554046905_894498_315" annotatedElement="_19_0_4_b9102da_1622125799012_832677_118">
+            <body>&lt;p>The &lt;code>FeatureChainings&lt;/code> that identify a &lt;code>Feature&lt;/code> as their &lt;code>chainingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1653691082829_801116_19636" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1622126224630_490502_132" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_b9102da_1622124560789_965972_39" name="FeatureChaining" visibility="public">
+        <ownedComment xmi:id="_19_0_4_b9102da_1622555242003_703526_356" annotatedElement="_19_0_4_b9102da_1622124560789_965972_39">
+          <body>&lt;p>&lt;code>FeatureChaining&lt;/code> is a &lt;code>Relationship&lt;/code> that makes its target &lt;code>Feature&lt;/code> one of the &lt;code>chainingFeatures&lt;/code> of its owning &lt;code>Feature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_b9102da_1622124573873_378054_64" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1622125799011_772669_117" name="chainingFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_19_0_4_b9102da_1622125799011_2804_116">
+          <ownedComment xmi:id="_19_0_4_b9102da_1622555004217_91259_353" annotatedElement="_19_0_4_b9102da_1622125799011_772669_117">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> whose values partly determine values of &lt;code>featureChained&lt;/code>, as described in &lt;code>Feature::chainingFeature&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1622126172190_83280_125" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1622126172190_785939_126" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1622125589880_897608_73" name="featureChained" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" subsettedProperty="_18_5_3_12e503d9_1543092026091_693018_16749" association="_19_0_4_b9102da_1622125589880_742459_71">
+          <ownedComment xmi:id="_19_0_4_b9102da_1622554942265_14718_352" annotatedElement="_19_0_4_b9102da_1622125589880_897608_73">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> whose values are partly determined by values of the &lt;code>chainingFeature&lt;/code>, as described in &lt;code>Feature::chainingFeature&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1622125599788_287387_80" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1622125599789_847560_81" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1619792219510_862475_444" name="A_chainingFeature_chainedFeature" visibility="public" memberEnd="_19_0_4_b9102da_1619792219511_543311_445 _19_0_4_b9102da_1619792219511_982351_446">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1619792219511_982351_446" name="chainedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" association="_19_0_4_b9102da_1619792219510_862475_444">
+          <ownedComment xmi:id="_19_0_4_b9102da_1622552832415_143671_310" annotatedElement="_19_0_4_b9102da_1619792219511_982351_446">
+            <body>&lt;p>The &lt;code>Features&lt;/code> that have a particular &lt;code>chainingFeature&lt;/code> in their &lt;code>Feature&lt;/code> chain, whose values are partly determined by values of the &lt;code>chainingFeature&lt;/code>, as described in &lt;code>chainingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1653691073749_876282_19629" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1619792260702_973572_456" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1625459277303_785076_5525" name="A_ownedMemberFeature_owningEndFeatureMembership" visibility="public" memberEnd="_19_0_4_12e503d9_1625459277304_568293_5526 _19_0_4_12e503d9_1625459277304_843796_5527">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1625459277304_843796_5527" name="owningEndFeatureMembership" visibility="public" type="_19_0_4_12e503d9_1625459008756_956040_5416" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674970_68441_43223" association="_19_0_4_12e503d9_1625459277303_785076_5525">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1625459413982_251309_5542" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1625459413982_164355_5543" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_b9102da_1623178487957_761743_77" name="FeatureInverting" visibility="public">
+        <ownedComment xmi:id="_19_0_4_b9102da_1623185379663_11599_345" annotatedElement="_19_0_4_b9102da_1623178487957_761743_77">
+          <body>&lt;p>A &lt;code>FeatureInverting&lt;/code> is a &lt;code>Relationship&lt;/code> between &lt;code>Features&lt;/code> asserting that their interpretations (sequences) are the reverse of each other, identified as &lt;code>featureInverted&lt;/code> and &lt;code>invertingFeature&lt;/code>. For example, a &lt;code>Feature&lt;/code> identifying each person&amp;#39;s parents is the inverse of a &lt;code>Feature&lt;/code> identifying each person&amp;#39;s children. A person identified as a parent of another will identify that other as one of their children.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_b9102da_1623178502607_947528_102" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1623178838862_842173_146" name="featureInverted" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" association="_19_0_4_b9102da_1623178838861_809305_144">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623181504457_210485_315" annotatedElement="_19_0_4_b9102da_1623178838862_842173_146">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is an inverse of the &lt;code>invertingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1623178845203_519917_153" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1623178845203_369244_154" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1623178854941_627588_162" name="invertingFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" association="_19_0_4_b9102da_1623178854940_222552_161">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623181509750_69288_316" annotatedElement="_19_0_4_b9102da_1623178854941_627588_162">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is an inverse of the &lt;code>invertedFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1623178860899_575475_170" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1623178860900_755327_171" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1653567738671_122613_44" name="owningFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" subsettedProperty="_19_0_4_b9102da_1623178838862_842173_146 _18_5_3_12e503d9_1543092026091_693018_16749" association="_19_0_4_b9102da_1653567738670_491133_42">
+          <ownedComment xmi:id="_19_0_4_b9102da_1653570513173_499076_85" annotatedElement="_19_0_4_b9102da_1653567738671_122613_44">
+            <body>&lt;p>A &lt;code>featureInverted&lt;/code> that is also the &lt;code>owningRelatedElement&lt;/code> of this &lt;code>FeatureInverting&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1653690861162_17761_19591" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1653690861171_574260_19592" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1623178838861_809305_144" name="A_invertingFeatureInverting_featureInverted" visibility="public" memberEnd="_19_0_4_b9102da_1623178838861_768019_145 _19_0_4_b9102da_1623178838862_842173_146">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1623178838861_768019_145" name="invertingFeatureInverting" visibility="public" type="_19_0_4_b9102da_1623178487957_761743_77" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227" association="_19_0_4_b9102da_1623178838861_809305_144">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623181245139_994812_313" annotatedElement="_19_0_4_b9102da_1623178838861_768019_145">
+            <body>&lt;p>The FeatureInvertings that identify this Feature as their &lt;code>featureInverted&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1623178871691_362762_174" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1623178871691_202733_175" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1623178854940_222552_161" name="A_invertingFeature_invertedFeatureInverting" visibility="public" memberEnd="_19_0_4_b9102da_1623178854941_627588_162 _19_0_4_b9102da_1623178854941_692000_163">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1623178854941_692000_163" name="invertedFeatureInverting" visibility="public" type="_19_0_4_b9102da_1623178487957_761743_77" subsettedProperty="_18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_4_b9102da_1623178854940_222552_161">
+          <ownedComment xmi:id="_19_0_4_b9102da_1623181251595_726667_314" annotatedElement="_19_0_4_b9102da_1623178854941_692000_163">
+            <body>&lt;p>The FeatureInvertings that identify this Feature as their &lt;code>invertingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1623178875794_728827_178" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1623178875795_130197_179" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1653567738670_491133_42" name="A_ownedFeatureInverting_owningFeature" visibility="public" memberEnd="_19_0_4_b9102da_1653567738671_359235_43 _19_0_4_b9102da_1653567738671_122613_44"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1661555161559_640609_254" name="A_ownedReferenceSubsetting_referencingFeature" visibility="public" memberEnd="_19_0_4_12e503d9_1661555161564_247405_255 _19_0_4_12e503d9_1661555161575_539076_256"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1661554793960_500657_60" name="ReferenceSubsetting" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1661874263250_395563_285" annotatedElement="_19_0_4_12e503d9_1661554793960_500657_60">
+          <body>&lt;p>&lt;code>ReferenceSubsetting&lt;/code> is a kind of &lt;code>Subsetting&lt;/code> in which the &lt;code>referencedFeature&lt;/code> is syntactically distinguished from other &lt;code>Features&lt;/code> subsetted by the &lt;code>referencingFeature&lt;/code>. &lt;code>ReferenceSubsetting&lt;/code> has the same semantics as &lt;code>Subsetting&lt;/code>, but the &lt;code>referencedFeature&lt;/code> may have a special purpose relative to the &lt;code>referencingFeature&lt;/code>. For instance, &lt;code>ReferenceSubsetting&lt;/code> is used to identify the &lt;code>relatedFeatures&lt;/code> of a &lt;code>Connector&lt;/code>.&lt;/p>
+
+&lt;p>&lt;code>ReferenceSubsetting&lt;/code> is always an &lt;code>ownedRelationship&lt;/code> of its &lt;code>referencingFeature&lt;/code>. A &lt;code>Feature&lt;/code> can have at most one &lt;code>ownedReferenceSubsetting&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_12e503d9_1661554816924_586417_85" general="_18_5_3_12e503d9_1533160651710_980688_42209"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1661555055089_291547_207" name="referencedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674961_393191_43181" association="_19_0_4_12e503d9_1661555055088_640511_206">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661874604902_985945_286" annotatedElement="_19_0_4_12e503d9_1661555055089_291547_207">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is referenced by the &lt;code>referencingFeature&lt;/code> of this &lt;code>ReferenceSubsetting&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661555076153_843182_217" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661555076165_665292_218" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1661555161575_539076_256" name="referencingFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674987_236250_43311 _18_5_3_12e503d9_1533160674967_140305_43206" association="_19_0_4_12e503d9_1661555161559_640609_254">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1663089822365_749435_633" annotatedElement="_19_0_4_12e503d9_1661555161575_539076_256">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that owns this &lt;code>ReferenceSubsetting&lt;/code> relationship, which is also its &lt;code>subsettingFeature&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661555214322_667547_271" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661555214332_569495_272" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1661555055088_640511_206" name="A_referencedFeature_referencing" visibility="public" memberEnd="_19_0_4_12e503d9_1661555055089_291547_207 _19_0_4_12e503d9_1661555055090_897357_208">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1661555055090_897357_208" name="referencing" visibility="public" type="_19_0_4_12e503d9_1661554793960_500657_60" subsettedProperty="_18_5_3_12e503d9_1533160674961_265412_43180" association="_19_0_4_12e503d9_1661555055088_640511_206">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661874657217_101706_287" annotatedElement="_19_0_4_12e503d9_1661555055090_897357_208">
+            <body>&lt;p>The &lt;code>ReferenceSubsetting&lt;/code> with a certain &lt;code>Feature&lt;/code> as the &lt;code>referencedFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661555127425_579783_225" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661555127430_467271_226" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_2022x_2_12e503d9_1715790852907_371270_18" name="A_featureTarget_baseFeature" visibility="public" memberEnd="_2022x_2_12e503d9_1715790852907_110671_19 _2022x_2_12e503d9_1715790852908_486233_20">
+        <ownedEnd xmi:id="_2022x_2_12e503d9_1715790852908_486233_20" name="baseFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" association="_2022x_2_12e503d9_1715790852907_371270_18">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735842613879_882950_107" annotatedElement="_2022x_2_12e503d9_1715790852908_486233_20">
+            <body>&lt;p>The &lt;code>Features&lt;/code> that identify a &lt;code>Feature&lt;/code> as their &lt;code>featureTarget&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedComment xmi:id="_2022x_2_12e503d9_1715807356038_988310_83">
+            <body>&lt;p>The &lt;code>Features&lt;/code> that are the same as or the &lt;code>chainedFeature&lt;/code> for a &lt;code>targetFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1715791042979_76487_48" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1715791042980_789914_49" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1689616916594_935780_276" name="A_ownedCrossSubsetting_crossingFeature" visibility="public" memberEnd="_19_0_4_b9102da_1689616916594_145818_277 _19_0_4_b9102da_1689616916594_477020_278"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1689616524877_169275_247" name="A_crossedFeature_crossSupersetting" visibility="public" memberEnd="_19_0_4_b9102da_1689616524877_131585_248 _19_0_4_b9102da_1689616524878_59087_249">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1689616524878_59087_249" name="crossSupersetting" visibility="public" type="_19_0_4_b9102da_1689616180239_998062_127" subsettedProperty="_18_5_3_12e503d9_1533160674961_265412_43180" association="_19_0_4_b9102da_1689616524877_169275_247">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720898630616_397391_82" annotatedElement="_19_0_4_b9102da_1689616524878_59087_249">
+            <body>&lt;p>The &lt;code>CrossSubsetting&lt;/code> with a certain &lt;code>Feature&lt;/code> as the &lt;code>crossedFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1689616763984_296639_258" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1689616763984_695925_259" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_b9102da_1689616227528_569877_217" name="A_crossFeature_featureCrossing" visibility="public" memberEnd="_19_0_4_b9102da_1689616227528_355910_218 _19_0_4_b9102da_1689616227528_956348_219">
+        <ownedEnd xmi:id="_19_0_4_b9102da_1689616227528_956348_219" name="featureCrossing" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" association="_19_0_4_b9102da_1689616227528_569877_217">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720898674362_23773_83" annotatedElement="_19_0_4_b9102da_1689616227528_956348_219">
+            <body>&lt;p>The &lt;code>Features&lt;/code> with a certain other &lt;code>Feature&lt;/code> as the &lt;code>crossFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1720811229270_598172_8" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1720811229271_786329_9" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_b9102da_1689616180239_998062_127" name="CrossSubsetting" visibility="public">
+        <ownedComment xmi:id="_2022x_2_12e503d9_1720811178851_262962_5" annotatedElement="_19_0_4_b9102da_1689616180239_998062_127">
+          <body>&lt;p>&lt;code>CrossSubsetting&lt;/code> is a kind of &lt;code>Subsetting&lt;/code> for end &lt;code>Features&lt;/code>, as identified by &lt;code>crossingFeature&lt;/code>, to subset a chained &lt;code>Feature&lt;/code>, identified by &lt;code>crossedFeature.&lt;/code> It navigates to instances of the end &lt;code>Feature&lt;/code>’s type from instances of other end &lt;code>Feature&lt;/code> types on the same &lt;code>owningType&lt;/code> (at least two end &lt;code>Features&lt;/code> are required for any of them to have a &lt;code>CrossSubsetting&lt;/code>).&lt;/p>
+
+&lt;p>The &lt;code>crossedFeature&lt;/code> of a &lt;code>CrossSubsetting&lt;/code> must have a feature chain of exactly two &lt;code>Features&lt;/code>. The second &lt;code>Feature&lt;/code> in the chain is the &lt;code>crossFeature&lt;/code> of the &lt;code>crossingFeature&lt;/code> (end &lt;code>Feature&lt;/code>), which has the same type as the &lt;code>crossingFeature&lt;/code>. When the &lt;code>owningType&lt;/code> of the &lt;code>crossingFeature&lt;/code> has exactly two end &lt;code>Features&lt;/code>, the first &lt;code>Feature&lt;/code> in the chain of the &lt;code>crossedFeature&lt;/code> is the other end &lt;code>Feature&lt;/code>. The &lt;code>crossFeature&lt;/code>’s &lt;code>featuringType&lt;/code> in this case is the other end &lt;code>Feature&lt;/code>. When the &lt;code>owningType&lt;/code> has more than two end &lt;code>Features&lt;/code>, the first &lt;code>Feature&lt;/code> in the chain is a &lt;code>Feature&lt;/code> that &lt;code>CrossMultiplies&lt;/code> all the other end &lt;code>Features&lt;/code>, which is also the &lt;code>featuringType&lt;/code> of the &lt;code>crossFeature&lt;/code>.&lt;/p>
+
+&lt;p>A &lt;code>crossFeature&lt;/code> must be owned by its &lt;code>featureCrossing&lt;/code> (end &lt;code>Feature&lt;/code>) when the &lt;code>featureCrossing&lt;/code> &lt;code>owningType&lt;/code> has more than two end &lt;code>Features&lt;/code>. Otherwise, for exactly two end &lt;code>Features&lt;/code>, the &lt;code>crossFeatures&lt;/code> of each the ends can instead optionally be inherited by the other end from one of its &lt;code>types&lt;/code> or a subsetted &lt;code>Feature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1720820552698_216052_58" name="validateCrossSubsettingCrossedFeature" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720820742810_914031_63" annotatedElement="_2022x_2_12e503d9_1720820552698_216052_58">
+            <body>&lt;p>The &lt;code>crossedFeature&lt;/code> of a &lt;code>CrossSubsetting&lt;/code> must have exactly two &lt;code>chainingFeatures&lt;/code>. If the &lt;code>crossingFeature&lt;/code> of the &lt;code>CrossSubsetting&lt;/code> is one of two end &lt;code>Features&lt;/code>, then the first &lt;code>chainingFeature&lt;/code> must be the other end &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1720820552700_159585_59" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>crossingFeature.isEnd and crossingFeature.owningType &lt;> null implies
+    let endFeatures: Sequence(Feature) = crossingFeature.owningType.endFeature in
+    let chainingFeatures: Sequence(Feature) = crossedFeature.chainingFeature in
+    chainingFeatures->size() = 2 and
+    endFeatures->size() = 2 implies 
+        chainingFeatures->at(1) = endFeatures->excluding(crossingFeature)->at(1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1720820616468_213938_60" name="validateCrossSubsettingCrossingFeature" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720820690846_785089_62" annotatedElement="_2022x_2_12e503d9_1720820616468_213938_60">
+            <body>&lt;p>The &lt;code>crossingFeature&lt;/code> of a &lt;code>CrossSubsetting&lt;/code> must be an end &lt;code>Feature&lt;/code> that is owned by a &lt;code>Type&lt;/code> with at least two end &lt;code>Features&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1720820616469_709381_61" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>crossingFeature.isEnd and
+crossingFeature.owningType&lt;>null and
+crossingFeature.owningType.endFeature ->size() > 1</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_b9102da_1689616194994_163253_152" general="_18_5_3_12e503d9_1533160651710_980688_42209"/>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1689616524877_131585_248" name="crossedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" redefinedProperty="_18_5_3_12e503d9_1533160674961_393191_43181" association="_19_0_4_b9102da_1689616524877_169275_247">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720818628964_301011_48" annotatedElement="_19_0_4_b9102da_1689616524877_131585_248">
+            <body>&lt;p>The chained &lt;code>Feature&lt;/code> that is cross subset by the &lt;code>crossingFeature&lt;/code> of this &lt;code>CrossSubsetting&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1689616819094_688132_264" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1689616819094_60864_265" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_b9102da_1689616916594_477020_278" name="crossingFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674987_236250_43311 _18_5_3_12e503d9_1533160674967_140305_43206" association="_19_0_4_b9102da_1689616916594_935780_276">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720818718520_112140_49" annotatedElement="_19_0_4_b9102da_1689616916594_477020_278">
+            <body>&lt;p>The end &lt;code>Feature&lt;/code> that owns this &lt;code>CrossSubsetting&lt;/code> relationship and is also its &lt;/code>subsettingFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_b9102da_1689616942453_593869_285" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_b9102da_1689616942454_95640_286" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1561108539241_462450_22354" name="Kernel" visibility="public" URI="">
+    <ownedComment xmi:id="_19_0_4_12e503d9_1597675032114_61882_912" annotatedElement="_18_5_3_12e503d9_1561108539241_462450_22354">
+      <body>The Kernel layer completes the KerML metamodel.</body>
+    </ownedComment>
+    <packageImport xmi:id="_19_0_4_12e503d9_1597674761459_723579_884" importedPackage="_18_5_3_12e503d9_1561108524767_843573_22341"/>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_b9102da_1540928550627_934738_16593" name="Interactions" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_b9102da_1536870573474_844688_18040" name="A_targetInputFeature_flowToInput" visibility="public" memberEnd="_18_5_3_b9102da_1536870573474_966268_18041 _18_5_3_b9102da_1536870573474_720155_18042">
+        <ownedEnd xmi:id="_18_5_3_b9102da_1536870573474_720155_18042" name="flowToInput" visibility="public" type="_18_5_3_b9102da_1536869417406_861526_17744" isDerived="true" association="_18_5_3_b9102da_1536870573474_844688_18040">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1619905678224_93665_59" annotatedElement="_18_5_3_b9102da_1536870573474_720155_18042">
+            <body>&lt;p>The ItemFlow that has a certain &lt;code>targetInputFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1619905609258_832022_48" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1619905609259_22922_49" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_b9102da_1536869417406_861526_17744" name="Flow" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1586211558706_855611_408" annotatedElement="_18_5_3_b9102da_1536869417406_861526_17744">
+          <body>&lt;p>An &lt;code>Flow&lt;/code> is a &lt;code>Step&lt;/code> that represents the transfer of values from one &lt;code>Feature&lt;/code> to another. &lt;code>Flows&lt;/code> can take non-zero time to complete.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667786608493_956029_2220" name="checkFlowSpecialization" visibility="public" constrainedElement="_18_5_3_b9102da_1536869417406_861526_17744">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669848323071_524197_261" annotatedElement="_19_0_4_12e503d9_1667786608493_956029_2220">
+            <body>&lt;p>A &lt;code>Flow&lt;/code> must directly or indirectly specialize the &lt;code>Step&lt;/code> &lt;code>&lt;em>Transfers::transfers&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667786608503_254347_2221" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Transfers::transfers')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676520368600_796509_511" name="deriveFlowPayloadType" visibility="public" constrainedElement="_18_5_3_b9102da_1536869417406_861526_17744">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676520514178_510041_513" annotatedElement="_19_0_4_12e503d9_1676520368600_796509_511">
+            <body>&lt;p>The &lt;code>payloadTypes&lt;/code> of a &lt;code>Flow&lt;/code> are the &lt;code>types&lt;/code> of the &lt;code>payloadFeature&lt;/code> of the &lt;code>Flow&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676520368632_32448_512" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>payloadType =
+    if payloadFeature = null then Sequence{}
+    else payloadFeature.type
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676521675879_309709_516" name="deriveFlowSourceOutputFeature" visibility="public" constrainedElement="_18_5_3_b9102da_1536869417406_861526_17744">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676521865426_745445_518" annotatedElement="_19_0_4_12e503d9_1676521675879_309709_516">
+            <body>&lt;p>The &lt;code>sourceOutputFeature&lt;/code> of a &lt;code>Flow&lt;/code> is the first &lt;code>ownedFeature&lt;/code> of the first &lt;code>connectorEnd&lt;/code> of the &lt;code>Flow&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676521675896_764583_517" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>sourceOutputFeature =
+    if connectorEnd->isEmpty() or 
+        connectorEnd.ownedFeature->isEmpty()
+    then null
+    else connectorEnd.ownedFeature->first()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676521881951_803666_519" name="deriveFlowTargetInputFeature" visibility="public" constrainedElement="_18_5_3_b9102da_1536869417406_861526_17744">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676521881971_622184_521" annotatedElement="_19_0_4_12e503d9_1676521881951_803666_519">
+            <body>&lt;p>The &lt;code>targetInputFeature&lt;/code> of a &lt;code>Flow&lt;/code> is the first &lt;code>ownedFeature&lt;/code> of the second &lt;code>connectorEnd&lt;/code> of the &lt;code>Flow&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676521881966_243787_520" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>targetInputFeature =
+    if connectorEnd->size() &lt; 2 or 
+        connectorEnd->at(2).ownedFeature->isEmpty()
+    then null
+    else connectorEnd->at(2).ownedFeature->first()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676522004917_143085_522" name="deriveFlowFlowEnd" visibility="public" constrainedElement="_18_5_3_b9102da_1536869417406_861526_17744">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676522113603_251569_524" annotatedElement="_19_0_4_12e503d9_1676522004917_143085_522">
+            <body>&lt;p>The &lt;code>flowEnds&lt;/code> of a &lt;code>Flow&lt;/code> are all its &lt;code>connectorEnds&lt;/code> that are &lt;code>FlowEnds&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676522004935_533946_523" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>flowEnd = connectorEnd->selectByKind(FlowEnd)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676522136487_231634_525" name="deriveFlowPayloadFeature" visibility="public" constrainedElement="_18_5_3_b9102da_1536869417406_861526_17744">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676522328797_487033_527" annotatedElement="_19_0_4_12e503d9_1676522136487_231634_525">
+            <body>&lt;p>The &lt;code>payloadFeature&lt;/code> of a &lt;code>Flow&lt;/code> is the single one of its &lt;code>ownedFeatures&lt;/code> that is a &lt;code>PayloadFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676522136496_866850_526" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>payloadFeature =
+    let payloadFeatures : Sequence(PayloadFeature) =
+        ownedFeature->selectByKind(PayloadFeature) in
+    if payloadFeatures->isEmpty() then null
+    else payloadFeatures->first()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676522345970_208105_528" name="validateFlowPayloadFeature" visibility="public" constrainedElement="_18_5_3_b9102da_1536869417406_861526_17744">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676522479617_175835_530" annotatedElement="_19_0_4_12e503d9_1676522345970_208105_528">
+            <body>&lt;p>A &lt;code>Flow&lt;/code> must have at most one &lt;code>ownedFeature&lt;/code> that is an &lt;code>PayloadFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676522345980_86720_529" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedFeature->selectByKind(PayloadFeature)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740174995892_91138_33" name="checkFlowWithEndsSpecialization" visibility="public" constrainedElement="_18_5_3_b9102da_1536869417406_861526_17744">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740175067755_790234_35" annotatedElement="_2022x_2_12e503d9_1740174995892_91138_33">
+            <body>&lt;p>A &lt;code>Flow&lt;/code> with &lt;code>ownedEndFeatures&lt;/code> must specialize the &lt;code>Step&lt;/code> &lt;code>&lt;em>Transfers::flowTransfers&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740174995893_608561_34" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedEndFeatures->notEmpty() implies
+    specializesFromLibrary('Transfers::flowTransfers')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_b9102da_1536869426707_78234_17772" general="_18_5_3_12e503d9_1533160651698_598377_42185"/>
+        <generalization xmi:id="_18_5_3_b9102da_1540395863817_112871_16872" general="_18_5_3_b9102da_1536345916995_711141_17306"/>
+        <ownedAttribute xmi:id="_18_5_3_b9102da_1536870569046_1672_18020" name="payloadType" visibility="public" type="_18_5_3_12e503d9_1533160651676_375105_42143" isOrdered="true" isUnique="false" isDerived="true" association="_18_5_3_b9102da_1536870569045_136097_18019">
+          <ownedComment xmi:id="_19_0_2_59601fc_1585936067102_738148_218" annotatedElement="_18_5_3_b9102da_1536870569046_1672_18020">
+            <body>&lt;p>The type of values transferred, which is the &lt;code>type&lt;/code> of the &lt;code>payloadFeature&lt;/code> of the &lt;code>Flow&lt;/code>.&lt;/p>
+
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_b9102da_1536870994165_545914_18129" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_b9102da_1536870994166_959422_18130" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_b9102da_1536870573474_966268_18041" name="targetInputFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isUnique="false" isDerived="true" association="_18_5_3_b9102da_1536870573474_844688_18040">
+          <ownedComment xmi:id="_19_0_2_59601fc_1585936026581_756163_213" annotatedElement="_18_5_3_b9102da_1536870573474_966268_18041">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that receives the values carried by the &lt;code>Flow&lt;/code>. It must be a &lt;code>feature&lt;/code> of the &lt;code>target&lt;/code> of the &lt;code>Flow&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_b9102da_1536870658049_717048_18075" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_b9102da_1536870658050_361429_18076" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_b9102da_1536870707078_57525_18088" name="sourceOutputFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isUnique="false" isDerived="true" association="_18_5_3_b9102da_1536870707078_432932_18087">
+          <ownedComment xmi:id="_19_0_2_59601fc_1585936038114_949727_214" annotatedElement="_18_5_3_b9102da_1536870707078_57525_18088">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that provides the items carried by the &lt;code>Flow&lt;/code>. It must be a &lt;code>feature&lt;/code> of the &lt;code>source&lt;/code> of the &lt;code>Flow&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_b9102da_1536870738353_732026_18110" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_b9102da_1536870738354_480077_18111" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1563219311176_506548_20966" name="flowEnd" visibility="public" type="_18_5_3_12e503d9_1563219035000_53223_20571" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1556735067666_827798_21922" association="_18_5_3_12e503d9_1563219311175_360909_20965">
+          <ownedComment xmi:id="_19_0_2_59601fc_1585936081381_148337_220" annotatedElement="_18_5_3_12e503d9_1563219311176_506548_20966">
+            <body>&lt;p>The &lt;code>connectorEnds&lt;/code> of this &lt;code>Flow&lt;/code> that are &lt;code>FlowEnds&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1563219335432_755312_21006" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1563219335433_657482_21007" name="" visibility="public" value="2"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1563219424870_347345_21142" name="payloadFeature" visibility="public" type="_18_5_3_12e503d9_1563219020686_897240_20518" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674959_226999_43167" association="_18_5_3_12e503d9_1563219424870_945729_21141">
+          <ownedComment xmi:id="_19_0_2_59601fc_1585936088626_618135_221" annotatedElement="_18_5_3_12e503d9_1563219424870_347345_21142">
+            <body>&lt;p>The &lt;code>ownedFeature&lt;/code> of the &lt;code>Flow&lt;/code> that is a &lt;code>PayloadFeature&lt;/code> (if any).&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1563219451416_116737_21174" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1563219451417_683016_21175" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1661900477937_518125_727" name="interaction" visibility="public" type="_18_5_3_b9102da_1536782424772_574530_21292" isOrdered="true" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674983_471497_43284 _18_5_3_b9102da_1536346315176_954314_17388" association="_19_0_4_12e503d9_1661900477933_581560_726">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661900917602_165719_880" annotatedElement="_19_0_4_12e503d9_1661900477937_518125_727">
+            <body>&lt;p>The &lt;code>Interactions&lt;/code> that type this &lt;code>Flow&lt;/code>. &lt;code>Interactions&lt;/code> are both &lt;code>Associations&lt;/code> and &lt;code>Behaviors&lt;/code>, which can type &lt;code>Connectors&lt;/code> and &lt;code>Steps&lt;/code>, respectively.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661900494432_501813_737" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661900494435_256232_738" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_b9102da_1536870569045_136097_18019" name="A_payloadType_flowForPayloadType" visibility="public" memberEnd="_18_5_3_b9102da_1536870569046_1672_18020 _18_5_3_b9102da_1536870569046_846283_18021">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1619905686830_466749_60" annotatedElement="_18_5_3_b9102da_1536870569045_136097_18019">
+          <body>&lt;p>The ItemFlow that has a certain &lt;code>itemType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedEnd xmi:id="_18_5_3_b9102da_1536870569046_846283_18021" name="flowForPayloadType" visibility="public" type="_18_5_3_b9102da_1536869417406_861526_17744" isDerived="true" association="_18_5_3_b9102da_1536870569045_136097_18019">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1619905630426_918858_54" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1619905630427_722309_55" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_b9102da_1536869794875_359922_17902" name="SuccessionFlow" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1585936276240_372209_240" annotatedElement="_18_5_3_b9102da_1536869794875_359922_17902">
+          <body>&lt;p>A &lt;code>SuccessionFlow&lt;/code> is a &lt;code>Flow&lt;/code> that also provides temporal ordering. It classifies &lt;code>&lt;em>Transfers&lt;/em>&lt;/code> that cannot start until the source &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> has completed and that must complete before the target &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> can start.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667786659284_263611_2222" name="checkSuccessionFlowSpecialization" visibility="public" constrainedElement="_18_5_3_b9102da_1536869794875_359922_17902">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669849133817_624034_262" annotatedElement="_19_0_4_12e503d9_1667786659284_263611_2222">
+            <body>&lt;p>A &lt;code>SuccessionFlow&lt;/code> must directly or indirectly specialize the &lt;code>Step&lt;/code> &lt;code>&lt;em>Transfers::flowTransfersBefore&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667786659289_297086_2223" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Transfers::flowTransfersBefore')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_b9102da_1536869820902_976674_17933" general="_18_5_3_71301a1_1536100248189_622183_16479"/>
+        <generalization xmi:id="_18_5_3_b9102da_1536869809008_685208_17930" general="_18_5_3_b9102da_1536869417406_861526_17744"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_b9102da_1536870707078_432932_18087" name="A_sourceOutputFeature_flowFromOutput" visibility="public" memberEnd="_18_5_3_b9102da_1536870707078_57525_18088 _18_5_3_b9102da_1536870707079_595957_18089">
+        <ownedEnd xmi:id="_18_5_3_b9102da_1536870707079_595957_18089" name="flowFromOutput" visibility="public" type="_18_5_3_b9102da_1536869417406_861526_17744" isDerived="true" association="_18_5_3_b9102da_1536870707078_432932_18087">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1619905666821_394156_58" annotatedElement="_18_5_3_b9102da_1536870707079_595957_18089">
+            <body>&lt;p>The ItemFlow that has a certain &lt;code>sourceOutputFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1619905589056_769670_42" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1619905589057_204571_43" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1563219311175_360909_20965" name="A_flowEnd_featuringFlow" visibility="public" memberEnd="_18_5_3_12e503d9_1563219311176_506548_20966 _18_5_3_12e503d9_1563219311176_810249_20967">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1563219311176_810249_20967" name="featuringFlow" visibility="public" type="_18_5_3_b9102da_1536869417406_861526_17744" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1556735067667_716674_21923" association="_18_5_3_12e503d9_1563219311175_360909_20965">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1734383336807_375557_317" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1734383336807_35614_318" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1563219424870_945729_21141" name="A_payloadFeature_flowWithPayloadFeature" visibility="public" memberEnd="_18_5_3_12e503d9_1563219424870_347345_21142 _18_5_3_12e503d9_1563219424871_731860_21143">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1563219424871_731860_21143" name="flowWithPayloadFeature" visibility="public" type="_18_5_3_b9102da_1536869417406_861526_17744" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674965_592215_43200" association="_18_5_3_12e503d9_1563219424870_945729_21141">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1734383239925_167536_275" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1734383239925_78122_276" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_b9102da_1536782424772_574530_21292" name="Interaction" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1585936194835_397791_229" annotatedElement="_18_5_3_b9102da_1536782424772_574530_21292">
+          <body>&lt;p>An &lt;code>Interaction&lt;/code> is a &lt;code>Behavior&lt;/code> that is also an &lt;code>Association&lt;/code>, providing a context for multiple objects that have behaviors that impact one another.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_18_5_3_b9102da_1536782450921_895921_21320" general="_18_5_3_12e503d9_1533160651709_376789_42207"/>
+        <generalization xmi:id="_18_5_3_b9102da_1536782453696_458937_21323" general="_18_5_3_12e503d9_1533160651716_116234_42240"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1661900477933_581560_726" name="A_interaction_typedFlow" visibility="public" memberEnd="_19_0_4_12e503d9_1661900477937_518125_727 _19_0_4_12e503d9_1661900477942_246120_728">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1661900477942_246120_728" name="typedFlow" visibility="public" type="_18_5_3_b9102da_1536869417406_861526_17744" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674995_282523_43352 _18_5_3_b9102da_1536346315176_644912_17389" association="_19_0_4_12e503d9_1661900477933_581560_726">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1734383111530_685900_205" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1734383111531_996991_206" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1563219020686_897240_20518" name="PayloadFeature" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1667061132290_841391_2892" annotatedElement="_18_5_3_12e503d9_1563219020686_897240_20518">
+          <body>&lt;p>A &lt;code>PayloadFeature&lt;/code> is the &lt;code>ownedFeature&lt;/code> of a &lt;code>Flow&lt;/code> that identifies the things carried by the kinds of transfers that are instances of the &lt;code>Flow&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667786849968_285710_2224" name="checkPayloadFeatureRedefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1563219020686_897240_20518">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671164586185_982202_101321" annotatedElement="_19_0_4_12e503d9_1667786849968_285710_2224">
+            <body>&lt;p>A &lt;code>PayloadFeature&lt;/code> must redefine the &lt;code>Feature&lt;/code> &lt;code>&lt;em>Transfers::Transfer::payload&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667786849992_733756_2225" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>redefinesFromLibrary('Transfers::Transfer::payload')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1563219030206_829747_20560" general="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1563219035000_53223_20571" name="FlowEnd" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1667060892812_513507_2877" annotatedElement="_18_5_3_12e503d9_1563219035000_53223_20571">
+          <body>&lt;p>A &lt;code>FlowEnd&lt;/code> is a &lt;code>Feature&lt;/code> that is one of the &lt;code>connectorEnds&lt;/code> giving the &lt;code>&lt;em>source&lt;/em>&lt;/code> or &lt;code>&lt;em>target&lt;/em>&lt;/code> of a &lt;code>Flow&lt;/code>. For &lt;code>Flows&lt;/code> typed by &lt;code>&lt;em>FlowTransfer&lt;/em>&lt;/code> or its specializations, &lt;code>FlowEnds&lt;/code> must have exactly one &lt;code>ownedFeature&lt;/code>, which redefines &lt;code>&lt;em>Transfer::source::sourceOutput&lt;/em>&lt;/code> or &lt;code>&lt;em>Transfer::target::targetInput&lt;/em>&lt;/code> and redefines the corresponding feature of the &lt;code>relatedElement&lt;/code> for its end.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676522702464_195140_531" name="validateFlowEndIsEnd" visibility="public" constrainedElement="_18_5_3_12e503d9_1563219035000_53223_20571">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676522763162_94099_533" annotatedElement="_19_0_4_12e503d9_1676522702464_195140_531">
+            <body>&lt;p>A &lt;code>FlowEnd&lt;/code> must be an end &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676522702480_223219_532" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isEnd</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676522802627_798191_534" name="validateFlowEndNestedFeature" visibility="public" constrainedElement="_18_5_3_12e503d9_1563219035000_53223_20571">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676522876611_14787_536" annotatedElement="_19_0_4_12e503d9_1676522802627_798191_534">
+            <body>&lt;p>A &lt;code>FlowEnd&lt;/code> must have exactly one &lt;code>ownedFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676522802638_364186_535" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedFeature->size() = 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676522891333_534509_537" name="validateFlowEndOwningType" visibility="public" constrainedElement="_18_5_3_12e503d9_1563219035000_53223_20571">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676522993584_780448_539" annotatedElement="_19_0_4_12e503d9_1676522891333_534509_537">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>FlowEnd&lt;/code> must be a &lt;code>Flow&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676522891341_147560_538" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and owningType.oclIsKindOf(Flow)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1563219055881_493245_20619" general="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_4_12e503d9_1606345469193_253210_78" name="Packages" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1665457931502_349175_779" name="LibraryPackage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1665458106407_999826_808" annotatedElement="_19_0_4_12e503d9_1665457931502_349175_779">
+          <body>&lt;p>A &lt;code>LibraryPackage&lt;/code> is a &lt;code>Package&lt;/code> that is the container for a model library. A &lt;code>LibraryPackage&lt;/code> is itself a library &lt;code>Element&lt;/code> as are all &lt;code>Elements&lt;/code> that are directly or indirectly contained in it.&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_12e503d9_1665457950860_738400_804" general="_19_0_4_12e503d9_1606943754976_445656_5532"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1665459011301_65344_899" name="isStandard" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665459098556_785056_908" annotatedElement="_19_0_4_12e503d9_1665459011301_65344_899">
+            <body>&lt;p>Whether this &lt;code>LibraryPackage&lt;/code> contains a standard library model. This should only be set to true for &lt;code>LibraryPackages&lt;/code> in the standard Kernel Model Libraries or in normative model libraries for a language built on KerML.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1665459026582_736805_903" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665457962189_992477_805" name="libraryNamespace" visibility="public" bodyCondition="_19_0_4_12e503d9_1665458161668_493515_810" redefinedOperation="_19_0_4_12e503d9_1665443526567_946990_725">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665458139029_834223_809" annotatedElement="_19_0_4_12e503d9_1665457962189_992477_805">
+            <body>&lt;p>The &lt;code>libraryNamespace&lt;/code> for a &lt;code>LibraryPackage&lt;/code> is itself.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665458161668_493515_810" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665458161690_709062_811" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>self</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665524241735_51882_1953" name="" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665527222121_444817_2191" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665527222124_271065_2192" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1605760960644_813844_5877" name="ElementFilterMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1606944733623_452273_6098" annotatedElement="_19_0_4_12e503d9_1605760960644_813844_5877">
+          <body>&lt;p>&lt;code>ElementFilterMembership&lt;/code> is a &lt;code>Membership&lt;/code> between a &lt;code>Namespace&lt;/code> and a model-level evaluable &lt;code>&lt;em>Boolean&lt;/em>&lt;/code>-valued &lt;code>Expression&lt;/code>, asserting that imported &lt;code>members&lt;/code> of the &lt;code>Namespace&lt;/code> should be filtered using the &lt;code>condition&lt;/code> &lt;code>Expression&lt;/code>. A general &lt;code>Namespace&lt;/code> does not define any specific filtering behavior, but such behavior may be defined for various specialized kinds of &lt;code>Namespaces&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1609977362305_660250_1799" name="validateElementFilterMembershipConditionIsModelLevelEvaluable" visibility="public" constrainedElement="_19_0_4_12e503d9_1605760960644_813844_5877">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609977435404_608189_1801" annotatedElement="_19_0_4_12e503d9_1609977362305_660250_1799">
+            <body>&lt;p>The &lt;code>condition&lt;/code> &lt;code>Expression&lt;/code> must be model-level evaluable.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1609977362306_92322_1800" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>condition.isModelLevelEvaluable</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1609977466991_385250_1802" name="validateElementFilterMembershipConditionIsBoolean" visibility="public" constrainedElement="_19_0_4_12e503d9_1605760960644_813844_5877">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609977731247_393471_1804" annotatedElement="_19_0_4_12e503d9_1609977466991_385250_1802">
+            <body>&lt;p>The &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>condition&lt;/code> &lt;code>Expression&lt;/code> must directly or indirectly specialize &lt;code>&lt;em>ScalarValues::Boolean&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1609977466991_183109_1803" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>condition.result.specializesFromLibrary('ScalarValues::Boolean')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1605761059117_504971_6006" general="_19_0_4_12e503d9_1648180804650_933390_31"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1605762464250_876969_157" name="condition" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" aggregation="composite" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674965_501750_43196" association="_19_0_4_12e503d9_1605762464249_806349_156">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606945155397_658252_6104" annotatedElement="_19_0_4_12e503d9_1605762464250_876969_157">
+            <body>&lt;p>The model-level evaluable &lt;code>Boolean&lt;/code>-valued &lt;code>Expression&lt;/code> used to filter the imported &lt;code>members&lt;/code> of the &lt;code>membershipOwningNamespace&lt;/code> of this &lt;code>ElementFilterMembership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1605763197568_454979_478" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1605763197569_947021_479" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1607033896050_754536_6205" name="A_filterCondition_conditionedPackage" visibility="public" memberEnd="_19_0_4_12e503d9_1607033896050_867332_6206 _19_0_4_12e503d9_1607033896050_245369_6207">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1607033896050_245369_6207" name="conditionedPackage" visibility="public" type="_19_0_4_12e503d9_1606943754976_445656_5532" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674986_474739_43306" association="_19_0_4_12e503d9_1607033896050_754536_6205">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607034085459_935941_6227" annotatedElement="_19_0_4_12e503d9_1607033896050_245369_6207">
+            <body>&lt;p>The Package that has a certain Expression as a &lt;code>filterCondition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1607034038209_440249_6223" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1607034038209_376717_6224" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1606943754976_445656_5532" name="Package" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1606944660867_301648_6097" annotatedElement="_19_0_4_12e503d9_1606943754976_445656_5532">
+          <body>&lt;p>A &lt;code>Package&lt;/code> is a &lt;code>Namespace&lt;/code> used to group &lt;code>Elements&lt;/code>, without any instance-level semantics. It may have one or more model-level evaluable &lt;code>filterCondition&lt;/code> &lt;code>Expressions&lt;/code> used to filter its &lt;code>importedMemberships&lt;/code>. Any imported &lt;code>member&lt;/code> must meet all of the &lt;code>filterConditions&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676526686767_701915_583" name="derivePackageFilterCondition" visibility="public" constrainedElement="_19_0_4_12e503d9_1606943754976_445656_5532">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676526859601_315367_585" annotatedElement="_19_0_4_12e503d9_1676526686767_701915_583">
+            <body>&lt;p>The &lt;code>filterConditions&lt;/code> of a &lt;code>Package&lt;/code> are the &lt;code>conditions&lt;/code> of its owned &lt;code>ElementFilterMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676526686778_546839_584" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>filterCondition = ownedMembership->
+    selectByKind(ElementFilterMembership).condition</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1605761929878_914190_6391" general="_18_5_3_12e503d9_1533160651694_110063_42176"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1607033896050_867332_6206" name="filterCondition" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_259543_43268" association="_19_0_4_12e503d9_1607033896050_754536_6205">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607033966342_218198_6220" annotatedElement="_19_0_4_12e503d9_1607033896050_867332_6206">
+            <body>&lt;p>The model-level evaluable &lt;code>&lt;em>Boolean&lt;/em>&lt;/code>-valued &lt;code>Expression&lt;/code> used to filter the &lt;code>members&lt;/code> of this &lt;code>Package&lt;/code>, which are owned by the &lt;code>Package&lt;/code> are via &lt;code>ElementFilterMemberships&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1607033918469_391395_6216" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1607033918469_115646_6217" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1606943801860_729452_5555" name="importedMemberships" visibility="public" bodyCondition="_19_0_4_12e503d9_1609978188762_983273_1810" redefinedOperation="_19_0_4_12e503d9_1606943219472_311375_5504">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606944255984_812657_6094" annotatedElement="_19_0_4_12e503d9_1606943801860_729452_5555">
+            <body>&lt;p>Exclude &lt;code>Elements&lt;/code> that do not meet all the &lt;code>filterConditions&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1609978188762_983273_1810" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1609978188762_129554_1811" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>self.oclAsType(Namespace).importedMemberships(excluded)->
+    select(m | self.includeAsMember(m.memberElement))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1619111945098_688654_5463" name="excluded" visibility="public" type="_18_5_3_12e503d9_1533160651694_110063_42176">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1619111945320_392917_5464" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1619111945323_973272_5465" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1606943849705_367474_5559" name="" visibility="public" type="_18_5_3_12e503d9_1533160651680_888716_42152" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606943849839_989131_5560" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606943849840_307547_5561" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1609977831017_515945_1805" name="includeAsMember" visibility="public" bodyCondition="_19_0_4_12e503d9_1610036968391_215939_1834">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609978076129_216591_1809" annotatedElement="_19_0_4_12e503d9_1609977831017_515945_1805">
+            <body>&lt;p>Determine whether the given &lt;code>element&lt;/code> meets all the &lt;code>filterConditions&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1610036968391_215939_1834" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1610036968391_487897_1835" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let metadataFeatures: Sequence(AnnotatingElement) = 
+    element.ownedAnnotation.annotatingElement->
+        selectByKind(MetadataFeature) in
+    self.filterCondition->forAll(cond | 
+        metadataFeatures->exists(elem | 
+            cond.checkCondition(elem)))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609977912929_723280_1807" name="element" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609977912933_223660_1808" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1605762464249_806349_156" name="A_condition_owningFilter" visibility="public" memberEnd="_19_0_4_12e503d9_1605762464250_876969_157 _19_0_4_12e503d9_1605762464252_980118_158">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1605762464252_980118_158" name="owningFilter" visibility="public" type="_19_0_4_12e503d9_1605760960644_813844_5877" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674972_622493_43236" association="_19_0_4_12e503d9_1605762464249_806349_156">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606945195997_684690_6105" annotatedElement="_19_0_4_12e503d9_1605762464252_980118_158">
+            <body>&lt;p>The ElementFilterMembership that owns the &lt;code>condition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1605762711107_575493_293" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1605762711108_606595_294" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_4_12e503d9_1660170826700_866325_973" name="Classes" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1557527582956_258352_110280" name="Class" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1583533449287_872583_439" annotatedElement="_18_5_3_12e503d9_1557527582956_258352_110280">
+          <body>&lt;p>A &lt;code>Class&lt;/code> is a &lt;code>Classifier&lt;/code> of things (in the universe) that can be distinguished without regard to how they are related to other things (via &lt;code>Features&lt;/code>). This means multiple things classified by the same &lt;code>Class&lt;/code> can be distinguished, even when they are related other things in exactly the same way.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_b9102da_1610037848369_188506_1242" name="checkClassSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1557527582956_258352_110280">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1667164416645_650725_85" annotatedElement="_19_0_4_b9102da_1610037848369_188506_1242">
+            <body>&lt;p>A &lt;code>Class&lt;/code> must directly or indirectly specialize the base &lt;code>Class&lt;/code> &lt;code>&lt;em>Occurrences::Occurrence&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1610037848369_862100_1243" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Occurrences::Occurrence')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1660171458394_145568_1637" name="validateClassSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1557527582956_258352_110280">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1660171531444_169856_1639" annotatedElement="_19_0_4_12e503d9_1660171458394_145568_1637">
+            <body>&lt;p>A &lt;code>Class&lt;/code> must not specialize a &lt;code>DataType&lt;/code> and it can only specialize an &lt;code>Association&lt;/code> if it is also itself a kind of &lt;code>Association&lt;/code> (such as an &lt;code>AssociationStructure&lt;/code> or &lt;code>Interaction&lt;/code>).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1660171458402_69835_1638" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedSpecialization.general->
+    forAll(not oclIsKindOf(DataType)) and
+not oclIsKindOf(Association) implies
+    ownedSpecialization.general->
+        forAll(not oclIsKindOf(Association))</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1557527614841_708835_110372" general="_18_5_3_12e503d9_1533160651676_375105_42143"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_71301a1_1536098696655_507867_17210" name="Expressions" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651699_96836_42187" name="LiteralBoolean" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1585936206027_991934_231" annotatedElement="_18_5_3_12e503d9_1533160651699_96836_42187">
+          <body>&lt;p>&lt;code>LiteralBoolean&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides a &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have type &lt;code>&lt;em>Boolean&lt;/em>&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695238988903_265318_45" name="checkLiteralBooleanSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651699_96836_42187">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1708886011171_886607_2" annotatedElement="_19_0_4_12e503d9_1695238988903_265318_45">
+            <body>&lt;p>A &lt;code>LiteralBoolean&lt;/code> must directly or indirectly specialize &lt;em>&lt;code>Performances::literalBooleanEvaluations&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695238988942_979790_46" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::literalBooleanEvaluations')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674972_21318_43237" general="_18_5_3_12e503d9_1533160651688_624289_42165"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674984_421338_43289" name="value" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1586211975239_455564_410" annotatedElement="_18_5_3_12e503d9_1533160674984_421338_43289">
+            <body>&lt;p>The &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> value that is the result of evaluating this &lt;code>LiteralBoolean&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_59601fc_1585935982459_631518_208" annotatedElement="_18_5_3_12e503d9_1533160674984_421338_43289">
+            <body>&lt;p>The Boolean value that is the result of evaluating this Expression.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651688_624289_42165" name="LiteralExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1585936211120_46036_232" annotatedElement="_18_5_3_12e503d9_1533160651688_624289_42165">
+          <body>&lt;p>A &lt;code>LiteralExpression&lt;/code> is an &lt;code>Expression&lt;/code> that provides a basic &lt;code>&lt;em>DataValue&lt;/em>&lt;/code> as a result.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1609974300294_434651_1691" name="deriveLiteralExpressionIsModelLevelEvaluable" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651688_624289_42165">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609974300296_996573_1693" annotatedElement="_19_0_4_12e503d9_1609974300294_434651_1691">
+            <body>&lt;p>A &lt;code>LiteralExpression&lt;/code> is always model-level evaluable.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1609974300296_605242_1692" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isModelLevelEvaluable = true</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1669847816809_705401_235" name="checkLiteralExpressionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651688_624289_42165">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847921207_949121_237" annotatedElement="_19_0_4_12e503d9_1669847816809_705401_235">
+            <body>&lt;p>A &lt;code>LiteralExpression&lt;/code> must directly or indirectly specialize the base &lt;code>LiteralExpression&lt;/code> &lt;code>&lt;em>Performances::literalEvaluations&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669847816825_164269_236" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::literalEvaluations')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1606348352860_998110_2832" general="_18_5_3_12e503d9_1533160651686_908654_42163"/>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665517677871_762920_1496" name="modelLevelEvaluable" visibility="public" bodyCondition="_19_0_4_12e503d9_1665517956995_133993_1678" redefinedOperation="_19_0_4_12e503d9_1665516752162_909455_1465">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665517677877_531583_1498" annotatedElement="_19_0_4_12e503d9_1665517677871_762920_1496">
+            <body>&lt;p>A &lt;code>LiteralExpression&lt;/code> is always model-level evaluable.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665517956995_133993_1678" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665517957004_404064_1679" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>true</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665517677876_139525_1497" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665611093597_642835_2654" name="visited" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665611093603_252011_2656" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665611093602_393187_2655" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1609972551460_69445_1294" name="evaluate" visibility="public" bodyCondition="_19_0_4_12e503d9_1609973620749_725300_1686" redefinedOperation="_19_0_4_12e503d9_1606345564739_966196_237">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609972551462_123505_1297" annotatedElement="_19_0_4_12e503d9_1609972551460_69445_1294">
+            <body>&lt;p>The model-level value of a &lt;code>LiteralExpression&lt;/code> is itself.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1609973620749_725300_1686" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1609973620749_983562_1687" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>Sequence{self}</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609972551461_929395_1295" name="target" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609972551461_804140_1296" name="result" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isUnique="false" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1609972551463_123787_1299" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1609972551463_823734_1298" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651706_235283_42203" name="LiteralRational" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1586212374384_569258_418" annotatedElement="_18_5_3_12e503d9_1533160651706_235283_42203">
+          <body>&lt;p>A &lt;code>LiteralRational&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides a &lt;code>&lt;em>Rational&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have the type &lt;code>&lt;em>Rational&lt;/em>&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695239139441_330438_56" name="checkLiteralRationalSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651706_235283_42203">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1708886066298_724413_5" annotatedElement="_19_0_4_12e503d9_1695239139441_330438_56">
+            <body>&lt;p>A &lt;code>LiteralRational&lt;/code> must directly or indirectly specialize &lt;em>&lt;code>Performances::literalRationalEvaluations&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695239139458_743009_57" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::literalRationalEvaluations')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674973_650906_43241" general="_18_5_3_12e503d9_1533160651688_624289_42165"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674987_967605_43310" name="value" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1585935982459_190002_209" annotatedElement="_18_5_3_12e503d9_1533160674987_967605_43310">
+            <body>&lt;p>The value whose rational approximation is the result of evaluating this &lt;code>LiteralRational&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_59601fc_1586212364765_458055_417" annotatedElement="_18_5_3_12e503d9_1533160674987_967605_43310">
+            <body>&lt;p>The Real value that is the result of evaluating this Expression.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Real"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651697_757989_42184" name="LiteralInfinity" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1585936245808_527685_236" annotatedElement="_18_5_3_12e503d9_1533160651697_757989_42184">
+          <body>&lt;p>A &lt;code>LiteralInfinity&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides the positive infinity value (&lt;code>*&lt;/code>). It's &lt;code>result&lt;/code> must have the type &lt;code>&lt;em>Positive&lt;/em>&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695239047328_926239_50" name="checkLiteralInfinitySpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651697_757989_42184">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1708886025562_635959_3" annotatedElement="_19_0_4_12e503d9_1695239047328_926239_50">
+            <body>&lt;p>A &lt;code>LiteralInfinity&lt;/code> must directly or indirectly specialize &lt;em>&lt;code>Performances::literalIntegerEvaluations&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695239047348_883791_51" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::literalIntegerEvaluations')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674972_384682_43239" general="_18_5_3_12e503d9_1533160651688_624289_42165"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651681_567347_42153" name="LiteralInteger" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1585936220961_733855_233" annotatedElement="_18_5_3_12e503d9_1533160651681_567347_42153">
+          <body>&lt;p>A &lt;code>LiteralInteger&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides an &lt;code>&lt;em>Integer&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have the type &lt;code>&lt;em>Integer&lt;/em>&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695239098928_832388_53" name="checkLiteralIntegerSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651681_567347_42153">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1708886052256_698292_4" annotatedElement="_19_0_4_12e503d9_1695239098928_832388_53">
+            <body>&lt;p>A &lt;code>LiteralInteger&lt;/code> must directly or indirectly specialize &lt;em>&lt;code>Performances::literalIntegerEvaluations&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695239098945_195972_54" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::literalIntegerEvaluations')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674965_179504_43198" general="_18_5_3_12e503d9_1533160651688_624289_42165"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674965_358889_43199" name="value" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1586212073728_11958_413" annotatedElement="_18_5_3_12e503d9_1533160674965_358889_43199">
+            <body>&lt;p>The &lt;code>&lt;em>Integer&lt;/em>&lt;/code> value that is the result of evaluating this &lt;code>LiteralInteger&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_59601fc_1585935982459_615521_207" annotatedElement="_18_5_3_12e503d9_1533160674965_358889_43199">
+            <body>&lt;p>The Integer value that is the result of evaluating this Expression.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651705_773974_42202" name="NullExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1585936254528_462430_237" annotatedElement="_18_5_3_12e503d9_1533160651705_773974_42202">
+          <body>&lt;p>A &lt;code>NullExpression&lt;/code> is an &lt;code>Expression&lt;/code> that results in a null value.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667786263190_604976_2214" name="checkNullExpressionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651705_773974_42202">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847999876_205024_239" annotatedElement="_19_0_4_12e503d9_1667786263190_604976_2214">
+            <body>&lt;p>A &lt;code>NullExpression&lt;/code> must directly or indirectly specialize the base &lt;code>NullExpression&lt;/code> &lt;code>&lt;em>Performances::nullEvaluations&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667786263205_48762_2215" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::nullEvaluations')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1606348356122_319369_2841" general="_18_5_3_12e503d9_1533160651686_908654_42163"/>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665517623078_326511_1474" name="modelLevelEvaluable" visibility="public" bodyCondition="_19_0_4_12e503d9_1665611546705_365250_2666" redefinedOperation="_19_0_4_12e503d9_1665516752162_909455_1465">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665517623087_897522_1476" annotatedElement="_19_0_4_12e503d9_1665517623078_326511_1474">
+            <body>&lt;p>A &lt;code>NullExpression&lt;/code> is always model-level evaluable.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665611546705_365250_2666" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665611546721_878419_2667" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>true</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665517623084_320111_1475" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665611130317_97281_2663" name="visited" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665611130324_421955_2665" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665611130323_905684_2664" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1609972409054_28498_1245" name="evaluate" visibility="public" bodyCondition="_19_0_4_12e503d9_1609973601814_918228_1684" redefinedOperation="_19_0_4_12e503d9_1606345564739_966196_237">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609972409062_939870_1248" annotatedElement="_19_0_4_12e503d9_1609972409054_28498_1245">
+            <body>&lt;p>The model-level value of a &lt;code>NullExpression&lt;/code> is an empty sequence.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1609973601814_918228_1684" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1609973601814_93897_1685" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>Sequence{}</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609972409057_807903_1246" name="target" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609972409060_645581_1247" name="result" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isUnique="false" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1609972409065_291382_1250" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1609972409063_752708_1249" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651701_975433_42193" name="LiteralString" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1586212399610_135629_420" annotatedElement="_18_5_3_12e503d9_1533160651701_975433_42193">
+          <body>&lt;p>A &lt;code>LiteralString&lt;/code> is a &lt;code>LiteralExpression&lt;/code> that provides a &lt;code>&lt;em>String&lt;/em>&lt;/code> value as a result. Its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> must have the type &lt;code>&lt;em>String&lt;/em>&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695239178226_947408_59" name="checkLiteralStringSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651701_975433_42193">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1708886098213_614275_6" annotatedElement="_19_0_4_12e503d9_1695239178226_947408_59">
+            <body>&lt;p>A &lt;code>LiteralString&lt;/code> must directly or indirectly specialize &lt;em>&lt;code>Performances::literalStringEvaluations&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695239178247_400354_60" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::literalStringEvaluations')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674972_401150_43238" general="_18_5_3_12e503d9_1533160651688_624289_42165"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674985_368212_43297" name="value" visibility="public">
+          <ownedComment xmi:id="_19_0_2_59601fc_1586212387263_744939_419" annotatedElement="_18_5_3_12e503d9_1533160674985_368212_43297">
+            <body>&lt;p>The String value that is the result of evaluating this Expression.&lt;/p></body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_59601fc_1585935982458_245662_206" annotatedElement="_18_5_3_12e503d9_1533160674985_368212_43297">
+            <body>&lt;p>The &lt;code>&lt;em>String&lt;/em>&lt;/code> value that is the result of evaluating this &lt;code>LiteralString&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1557528671608_638869_111563" name="InvocationExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1588776722445_341155_3933" annotatedElement="_18_5_3_12e503d9_1557528671608_638869_111563">
+          <body>&lt;p>An &lt;code>InvocationExpression&lt;/code> is an &lt;code>InstantiationExpression&lt;/code> whose &lt;code>instantiatedType&lt;/code> must be a &lt;code>Behavior&lt;/code> or a &lt;code>Feature&lt;/code> typed by a single &lt;code>Behavior&lt;/code> (such as a &lt;code>Step&lt;/code>). Each of the input &lt;code>parameters&lt;/code> of the &lt;code>instantiatedType&lt;/code> are bound to the &lt;code>result&lt;/code> of an &lt;code>argument&lt;/code> &lt;code>Expression&lt;/code>. If the &lt;code>instantiatedType&lt;/code> is a &lt;code>Function&lt;/code> or a &lt;code>Feature&lt;/code> typed by a &lt;code>Function&lt;/code>, then the &lt;code>result&lt;/code> of the &lt;code>InvocationExpression&lt;/code> is the &lt;code>result&lt;/code> of the invoked &lt;code>Function&lt;/code>. Otherwise, the &lt;code>result&lt;/code> is an instance of the &lt;code>instantiatedType&lt;/code> (essentially like a behavioral &lt;code>ConstructorExpression&lt;/code>).&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1671138660397_355420_101268" name="checkInvocationExpressionBehaviorBindingConnector" visibility="public" constrainedElement="_18_5_3_12e503d9_1557528671608_638869_111563">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671138871326_925189_101270" annotatedElement="_19_0_4_12e503d9_1671138660397_355420_101268">
+            <body>&lt;p>If the &lt;code>instantiatedType&lt;/code> of an &lt;code>InvocationExpression&lt;/code> is neither a &lt;code>Function&lt;/code> nor a &lt;code>Feature&lt;/code> whose type is a &lt;code>Function&lt;/code>, then the &lt;code>InvocationExpression&lt;/code> must own a &lt;code>BindingConnector&lt;/code> between itself and its &lt;code>result&lt;/code> parameter.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1671138660435_874487_101269" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>not instantiatedType.oclIsKindOf(Function) and
+not (instantiatedType.oclIsKindOf(Feature) and 
+     instantiatedType.oclAsType(Feature).type->exists(oclIsKindOf(Function))) implies
+    ownedFeature.selectByKind(BindingConnector)->exists(
+        relatedFeature->includes(self) and
+        relatedFeature->includes(result))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1671140349781_30567_101273" name="checkInvocationExpressionDefaultValueBindingConnector" visibility="public" constrainedElement="_18_5_3_12e503d9_1557528671608_638869_111563">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671144762034_831876_101289" annotatedElement="_19_0_4_12e503d9_1671140349781_30567_101273">
+            <body>&lt;p>An &lt;code>InvocationExpression&lt;/code> must own a &lt;code>BindingConnector&lt;/code> between the &lt;code>featureWithValue&lt;/code> and &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> of any &lt;code>FeatureValue&lt;/code> that is the effective default value for a &lt;code>feature&lt;/code> of the &lt;code>instantiatedType&lt;/code> of the &lt;code>InvocationExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1671140349787_515441_101274" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>TBD</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676506981725_507991_466" name="deriveInvocationExpressionArgument" visibility="public" constrainedElement="_18_5_3_12e503d9_1557528671608_638869_111563">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676507288411_375023_468" annotatedElement="_19_0_4_12e503d9_1676506981725_507991_466">
+            <body>&lt;p>The &lt;code>arguments&lt;/code> of an &lt;code>InvocationExpression&lt;/code> are the &lt;code>value&lt;/code> &lt;code>Expressions&lt;/code> of the &lt;code>FeatureValues&lt;/code> of its &lt;code>ownedFeatures&lt;/code>, in an order corresponding to the order of the &lt;code>input&lt;/code> parameters of the &lt;code>instantiatedType&lt;/code> that the &lt;code>ownedFeatures&lt;/code> redefine.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676506981746_574002_467" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>instantiatedType.input->collect(inp | 
+    ownedFeatures->select(redefines(inp)).valuation->
+    select(v | v &lt;> null).value
+)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695245616370_891542_170" name="validateInvocationExpressionParameterRedefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1557528671608_638869_111563">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695245663579_807293_172" annotatedElement="_19_0_4_12e503d9_1695245616370_891542_170">
+            <body>&lt;p>Each &lt;code>input&lt;/code> parameter of an &lt;code>InvocationExpression&lt;/code> must redefine exactly one &lt;code>input&lt;/code> parameter of the &lt;code>instantiatedType&lt;/code> of the &lt;code>InvocationExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695245616387_748501_171" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let parameters : OrderedSet(Feature) = instantiatedType.input in
+input->forAll(inp | 
+    inp.ownedRedefinition.redefinedFeature->
+        intersection(parameters)->size() = 1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695245732619_189197_173" name="validateInvocationExpressionNoDuplicateParameterRedefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1557528671608_638869_111563">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695245834138_998208_175" annotatedElement="_19_0_4_12e503d9_1695245732619_189197_173">
+            <body>&lt;p>Two different &lt;code>ownedFeatures&lt;/code> of an &lt;code>InvocationExpression&lt;/code> must not redefine the same &lt;code>feature&lt;/code> of the &lt;code>instantiatedType&lt;/code> of the &lt;code>InvocationExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695245732637_331229_174" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let features : OrderedSet(Feature) = instantiatedType.feature in
+input->forAll(inp1 | input->forAll(inp2 |
+    inp1 &lt;> inp2 implies
+        inp1.ownedRedefinition.redefinedFeature->
+            intersection(inp2.ownedRedefinition.redefinedFeature)->
+            intersection(features)->isEmpty()))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739252284417_17008_642" name="checkInvocationExpressionBehaviorResultSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1557528671608_638869_111563">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739252369441_493801_644" annotatedElement="_2022x_2_12e503d9_1739252284417_17008_642">
+            <body>&lt;p>If the &lt;code>instantiatedType&lt;/code> of an &lt;code>InvocationExpression&lt;/code> is neither a &lt;code>Function&lt;/code> nor a &lt;code>Feature&lt;/code> whose type is a &lt;code>Function&lt;/code>, then the &lt;code>result&lt;/code> of the &lt;code>InvocationExpression&lt;/code> must specialize the &lt;code>instantiatedType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739252284418_629816_643" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>not instantiatedType.oclIsKindOf(Function) and
+not (instantiatedType.oclIsKindOf(Feature) and 
+     instantiatedType.oclAsType(Feature).type->exists(oclIsKindOf(Function))) implies
+    result.specializes(instantiatedType)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739141932523_592676_281" name="checkInvocationExpressionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1557528671608_638869_111563">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739142085594_208790_283" annotatedElement="_2022x_2_12e503d9_1739141932523_592676_281">
+            <body>&lt;p>An &lt;code>InvocationExpression&lt;/code> must specialize its &lt;code>instantiatedType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739141932523_480053_282" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializes(instantiatedType)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739207457639_544989_378" name="validateInvocationExpressionInstantiatedType" visibility="public" constrainedElement="_18_5_3_12e503d9_1557528671608_638869_111563">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739207735779_298450_380" annotatedElement="_2022x_2_12e503d9_1739207457639_544989_378">
+            <body>&lt;p>The &lt;code>instantiatedType&lt;/code> of an &lt;code>InvocationExpression&lt;/code> must be either a &lt;code>Behavior&lt;/code> or a &lt;code>Feature&lt;/code> with a single &lt;code>type&lt;/code>, which is a &lt;code>Behavior&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739207457639_826765_379" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>instantiatedType.oclIsKindOf(Behavior) or
+instantiatedType.oclIsKindOf(Feature) and
+    instantiatedType.type->exists(oclIsKindOf(Behavior)) and
+    instantiatedType.type->size(1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739142375703_491318_302" name="validateInvocationExpressionOwnedFeatures" visibility="public" constrainedElement="_18_5_3_12e503d9_1557528671608_638869_111563">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739142577895_940108_306" annotatedElement="_2022x_2_12e503d9_1739142375703_491318_302">
+            <body>&lt;p>Other than its &lt;code>result&lt;/code>, all the &lt;code>ownedFeatures&lt;/code> of an &lt;code>InvocationExpression&lt;/code> must have &lt;code>direction = in&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739142375704_361115_303" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedFeature->forAll(f |
+    f &lt;> result implies 
+        f.direction = FeatureDirectionKind::_'in')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1557528770847_194102_111617" general="_2022x_2_12e503d9_1739136879941_579104_183"/>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665517684263_241917_1508" name="modelLevelEvaluable" visibility="public" bodyCondition="_19_0_4_12e503d9_1665519036000_915703_1738" redefinedOperation="_19_0_4_12e503d9_1665516752162_909455_1465">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665517684268_105817_1510" annotatedElement="_19_0_4_12e503d9_1665517684263_241917_1508">
+            <body>&lt;p>An &lt;code>InvocationExpression&lt;/code> is model-level evaluable if all its &lt;code>argument&lt;/code> &lt;code>Expressions&lt;/code> are model-level evaluable and its &lt;code>function&lt;/code> is model-level evaluable.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665519036000_915703_1738" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665519036014_206273_1739" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>argument->forAll(modelLevelEvaluable(visited)) and
+    function.isModelLevelEvaluable</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665517684267_406844_1509" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665611089031_823433_2651" name="visited" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665611089063_406538_2653" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665611089058_725397_2652" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1609972557398_639503_1312" name="evaluate" visibility="public" redefinedOperation="_19_0_4_12e503d9_1606345564739_966196_237">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609972557402_250960_1315" annotatedElement="_19_0_4_12e503d9_1609972557398_639503_1312">
+            <body>&lt;p>Apply the &lt;code>Function&lt;/code> that is the &lt;code>type&lt;/code> of this &lt;code>InvocationExpression&lt;/code> to the argument values resulting from evaluating each of the &lt;code>argument&lt;/code> &lt;code>Expressions&lt;/code> on the given &lt;code>target&lt;/code>. If the application is not possible, then return an empty sequence.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609972557401_524183_1313" name="target" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609972557401_465957_1314" name="result" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isUnique="false" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1609972557402_24528_1317" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1609972557402_189390_1316" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651680_105632_42151" name="FeatureReferenceExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1588776398013_120415_3931" annotatedElement="_18_5_3_12e503d9_1533160651680_105632_42151">
+          <body>&lt;p>A &lt;code>FeatureReferenceExpression&lt;/code> is an &lt;code>Expression&lt;/code> whose &lt;code>result&lt;/code> is bound to a &lt;code>referent&lt;/code> &lt;code>Feature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676504548006_164009_444" name="deriveFeatureReferenceExpressionReferent" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651680_105632_42151">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676504548028_180256_446" annotatedElement="_19_0_4_12e503d9_1676504548006_164009_444">
+            <body>&lt;p>The &lt;code>referent&lt;/code> of a &lt;code>FeatureReferenceExpression&lt;/code> is the &lt;code>memberElement&lt;/code> of its first &lt;code>ownedMembership&lt;/code> that is not a &lt;code>ParameterMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676504548023_498757_445" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referent =
+    let nonParameterMemberships : Sequence(Membership) = ownedMembership->
+        reject(oclIsKindOf(ParameterMembership)) in
+    if nonParameterMemberships->isEmpty() or
+       not nonParameterMemberships->first().memberElement.oclIsKindOf(Feature)
+    then null
+    else nonParameterMemberships->first().memberElement.oclAsType(Feature)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676504793461_760492_459" name="checkFeatureReferenceExpressionBindingConnector" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651680_105632_42151">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676504948315_610211_461" annotatedElement="_19_0_4_12e503d9_1676504793461_760492_459">
+            <body>&lt;p>A &lt;code>FeatureReferenceExpression&lt;/code> must have an &lt;code>ownedMember&lt;/code> that is a &lt;code>BindingConnector&lt;/code> between the &lt;code>referent&lt;/code> and &lt;code>result&lt;/code> of the &lt;code>FeatureReferenceExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676504793478_797926_460" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMember->selectByKind(BindingConnector)->exists(b |
+    b.relatedFeatures->includes(targetFeature) and
+    b.relatedFeatures->includes(result))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695245461545_688998_167" name="validateFeatureReferenceExpressionReferentIsFeature" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651680_105632_42151">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695245557540_935643_169" annotatedElement="_19_0_4_12e503d9_1695245461545_688998_167">
+            <body>&lt;p>The first &lt;code>ownedMembership&lt;/code> of a &lt;code>FeatureReferenceExpression&lt;/code> that is not a &lt;code>ParameterMembership&lt;/code> must have a &lt;code>Feature&lt;/code> as its &lt;code>memberElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695245461561_866619_168" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let membership : Membership = 
+    ownedMembership->reject(m | m.oclIsKindOf(ParameterMembership)) in
+membership->notEmpty() and
+membership->at(1).memberElement.oclIsKindOf(Feature)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735774917738_212381_41" name="checkFeatureReferenceExpressionResultSpecialization" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735774966890_557486_43" annotatedElement="_2022x_2_12e503d9_1735774917738_212381_41">
+            <body>&lt;p>The &lt;code>result&lt;/code> parameter of a &lt;code>FeatureReferenceExpression&lt;/code> must specialize the &lt;code>referent&lt;/code> of the &lt;code>FeatureReferenceExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735774917739_425351_42" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>result.owningType() = self and result.specializes(referent)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740178896654_284731_30" name="validateFeatureReferenceExpressionResult" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651680_105632_42151">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740178961561_221714_32" annotatedElement="_2022x_2_12e503d9_1740178896654_284731_30">
+            <body>&lt;p>A &lt;code>FeatureReferenceExpression&lt;/code> must own its &lt;code>result&lt;/code> parameter.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740178896657_970076_31" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>result.owningType = self</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674963_583122_43188" general="_18_5_3_12e503d9_1533160651686_908654_42163"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674962_848357_43185" name="referent" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_644335_43267" association="_18_5_3_12e503d9_1533160651679_304226_42149">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1588776617290_31491_3932" annotatedElement="_18_5_3_12e503d9_1533160674962_848357_43185">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is referenced by this &lt;code>FeatureReferenceExpression&lt;/code>, which is its first non-&lt;code>parameter&lt;/code> &lt;code>member&lt;/code>.&lt;p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678360_657815_43958" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678360_451423_43957" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665517673641_112331_1490" name="modelLevelEvaluable" visibility="public" bodyCondition="_19_0_4_12e503d9_1665518816809_277040_1692" redefinedOperation="_19_0_4_12e503d9_1665516752162_909455_1465">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665517673671_429137_1492" annotatedElement="_19_0_4_12e503d9_1665517673641_112331_1490">
+            <body>&lt;p>A &lt;code>FeatureReferenceExpression&lt;/code> is model-level evaluable if it&amp;#39;s &lt;code>referent&lt;/code>&lt;/p>
+
+&lt;ul>
+	&lt;li>conforms to the self-reference feature &lt;code>&lt;em>Anything::self&lt;/em>&lt;/code>;&lt;/li>
+	&lt;li>is an &lt;code>Expression&lt;/code> that is model-level evaluable;&lt;/li>
+	&lt;li>has an &lt;code>owningType&lt;/code> that is a &lt;code>Metaclass&lt;/code> or &lt;code>MetadataFeature&lt;/code>; or&lt;/li>
+	&lt;li>has no &lt;code>featuringTypes&lt;/code> and, if it has a &lt;code>FeatureValue&lt;/code>, the &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> is model-level evaluable.&lt;/li>
+&lt;/ul>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665518816809_277040_1692" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665518816830_67822_1693" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>referent.conformsTo('Anything::self') or
+visited->excludes(referent) and 
+(referent.oclIsKindOf(Expression) and 
+    referent.oclAsType(Expression).modelLevelEvaluable(visited->including(referent)) or
+referent.owningType &lt;> null and 
+    (referent.owningType.isOclKindOf(MetaClass) or 
+    referent.owningType.isOclKindOf(MetadataFeature)) or
+referent.featuringType->isEmpty() and
+    (referent.valuation = null or 
+    referent.valuation.modelLevelEvaluable(visited->including(referent))))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665517673669_399598_1491" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665611122427_537658_2660" name="visited" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665611122443_768643_2662" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665611122441_640732_2661" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1609972555006_942459_1303" name="evaluate" visibility="public" bodyCondition="_19_0_4_12e503d9_1610053528965_571750_2662" redefinedOperation="_19_0_4_12e503d9_1606345564739_966196_237">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609972555008_572640_1306" annotatedElement="_19_0_4_12e503d9_1609972555006_942459_1303">
+            <body>&lt;p>First, determine a &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> for the &lt;code>referent&lt;/code>:&lt;/p>
+
+&lt;ul>
+	&lt;li>If the &lt;code>target&lt;/code> &lt;code>Element&lt;/code> is a Type that has a &lt;code>feature&lt;/code> that is the &lt;code>referent&lt;/code> or (directly or indirectly) redefines it, then the &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> of the &lt;code>FeatureValue&lt;/code> for that &lt;code>feature&lt;/code> (if any).&lt;/li>
+	&lt;li>Else, if the &lt;code>referent&lt;/code> has no &lt;code>featuringTypes&lt;/code>, the &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> of the &lt;code>FeatureValue&lt;/code> for the &lt;code>referent&lt;/code> (if any).&lt;/li>
+&lt;/ul>
+
+&lt;p>Then:&lt;/p>
+
+&lt;ul>
+	&lt;li>If such a value &lt;code>Expression&lt;/code> exists, return the result of evaluating that &lt;code>Expression&lt;/code> on the &lt;code>target&lt;/code>.&lt;/li>
+	&lt;li>Else, if the &lt;code>referent&lt;/code> is not an &lt;code>Expression&lt;/code>, return the &lt;code>referent&lt;/code>.&lt;/li>
+	&lt;li>Else return the empty sequence.&lt;/li>
+&lt;/ul>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1610053528965_571750_2662" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1610053528966_775520_2663" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if not target.oclIsKindOf(Type) then Sequence{}
+else
+    let feature: Sequence(Feature) = 
+        target.oclAsType(Type).feature->select(f |
+            f.ownedRedefinition.redefinedFeature->
+                includes(referent)) in
+        if feature->notEmpty() then 
+            feature.valuation.value.evaluate(target)
+        else if referent.featuringType->isEmpty() 
+            then referent
+        else Sequence{} 
+        endif endif
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609972555007_466279_1304" name="target" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609972555007_150847_1305" name="result" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isUnique="false" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1609972555008_577918_1308" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1609972555008_87749_1307" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651679_304226_42149" name="A_referent_referenceExpression" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674962_848357_43185 _18_5_3_12e503d9_1533160674962_496754_43184">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674962_496754_43184" name="referenceExpression" visibility="public" type="_18_5_3_12e503d9_1533160651680_105632_42151" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674980_717955_43271" association="_18_5_3_12e503d9_1533160651679_304226_42149">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1645050874774_826391_114" annotatedElement="_18_5_3_12e503d9_1533160674962_496754_43184">
+            <body>&lt;p>A &lt;code>FeatureReferenceExpression&lt;/code> that has a certain &lt;code>referent&lt;/code> &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678360_942126_43956" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678360_320527_43955" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1559596717567_82711_29088" name="SelectExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1645051252314_918834_117" annotatedElement="_18_5_3_12e503d9_1559596717567_82711_29088">
+          <body>&lt;p>A &lt;code>SelectExpression&lt;/code> is an &lt;code>OperatorExpression&lt;/code> whose operator is &lt;code>&quot;select&quot;&lt;/code>, which resolves to the &lt;code>Function&lt;/code> &lt;em>&lt;code>ControlFunctions::select&lt;/code>&lt;/em> from the Kernel Functions Library.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695245870883_252010_176" name="validateSelectExpressionOperator" visibility="public" constrainedElement="_18_5_3_12e503d9_1559596717567_82711_29088">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695245947634_86721_178" annotatedElement="_19_0_4_12e503d9_1695245870883_252010_176">
+            <body>&lt;p>The &lt;code>operator&lt;/code> of a &lt;code>SelectExpression&lt;/code> must be &lt;code>'select'&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695245870894_697168_177" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>operator = 'select'</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735774127917_17634_25" name="checkSelectExpressionResultSpecialization" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735774205769_290848_27" annotatedElement="_2022x_2_12e503d9_1735774127917_17634_25">
+            <body>&lt;p>The &lt;code>result&lt;/code> of a &lt;code>SelectExpression&lt;/code> must specialize the &lt;code>result&lt;/code> parameter of the first &lt;code>argument&lt;/code> of the &lt;code>SelectExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735774127918_237821_26" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>arguments->notEmpty() implies
+    result.specializes(arguments->first().result)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1559596755919_353746_29147" general="_18_5_3_12e503d9_1557528779746_71999_111623"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1559596728932_861031_29126" name="operator" visibility="public" redefinedProperty="_18_5_3_12e503d9_1557528808100_646606_111674">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_18_5_3_12e503d9_1559596745606_912182_29130" name="" visibility="public" value="select"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1557528779746_71999_111623" name="OperatorExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1645050086009_194955_69" annotatedElement="_18_5_3_12e503d9_1557528779746_71999_111623">
+          <body>&lt;p>An &lt;code>OperatorExpression&lt;/code> is an &lt;code>InvocationExpression&lt;/code> whose &lt;code>function&lt;/code> is determined by resolving its &lt;code>operator&lt;/code> in the context of one of the standard packages from the Kernel Function Library.&lt;/p></body>
+        </ownedComment>
+        <generalization xmi:id="_18_5_3_12e503d9_1557528801403_438454_111669" general="_18_5_3_12e503d9_1557528671608_638869_111563"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1557528808100_646606_111674" name="operator" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1645050177310_449306_70" annotatedElement="_18_5_3_12e503d9_1557528808100_646606_111674">
+            <body>&lt;p>An &lt;code>operator&lt;/code> symbol that names a corresponding &lt;code>Function&lt;/code> from one of the standard packages from the Kernel Function Library .&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1740180825970_454554_144" name="instantiatedType" visibility="public" bodyCondition="_2022x_2_12e503d9_1740180949669_217299_211" redefinedOperation="_2022x_2_12e503d9_1740179456959_241700_64">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740180933079_413347_206" annotatedElement="_2022x_2_12e503d9_1740180825970_454554_144">
+            <body>&lt;p>The &lt;code>instantiatedType&lt;/code> of an &lt;code>OperatorExpression&lt;/code> is the resolution of it's &lt;code>operator&lt;/code> from one of the packages &lt;em>&lt;code>BaseFunctions&lt;/code>&lt;/em>, &lt;em>&lt;code>DataFunctions&lt;/code>&lt;/em>, or &lt;em>&lt;code>ControlFunctions&lt;/code>&lt;/em> from the Kernel Function Library.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1740180949669_217299_211" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740180949674_172155_212" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let libFunctions : Sequence(Element) =
+    Sequence{'BaseFunctions', 'DataFunctions', 'ControlFunctions'}->
+    collect(ns | resolveGlobal(ns + &quot;::'&quot; + operator + &quot;'&quot;).
+    memberElement) in
+if libFunctions->isEmpty() then null
+else libFunctions->first().oclAsType(Type)
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1740180835782_899435_151" name="" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" direction="return"/>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1559596612705_364896_29003" name="CollectExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1645051243009_910042_116" annotatedElement="_18_5_3_12e503d9_1559596612705_364896_29003">
+          <body>&lt;p>A &lt;code>CollectExpression&lt;/code> is an &lt;code>OperatorExpression&lt;/code> whose &lt;code>operator&lt;/code> is &lt;code>&quot;collect&quot;&lt;/code>, which resolves to the &lt;code>Function&lt;/code> &lt;em>&lt;code>ControlFunctions::collect&lt;/code>&lt;/em> from the Kernel Functions Library.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676501936774_170043_414" name="validateCollectExpressionOperator" visibility="public" constrainedElement="_18_5_3_12e503d9_1559596612705_364896_29003">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676502019810_30877_416" annotatedElement="_19_0_4_12e503d9_1676501936774_170043_414">
+            <body>&lt;p>The &lt;code>operator&lt;/code> of a &lt;code>CollectExpression&lt;/code> must be &lt;code>&quot;collect&quot;&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676501936799_364715_415" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>operator = 'collect'</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1559596652697_484345_29061" general="_18_5_3_12e503d9_1557528779746_71999_111623"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1559596670531_992404_29068" name="operator" visibility="public" redefinedProperty="_18_5_3_12e503d9_1557528808100_646606_111674">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_18_5_3_12e503d9_1559596687124_931891_29072" name="" visibility="public" value="collect"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1645049764787_93967_15" name="FeatureChainExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1645050570084_442190_71" annotatedElement="_19_0_4_12e503d9_1645049764787_93967_15">
+          <body>&lt;p>A &lt;code>FeatureChainExpression&lt;/code> is an &lt;code>OperatorExpression&lt;/code> whose operator is &lt;code>&quot;.&quot;&lt;/code>, which resolves to the &lt;code>Function&lt;/code> &lt;em>&lt;code>ControlFunctions::'.'&lt;/code>&lt;/em> from the Kernel Functions Library. It evaluates to the result of chaining the &lt;code>result&lt;/code> &lt;code>Feature&lt;/code> of its single &lt;code>argument&lt;/code> &lt;code>Expression&lt;/code> with its &lt;code>targetFeature&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676502992650_600385_417" name="checkFeatureChainExpressionTargetRedefinition" visibility="public" constrainedElement="_19_0_4_12e503d9_1645049764787_93967_15">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676503615681_531759_429" annotatedElement="_19_0_4_12e503d9_1676502992650_600385_417">
+            <body>&lt;p>The first &lt;code>ownedFeature&lt;/code> of the first owned input &lt;code>parameter&lt;/code> of a &lt;code>FeatureChainExpression&lt;/code> must redefine the &lt;code>Feature&lt;/code> &lt;code>&lt;em>ControlFunctions::'.'::source::target&lt;/em>&lt;/code> from the Kernel Functions Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676502992666_831947_418" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let sourceTargetFeature : Feature = sourceTargetFeature() in
+sourceTargetFeature &lt;> null and
+sourceTargetFeature.redefinesFromLibrary('ControlFunctions::\'.\'::source::target')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676503459380_401802_427" name="checkFeatureChainExpressionSourceTargetRedefinition" visibility="public" constrainedElement="_19_0_4_12e503d9_1645049764787_93967_15">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676503757051_643579_430" annotatedElement="_19_0_4_12e503d9_1676503459380_401802_427">
+            <body>&lt;p>The first &lt;code>ownedFeature&lt;/code> of the first owned input &lt;code>parameter&lt;/code> of a &lt;code>FeatureChainExpression&lt;/code> must redefine its &lt;code>targetFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676503459395_429688_428" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let sourceTargetFeature : Feature = sourceTargetFeature() in
+sourceTargetFeature &lt;> null and
+sourceTargetFeature.redefines(targetFeature)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676503819237_976974_439" name="deriveFeatureChainExpressionTargetFeature" visibility="public" constrainedElement="_19_0_4_12e503d9_1645049764787_93967_15">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676504489201_103113_443" annotatedElement="_19_0_4_12e503d9_1676503819237_976974_439">
+            <body>&lt;p>The &lt;code>targetFeature&lt;/code> of a &lt;code>FeatureChainExpression&lt;/code> is the &lt;code>memberElement&lt;/code> of its first &lt;code>ownedMembership&lt;/code> that is not a &lt;code>ParameterMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676503819249_499587_440" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>targetFeature =
+    let nonParameterMemberships : Sequence(Membership) = ownedMembership->
+        reject(oclIsKindOf(ParameterMembership)) in
+    if nonParameterMemberships->isEmpty() or
+       not nonParameterMemberships->first().memberElement.oclIsKindOf(Feature)
+    then null
+    else nonParameterMemberships->first().memberElement.oclAsType(Feature)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695245284299_803541_154" name="validateFeatureChainExpressionConformance" visibility="public" constrainedElement="_19_0_4_12e503d9_1645049764787_93967_15">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695245423377_901375_156" annotatedElement="_19_0_4_12e503d9_1695245284299_803541_154">
+            <body>&lt;p>The &lt;code>targetFeature&lt;/code> of a &lt;code>FeatureChainExpression&lt;/code> must be featured within the &lt;code>result&lt;/code> parameter of the &lt;code>argument&lt;/code> &lt;code>Expression&lt;/code> of the &lt;code>FeatureChainExpression&lt;/code>.&lt;/p>
+
+</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695245284316_327833_155" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>argument->notEmpty() implies
+    targetFeature.isFeaturedWithin(argument->first().result)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735077082301_826769_395" name="validateFeatureChainExpressionOperator" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735077082304_787849_397" annotatedElement="_2022x_2_12e503d9_1735077082301_826769_395">
+            <body>&lt;p>The &lt;code>operator&lt;/code> of a &lt;code>FeatureChainExpression&lt;/code> must be &lt;code>&quot;.&quot;&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735077082303_804170_396" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>operator = '.'</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735774791697_751589_38" name="checkFeatureChainExpressionResultSpecialization" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735774891764_485216_40" annotatedElement="_2022x_2_12e503d9_1735774791697_751589_38">
+            <body>&lt;p>The &lt;code>result&lt;/code> parameter of a &lt;code>FeatureChainExpression&lt;/code> must specialize the feature chain of the &lt;code>FeatureChainExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735774791698_404673_39" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let inputParameters : Sequence(Feature) = 
+    ownedFeatures->select(direction = _'in') in
+let sourceTargetFeature : Feature = 
+    owningExpression.sourceTargetFeature() in
+sourceTargetFeature &lt;> null and
+result.subsetsChain(inputParameters->first(), sourceTargetFeature) and
+result.owningType = self</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1645049779108_765718_40" general="_18_5_3_12e503d9_1557528779746_71999_111623"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1645049784007_509459_41" name="operator" visibility="public" redefinedProperty="_18_5_3_12e503d9_1557528808100_646606_111674">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_19_0_4_12e503d9_1645049784014_183587_42" name="" visibility="public" value="."/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1645049897369_762611_49" name="targetFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_644335_43267" association="_19_0_4_12e503d9_1645049897365_803252_48">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1645050937704_302330_115" annotatedElement="_19_0_4_12e503d9_1645049897369_762611_49">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is accessed by this &lt;code>FeatureChainExpression&lt;code>, which is its first non-&lt;code>parameter&lt;/code> &lt;code>member&lt;/code>.&lt;p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1645049987706_230518_59" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1645049987719_185430_60" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1676503197188_279748_419" name="sourceTargetFeature" visibility="public" bodyCondition="_19_0_4_12e503d9_1676503441068_436337_425">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676503278646_329204_424" annotatedElement="_19_0_4_12e503d9_1676503197188_279748_419">
+            <body>&lt;p>Return the first &lt;code>ownedFeature&lt;/code> of the first owned input &lt;code>parameter&lt;/code> of this &lt;code>FeatureChainExpression&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1676503441068_436337_425" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676503441084_836729_426" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let inputParameters : Feature = ownedFeatures->
+    select(direction = _'in') in
+if inputParameters->isEmpty() or 
+   inputParameters->first().ownedFeature->isEmpty()
+then null
+else inputParameters->first().ownedFeature->first()
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1676503227827_147952_421" name="" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1676503227844_661909_422" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1676503227848_579593_423" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1645049897365_803252_48" name="A_targetFeature_chainExpression" visibility="public" memberEnd="_19_0_4_12e503d9_1645049897369_762611_49 _19_0_4_12e503d9_1645049897376_442812_50">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1645049897376_442812_50" name="chainExpression" visibility="public" type="_19_0_4_12e503d9_1645049764787_93967_15" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674980_717955_43271" association="_19_0_4_12e503d9_1645049897365_803252_48">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1645049999368_451238_63" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1645049999375_242671_64" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1665514131646_525861_1340" name="A_referencedElement_accessExpression" visibility="public" memberEnd="_19_0_4_12e503d9_1665514131655_247232_1341 _19_0_4_12e503d9_1665514131669_89709_1342">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1665514131669_89709_1342" name="accessExpression" visibility="public" type="_19_0_4_12e503d9_1665514023745_516216_1215" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674980_717955_43271" association="_19_0_4_12e503d9_1665514131646_525861_1340">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665519348396_993548_1771" annotatedElement="_19_0_4_12e503d9_1665514131669_89709_1342">
+            <body>&lt;p>The &lt;code>MetadataAccessExpressions&lt;/code> having a certain &lt;code>Element&lt;/code> as their &lt;code>referencedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665514243081_836024_1429" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665514243085_61418_1430" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1665514023745_516216_1215" name="MetadataAccessExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1665515955381_558135_1447" annotatedElement="_19_0_4_12e503d9_1665514023745_516216_1215">
+          <body>&lt;p>A &lt;code>MetadataAccessExpression&lt;/code> is an &lt;code>Expression&lt;/code> whose &lt;code>result&lt;/code> is a sequence of instances of &lt;code>Metaclasses&lt;/code> representing all the &lt;code>MetadataFeature&lt;/code> annotations of the &lt;code>referencedElement&lt;/code>. In addition, the sequence includes an instance of the reflective &lt;code>Metaclass&lt;/code> corresponding to the MOF class of the &lt;code>referencedElement&lt;/code>, with values for all the abstract syntax properties of the &lt;code>referencedElement&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667786542957_432421_2218" name="checkMetadataAccessExpressionSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1665514023745_516216_1215">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847949670_224545_238" annotatedElement="_19_0_4_12e503d9_1667786542957_432421_2218">
+            <body>&lt;p>A &lt;code>MetadataAccessExpression&lt;/code> must directly or indirectly specialize the base &lt;code>MetadataAccessExpression&lt;/code> &lt;code>&lt;em>Performances::metadataAccessEvaluations&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667786542962_293458_2219" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::metadataAccessEvaluations')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740197030629_947811_26" name="validateMetadataAccessExpressionReferencedElement" visibility="public" constrainedElement="_19_0_4_12e503d9_1665514023745_516216_1215">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740197112917_693551_28" annotatedElement="_2022x_2_12e503d9_1740197030629_947811_26">
+            <body>&lt;p>A &lt;code>MetadataAccessExpression&lt;/code> must have at least one &lt;code>ownedMember&lt;/code> that is not a &lt;code>FeatureMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740197030631_775507_27" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMembership->exists(not oclIsKindOf(FeatureMembership))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739212141873_785669_484" name="deriveMetadataAccessExpressionReferencedElement" visibility="public" constrainedElement="_19_0_4_12e503d9_1665514023745_516216_1215">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739212141874_913711_486" annotatedElement="_2022x_2_12e503d9_1739212141873_785669_484">
+            <body>&lt;p>The &lt;code>referencedElement&lt;/code> of a &lt;code>MetadataAccessExpression&lt;/code> is the &lt;code>memberElement&lt;/code> of its first &lt;code>ownedMembership&lt;/code> that is not a &lt;code>FeatureMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739212141874_380458_485" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referencedElement =
+    let elements : Sequence(Element) = ownedMembership->
+        reject(oclIsKindOf(FeatureMembership)).memberElement in
+    if elements->isEmpty() then null
+    else elements->first()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1665514087415_202720_1289" general="_18_5_3_12e503d9_1533160651686_908654_42163"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1665514131655_247232_1341" name="referencedElement" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_644335_43267" association="_19_0_4_12e503d9_1665514131646_525861_1340">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665519313166_902144_1770" annotatedElement="_19_0_4_12e503d9_1665514131655_247232_1341">
+            <body>&lt;p>The &lt;code>Element&lt;/code> whose metadata is being accessed.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665514209058_384633_1405" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665514209072_939809_1406" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665517680691_394631_1502" name="modelLevelEvaluable" visibility="public" bodyCondition="_19_0_4_12e503d9_1665611820295_564007_2668" redefinedOperation="_19_0_4_12e503d9_1665516752162_909455_1465">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665517680704_608567_1504" annotatedElement="_19_0_4_12e503d9_1665517680691_394631_1502">
+            <body>&lt;p>A &lt;code>MetadataAccessExpression&lt;/code> is always model-level evaluable.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665611820295_564007_2668" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665611820314_630966_2669" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>true</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665517680703_267241_1503" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665611100642_700669_2657" name="visited" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665611100648_310352_2659" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665611100647_434180_2658" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665514055049_100459_1252" name="evaluate" visibility="public" bodyCondition="_19_0_4_12e503d9_1665514055081_681894_1253" redefinedOperation="_19_0_4_12e503d9_1606345564739_966196_237">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665514055104_463398_1256" annotatedElement="_19_0_4_12e503d9_1665514055049_100459_1252">
+            <body>&lt;p>Return the &lt;code>ownedElements&lt;/code> of the &lt;code>referencedElement&lt;/code> that are &lt;code>MetadataFeatures&lt;/code> and have the &lt;code>referencedElement&lt;/code> as an &lt;code>annotatedElement&lt;/code>, plus a &lt;code>MetadataFeature&lt;/code> whose &lt;code>annotatedElement&lt;/code> is the &lt;code>referencedElement&lt;/code>, whose &lt;code>metaclass&lt;/code> is the reflective &lt;code>Metaclass&lt;/code> corresponding to the MOF class of the &lt;code>referencedElement&lt;/code> and whose &lt;code>ownedFeatures&lt;/code> are bound to the values of the MOF properties of the &lt;code>referencedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665514055081_681894_1253" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665514055105_138475_1257" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>referencedElement.ownedElement->
+    select(oclIsKindOf(MetadataFeature) 
+        and annotatedElement->includes(referencedElement))->
+    including(metaclassFeature())</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665514055091_607392_1254" name="target" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665514055099_249828_1255" name="result" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isUnique="false" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665514055121_703483_1259" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665514055116_856174_1258" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1666539953437_342899_25772" name="metaclassFeature" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1666540015709_30829_25776" annotatedElement="_19_0_4_12e503d9_1666539953437_342899_25772">
+            <body>&lt;p>Return a &lt;code>MetadataFeature&lt;/code> whose &lt;code>annotatedElement&lt;/code> is the &lt;code>referencedElement&lt;/code>, whose &lt;code>metaclass&lt;/code> is the reflective &lt;code>Metaclass&lt;/code> corresponding to the MOF class of the &lt;code>referencedElement&lt;/code> and whose &lt;code>ownedFeatures&lt;/code> are bound to the MOF properties of the &lt;code>referencedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1666539985468_538518_25775" name="" visibility="public" type="_19_0_4_12e503d9_1606345563822_968574_178" direction="return"/>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_2022x_2_12e503d9_1735075421524_242675_323" name="IndexExpression" visibility="public">
+        <ownedComment xmi:id="_2022x_2_12e503d9_1735075421527_975043_326" annotatedElement="_2022x_2_12e503d9_1735075421524_242675_323">
+          <body>&lt;p>An &lt;code>IndexExpression&lt;/code> is an &lt;code>OperatorExpression&lt;/code> whose operator is &lt;code>&quot;#&quot;&lt;/code>, which resolves to the &lt;code>Function&lt;/code> &lt;em>&lt;code>BasicFunctions::'#'&lt;/code>&lt;/em> from the Kernel Functions Library.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735773712779_910396_22" name="checkIndexExpressionResultSpecialization" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735773810657_715734_24" annotatedElement="_2022x_2_12e503d9_1735773712779_910396_22">
+            <body>&lt;p>The &lt;code>result&lt;/code> of an &lt;code>IndexExpression&lt;/code> must specialize the &lt;code>result&lt;/code> parameter of the first &lt;code>argument&lt;/code> of the &lt;code>IndexExpression&lt;/code>, unless that &lt;code>result&lt;/code> already directly or indirectly specializes the &lt;code>DataType&lt;/code> &lt;em>&lt;code>Collections::Array&lt;/code>&lt;/em> from the Kernel Data Type Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735773712782_737365_23" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>arguments->notEmpty() and 
+not arguments->first().result.specializesFromLibrary('Collections::Array') implies
+    result.specializes(arguments->first().result)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735075421527_637567_325" name="validateIndexExpressionOperator" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735075421528_332325_330" annotatedElement="_2022x_2_12e503d9_1735075421527_637567_325">
+            <body>&lt;p>The &lt;code>operator&lt;/code> of an &lt;code>IndexExpression&lt;/code> must be &lt;code>&quot;#&quot;&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735075421528_608482_329" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>operator = '#'</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_2022x_2_12e503d9_1735075421527_919409_327" general="_18_5_3_12e503d9_1557528779746_71999_111623"/>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1735075421526_442091_324" name="operator" visibility="public" redefinedProperty="_18_5_3_12e503d9_1557528808100_646606_111674">
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_2022x_2_12e503d9_1735075421527_350488_328" name="" visibility="public" value="#"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_2022x_2_12e503d9_1739136879941_579104_183" name="InstantiationExpression" visibility="public" isAbstract="true">
+        <ownedComment xmi:id="_2022x_2_12e503d9_1739137990626_415503_218" annotatedElement="_2022x_2_12e503d9_1739136879941_579104_183">
+          <body>&lt;p>An &lt;code>InstantiationExpression&lt;/code> is an &lt;code>Expression&lt;/code> that instantiates its &lt;code>instantiatedType&lt;/code>, binding some or all of the &lt;code>features&lt;/code> of that &lt;code>Type&lt;/code> to the &lt;code>results&lt;/code> of its &lt;code>arguments&lt;/code>.&lt;/p>
+
+&lt;p>&lt;code>InstantiationExpression&lt;/code> is abstract, with concrete subclasses &lt;code>InvocationExpression&lt;/code> and &lt;code>ConstructorExpression&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739207292543_478661_375" name="validateInstantiationExpressionResult" visibility="public" constrainedElement="_2022x_2_12e503d9_1739136879941_579104_183">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739207367297_29005_377" annotatedElement="_2022x_2_12e503d9_1739207292543_478661_375">
+            <body>&lt;p>An &lt;code>InstantiationExpression&lt;/code> must own its &lt;code>result&lt;/code> parameter.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739207292543_843301_376" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>result.owningType = self</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739206399563_717964_369" name="deriveInstantiationExpressionInstantiatedType" visibility="public" constrainedElement="_2022x_2_12e503d9_1739136879941_579104_183">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739207042132_481133_371" annotatedElement="_2022x_2_12e503d9_1739206399563_717964_369">
+            <body>&lt;p>The &lt;code>instantiatedType&lt;/code> of an &lt;code>InstantiationExpression&lt;/code> is given by the result of the &lt;code>instantiatedType()&lt;/code> operation.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739206399564_558118_370" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>instantiatedType = instantiatedType()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739207054016_964736_372" name="validateInstantiationExpressionInstantiatedType" visibility="public" constrainedElement="_2022x_2_12e503d9_1739136879941_579104_183">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739207206230_312109_374" annotatedElement="_2022x_2_12e503d9_1739207054016_964736_372">
+            <body>&lt;p>An &lt;code>InstantiationExpression&lt;/code> must have an &lt;code>InstantiatedType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739207054016_464194_373" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>instantiatedType() &lt;> null</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_2022x_2_12e503d9_1739137172415_81744_216" general="_18_5_3_12e503d9_1533160651686_908654_42163"/>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1739134437590_328753_108" name="argument" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" isOrdered="true" isDerived="true" association="_2022x_2_12e503d9_1739134437590_97461_107">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739135546829_201938_159" annotatedElement="_2022x_2_12e503d9_1739134437590_328753_108">
+            <body>&lt;p>The &lt;code>Expressions&lt;/code> whose &lt;code>results&lt;/code> are bound to &lt;code>features&lt;/code> of the &lt;code>instantiatedType&lt;/code>. The &lt;code>arguments&lt;/code> are ordered consistent with the order of the &lt;code>features&lt;/code>, though they may not be one-to-one with all the &lt;code>features&lt;/code>.&lt;/p>
+
+&lt;p>&lt;strong>Note.&lt;/strong> The derivation of &lt;code>argument&lt;/code> is given in the concrete subclasses of &lt;code>InstantiationExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1739135026583_562981_118" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1739135026584_106325_119" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1739134352572_416088_80" name="instantiatedType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_644335_43267" association="_2022x_2_12e503d9_1739134352572_900293_79">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739137847189_650460_217" annotatedElement="_2022x_2_12e503d9_1739134352572_416088_80">
+            <body>&lt;p>The &lt;code>Type&lt;/code> that is being instantiated.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1739134410259_790339_90" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1739134410259_215062_91" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1740179456959_241700_64" name="instantiatedType" visibility="public" bodyCondition="_2022x_2_12e503d9_1740179763032_509317_74">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740179745049_908592_71" annotatedElement="_2022x_2_12e503d9_1740179456959_241700_64">
+            <body>&lt;p>Return the &lt;code>Type&lt;/code> to act as the &lt;code>instantiatedType&lt;/code> for this &lt;code>InstantiationExpression&lt;/code>. By default, this is the &lt;code>memberElement&lt;/code> of the first &lt;code>ownedMembership&lt;/code> that is not a &lt;code>FeatureMembership&lt;/code>, which must be a &lt;code>Type&lt;/code>.&lt;/p>
+
+&lt;p>&lt;b>Note.&lt;/b> This operation is overridden in the subclass &lt;code>OperatorExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1740179763032_509317_74" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740179763035_292217_75" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let members : Sequence(Element) = ownedMembership->
+    reject(oclIsKindOf(FeatureMembership)).memberElement in
+if members->isEmpty() or not members->first().oclIsKindOf(Type) then null
+else typeMembers->first().oclAsType(Type)
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1740179691384_316963_68" name="" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1740179691385_683170_69" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1740179691386_791671_70" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_2022x_2_12e503d9_1739134352572_900293_79" name="A_instantiatedType_instantiationExpression" visibility="public" memberEnd="_2022x_2_12e503d9_1739134352572_416088_80 _2022x_2_12e503d9_1739134352572_314769_81">
+        <ownedEnd xmi:id="_2022x_2_12e503d9_1739134352572_314769_81" name="instantiationExpression" visibility="public" type="_2022x_2_12e503d9_1739136879941_579104_183" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674980_717955_43271" association="_2022x_2_12e503d9_1739134352572_900293_79">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1739134420551_25250_96" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1739134420552_968830_97" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_2022x_2_12e503d9_1739134182574_300577_15" name="ConstructorExpression" visibility="public">
+        <ownedComment xmi:id="_2022x_2_12e503d9_1739136534293_136908_176" annotatedElement="_2022x_2_12e503d9_1739134182574_300577_15">
+          <body>&lt;p>A &lt;code>ConstructorExpression&lt;/code> is an &lt;code>InstantiationExpression&lt;/code> whose &lt;code>result&lt;/code> specializes its &lt;code>instantiatedType&lt;/code>, binding some or all of the &lt;code>features&lt;/code> of the &lt;code>instantiatedType&lt;/code> to the &lt;code>results&lt;/code> of its &lt;code>argument&lt;/code> &lt;code>Expressions&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739208293290_217311_403" name="deriveConstructorExpressionArgument" visibility="public" constrainedElement="_2022x_2_12e503d9_1739134182574_300577_15">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739208293291_80027_405" annotatedElement="_2022x_2_12e503d9_1739208293290_217311_403">
+            <body>&lt;p>The &lt;code>arguments&lt;/code> of a &lt;code>ConstructorExpression&lt;/code> are the &lt;code>value&lt;/code> &lt;code>Expressions&lt;/code> of the &lt;code>FeatureValues&lt;/code> of the &lt;code>ownedFeatures&lt;/code> of its &lt;code>result&lt;/code> parameter, in an order corresponding to the order of the &lt;code>features&lt;/code> of the &lt;code>instantiatedType&lt;/code> that the &lt;code>result&lt;/code> &lt;code>ownedFeatures&lt;/code> redefine.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739208293290_348267_404" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>instantiatedType.feature->collect(f | 
+    result.ownedFeatures->select(redefines(f)).valuation->
+    select(v | v &lt;> null).value
+)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739208942889_156719_461" name="validateConstructorExpressionNoDuplicateFeatureRedefinition" visibility="public" constrainedElement="_2022x_2_12e503d9_1739134182574_300577_15">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739208942890_477713_464" annotatedElement="_2022x_2_12e503d9_1739208942889_156719_461">
+            <body>&lt;p>Two different &lt;code>ownedFeatures&lt;/code> of the &lt;code>result&lt;/code> of a &lt;code>ConstructorExpression&lt;/code> must not redefine the same &lt;code>feature&lt;/code> of the &lt;code>instantiatedType&lt;/code> of the &lt;code>ConstructorExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739208942890_652943_463" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let features : OrderedSet(Feature) = instantiatedType.feature->
+    select(visibility = VisibilityKind::public) in
+result.ownedFeature->forAll(f1 | result.ownedFeature->forAll(f2 |
+    f1 &lt;> f2 implies
+        f1.ownedRedefinition.redefinedFeature->
+            intersection(f2.ownedRedefinition.redefinedFeature)->
+            intersection(features)->isEmpty()))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739208942889_801887_462" name="checkConstructorExpressionResultFeatureRedefinition" visibility="public" constrainedElement="_2022x_2_12e503d9_1739134182574_300577_15">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739208942891_611506_466" annotatedElement="_2022x_2_12e503d9_1739208942889_801887_462">
+            <body>&lt;p>Each &lt;code>ownedFeature&lt;/code> of the result of a &lt;code>ConstructionExpression&lt;/code> must redefine exactly one public &lt;code>feature&lt;/code> of the &lt;code>instantiatedType&lt;/code> of the &lt;code>ConstructorExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739208942890_281263_465" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let features : OrderedSet(Feature) = instantiatedType.feature->
+    select(owningMembership.visibility = VisibilityKind::public) in
+result.ownedFeature->forAll(f | 
+    f.ownedRedefinition.redefinedFeature->
+        intersection(features)->size() = 1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739208705388_607232_458" name="checkConstructorExpressionResultDefaultValueBindingConnector" visibility="public" constrainedElement="_2022x_2_12e503d9_1739134182574_300577_15">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739208705396_29466_460" annotatedElement="_2022x_2_12e503d9_1739208705388_607232_458">
+            <body>&lt;p>The &lt;code>result&lt;/code> of a &lt;code>ConstructorExpression&lt;/code> must own a &lt;code>BindingConnector&lt;/code> between the &lt;code>featureWithValue&lt;/code> and &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> of any &lt;code>FeatureValue&lt;/code> that is the effective default value for a &lt;code>feature&lt;/code> of the &lt;code>instantiatedType&lt;/code> of the &lt;code>InvocationExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739208705395_205347_459" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>TBD</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740179210832_578560_53" name="checkConstructorExpressionSpecialization" visibility="public" constrainedElement="_2022x_2_12e503d9_1739134182574_300577_15">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740179270184_124755_55" annotatedElement="_2022x_2_12e503d9_1740179210832_578560_53">
+            <body>&lt;p>A &lt;code>ConstructorExpression&lt;/code> must directly or indirectly specialize the &lt;code>Expression&lt;/code> &lt;em>&lt;code>Performances::constructorEvaluations&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740179210834_602107_54" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializes('Performances::constructorEvaluations')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739207973239_870140_393" name="checkConstructorExpressionResultSpecialization" visibility="public" constrainedElement="_2022x_2_12e503d9_1739134182574_300577_15">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739208071576_28312_395" annotatedElement="_2022x_2_12e503d9_1739207973239_870140_393">
+            <body>&lt;p>The &lt;code>result&lt;/code> of a &lt;code>ConstructorExpression&lt;/code> must specialize the &lt;code>instantiatedType&lt;/code> of the &lt;code>ConstructorExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739207973239_504668_394" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>result.specializes(instantiatedType)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739208174676_442863_396" name="validateConstructorExpressionOwnedFeatures" visibility="public" constrainedElement="_2022x_2_12e503d9_1739134182574_300577_15">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739208276379_235868_398" annotatedElement="_2022x_2_12e503d9_1739208174676_442863_396">
+            <body>&lt;p>A &lt;code>ConstructorExpression&lt;/code> must not have any &lt;code>ownedFeatures&lt;/code> other than its &lt;code>result&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739208174677_447063_397" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedFeatures->excluding(result)->isEmpty()</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_2022x_2_12e503d9_1739134273784_918592_46" general="_2022x_2_12e503d9_1739136879941_579104_183"/>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1739136963864_647190_204" name="modelLevelEvaluable" visibility="public" bodyCondition="_2022x_2_12e503d9_1739136963865_243340_205" redefinedOperation="_19_0_4_12e503d9_1665516752162_909455_1465">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739136963865_687337_208" annotatedElement="_2022x_2_12e503d9_1739136963864_647190_204">
+            <body>&lt;p>A &lt;code>ConstructorExpression&lt;/code> is model-level evaluable if all its argument &lt;code>Expressions&lt;/code> are model-level evaluable.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1739136963865_243340_205" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739136963866_180066_209" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>argument->forAll(modelLevelEvaluable(visited))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1739136963865_720284_206" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1739136963865_897804_207" name="visited" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1739136963866_681594_211" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1739136963866_823814_210" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_2022x_2_12e503d9_1739134437590_97461_107" name="A_argument_instantiation" visibility="public" memberEnd="_2022x_2_12e503d9_1739134437590_328753_108 _2022x_2_12e503d9_1739134437590_721719_109">
+        <ownedEnd xmi:id="_2022x_2_12e503d9_1739134437590_721719_109" name="instantiation" visibility="public" type="_2022x_2_12e503d9_1739136879941_579104_183" isDerived="true" association="_2022x_2_12e503d9_1739134437590_97461_107">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739137131651_609156_212" annotatedElement="_2022x_2_12e503d9_1739134437590_721719_109">
+            <body>&lt;p>A &lt;code>InstantiationExpression&lt;/code> that has a certain &lt;code>argument&lt;/code> &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1739135350252_165797_151" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1739135350253_651239_152" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_4_b9102da_1610035180069_451308_1083" name="Structures" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_b9102da_1609606051359_625961_451" name="Structure" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1613429370999_218983_114" annotatedElement="_19_0_4_b9102da_1609606051359_625961_451">
+          <body>&lt;p>A &lt;code>Structure&lt;/code> is a &lt;code>Class&lt;/code> of objects in the modeled universe that are primarily structural in nature. While such an object is not itself behavioral, it may be involved in and acted on by &lt;code>Behaviors&lt;/code>, and it may be the performer of some of them.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_b9102da_1610038279833_813459_1252" name="checkStructureSpecialization" visibility="public" constrainedElement="_19_0_4_b9102da_1609606051359_625961_451">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1667164699297_946807_86" annotatedElement="_19_0_4_b9102da_1610038279833_813459_1252">
+            <body>&lt;p>A &lt;code>Structure&lt;/code> must directly or indirectly specialize the base &lt;code>Structure&lt;/code> &lt;code>&lt;em>Objects::Object&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1610038279833_103046_1253" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Objects::Object')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1701382859165_434519_13" name="validateStructureSpecialization" visibility="public" constrainedElement="_19_0_4_b9102da_1609606051359_625961_451">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1702143133026_191205_2" annotatedElement="_19_0_4_12e503d9_1701382859165_434519_13">
+            <body>&lt;p>A &lt;code>Structure&lt;/code> must not specialize a &lt;code>Behavior&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1701382859184_497558_14" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedSpecialization.general->forAll(not oclIsKindOf(Behavior))</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_b9102da_1609606067539_111314_476" general="_18_5_3_12e503d9_1557527582956_258352_110280"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1591566839080_110734_3870" name="Functions" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1595188071573_151091_362" name="A_result_computingExpression" visibility="public" memberEnd="_19_0_2_12e503d9_1595188071574_902060_363 _19_0_2_12e503d9_1595188071574_272731_364">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1595188071574_272731_364" name="computingExpression" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1595189174991_690604_658" association="_19_0_2_12e503d9_1595188071573_151091_362">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624022961048_450290_37509" annotatedElement="_19_0_2_12e503d9_1595188071574_272731_364">
+            <body>&lt;p>The Expressions that have a certain Feature its owned or inherited &lt;code>result&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595188149507_710305_401" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595188149507_969080_402" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651691_194569_42171" name="Predicate" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578066862690_291693_1019" annotatedElement="_18_5_3_12e503d9_1533160651691_194569_42171">
+          <body>&lt;p>A &lt;code>Predicate&lt;/code> is a &lt;code>Function&lt;/code> whose &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> has type &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> and multiplicity &lt;code>1..1&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772999993_808065_2199" name="checkPredicateSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651691_194569_42171">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847737781_158050_234" annotatedElement="_19_0_4_12e503d9_1667772999993_808065_2199">
+            <body>&lt;p>A &lt;code>Predicate&lt;/code> must directly or indirectly specialize the base &lt;code>Predicate&lt;/code> &lt;code>&lt;em>Performances::BooleanEvaluation&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667773000000_629167_2200" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::BooleanEvaluation')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674975_740775_43249" general="_18_5_3_12e503d9_1533160651697_513473_42183"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1557528148740_240982_111109" name="ReturnParameterMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591136212596_918428_1664" annotatedElement="_18_5_3_12e503d9_1557528148740_240982_111109">
+          <body>&lt;p>A &lt;code>ReturnParameterMembership&lt;/code> is a &lt;code>ParameterMembership&lt;/code> that indicates that the &lt;code>ownedMemberParameter&lt;/code> is the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of a &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code>. The &lt;code>direction&lt;/code> of the &lt;code>ownedMemberParameter&lt;/code> must be &lt;code>out&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676501659053_551641_386" name="validateReturnParameterMembershipOwningType" visibility="public" constrainedElement="_18_5_3_12e503d9_1557528148740_240982_111109">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676501659090_118381_388" annotatedElement="_19_0_4_12e503d9_1676501659053_551641_386">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>ReturnParameterMembership&lt;/code> must be a &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676501659082_181811_387" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsKindOf(Function) or owningType.oclIsKindOf(Expression)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1557528175519_427415_111163" general="_18_5_3_12e503d9_1557527738711_165124_110466"/>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1705637653604_560016_863" name="parameterDirection" visibility="public" isLeaf="true" bodyCondition="_19_0_4_12e503d9_1705637653655_795372_864" redefinedOperation="_19_0_4_12e503d9_1705637204486_718324_854">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1705637653661_460181_866" annotatedElement="_19_0_4_12e503d9_1705637653604_560016_863">
+            <body>&lt;p>The &lt;code>ownedMemberParameter&lt;/code> of a &lt;code>ReturnParameterMembership&lt;/code> must have direction &lt;code>out&lt;/code>. (This is a leaf operation that cannot be further redefined.)&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1705637653655_795372_864" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1705637653663_705806_867" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>FeatureDirectionKind::out</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1705637653659_267221_865" name="" visibility="public" type="_18_5_3_12e503d9_1533160651677_936694_42144" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1705637653667_722482_869" name="" visibility="public" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1705637653665_831770_868" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543948912268_676930_21322" name="A_result_computingFunction" visibility="public" memberEnd="_18_5_3_12e503d9_1543948912268_88159_21323 _18_5_3_12e503d9_1543948912269_634234_21324">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1543948912269_634234_21324" name="computingFunction" visibility="public" type="_18_5_3_12e503d9_1533160651697_513473_42183" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543948010066_582406_20414" association="_18_5_3_12e503d9_1543948912268_676930_21322">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624022869541_270770_37508" annotatedElement="_18_5_3_12e503d9_1543948912269_634234_21324">
+            <body>&lt;p>The Functions that have a certain Feature its owned or inherited &lt;code>result&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1549427787869_616918_17915" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1549427787872_569543_17916" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1578025014367_499614_936" name="Invariant" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578066768064_830370_1018" annotatedElement="_19_0_2_12e503d9_1578025014367_499614_936">
+          <body>&lt;p>An &lt;code>Invariant&lt;/code> is a &lt;code>BooleanExpression&lt;/code> that is asserted to have a specific &lt;code>&lt;em>Boolean&lt;/em>&lt;/code> result value. If &lt;code>isNegated = false&lt;/code>, then the result is asserted to be true. If &lt;code>isNegated = true&lt;/code>, then the result is asserted to be false.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667773106722_751576_2207" name="checkInvariantSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1578025014367_499614_936">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847682482_740221_233" annotatedElement="_19_0_4_12e503d9_1667773106722_751576_2207">
+            <body>&lt;p>An &lt;code>Invariant&lt;/code> must directly or indirectly specialize either of the following &lt;code>BooleanExpressions&lt;/code> from the Kernel Semantic Library: &lt;code>&lt;em>Performances::trueEvaluations&lt;/em>&lt;/code>, if &lt;code>isNegated = false&lt;/code>, or  &lt;code>&lt;em>Performances::falseEvaluations&lt;/em>&lt;/code>, if &lt;code>isNegated = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667773106731_560504_2208" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if isNegated then
+    specializesFromLibrary('Performances::falseEvaluations')
+else
+    specializesFromLibrary('Performances::trueEvaluations')
+endif</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1578511366511_260707_381" general="_19_0_2_12e503d9_1578511256733_336334_354"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1623945815201_648891_36531" name="isNegated" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1623946068146_590032_36536" annotatedElement="_19_0_4_12e503d9_1623945815201_648891_36531">
+            <body>&lt;p>Whether this &lt;code>Invariant&lt;/code> is asserted to be false rather than true.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1623945834077_677375_36533" name="" visibility="public"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1578511256733_336334_354" name="BooleanExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1581045839449_611636_9518" annotatedElement="_19_0_2_12e503d9_1578511256733_336334_354">
+          <body>&lt;p>A &lt;code>BooleanExpression&lt;/code> is a &lt;em>&lt;code>Boolean&lt;/code>&lt;/em>-valued &lt;code>Expression&lt;/code> whose type is a &lt;code>Predicate&lt;/code>. It represents a logical condition resulting from the evaluation of the &lt;code>Predicate&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667773080717_141020_2205" name="checkBooleanExpressionSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1578511256733_336334_354">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847496117_6771_230" annotatedElement="_19_0_4_12e503d9_1667773080717_141020_2205">
+            <body>&lt;p>A &lt;code>BooleanExpression&lt;/code> must directly or indirectly specialize the base &lt;code>BooleanExpression&lt;/code> &lt;code>&lt;em>Performances::booleanEvaluations&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667773080724_382749_2206" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::booleanEvaluations')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1578025024340_846721_963" general="_18_5_3_12e503d9_1533160651686_908654_42163"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1578025035149_386_969" name="predicate" visibility="public" type="_18_5_3_12e503d9_1533160651691_194569_42171" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1543948477241_299049_20934" association="_19_0_2_12e503d9_1578025035147_440149_968">
+          <ownedComment xmi:id="_19_0_2_59601fc_1585936060451_213731_217" annotatedElement="_19_0_2_12e503d9_1578025035149_386_969">
+            <body>&lt;p>The Predicate that types the Expression.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_59601fc_1586211935410_812703_409" annotatedElement="_19_0_2_12e503d9_1578025035149_386_969">
+            <body>&lt;p>The &lt;code>Predicate&lt;/code> that types this &lt;code>BooleanExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578025060068_570302_979" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578025060073_270725_980" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651686_908654_42163" name="Expression" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1578413920664_753507_1258" annotatedElement="_18_5_3_12e503d9_1533160651686_908654_42163">
+          <body>&lt;p>An &lt;code>Expression&lt;/code> is a &lt;code>Step&lt;/code> that is typed by a &lt;code>Function&lt;/code>. An &lt;code>Expression&lt;/code> that also has a &lt;code>Function&lt;/code> as its &lt;code>featuringType&lt;/code> is a computational step within that &lt;code>Function&lt;/code>. An &lt;code>Expression&lt;/code> always has a single &lt;code>result&lt;/code> parameter, which redefines the &lt;code>result&lt;/code> parameter of its defining &lt;code>function&lt;/code>. This allows &lt;code>Expressions&lt;/code> to be interconnected in tree structures, in which inputs to each &lt;code>Expression&lt;/code> in the tree are determined as the results of other &lt;code>Expression&lt;/code> in the tree.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1665517512855_477457_1471" name="deriveExpressionIsModelLevelEvaluable" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651686_908654_42163">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665517608074_797782_1473" annotatedElement="_19_0_4_12e503d9_1665517512855_477457_1471">
+            <body>&lt;p>Whether an &lt;code>Expression&lt;/code> &lt;code>isModelLevelEvaluable&lt;/code> is determined by the &lt;code>modelLevelEvaluable()&lt;/code> operation.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665517512883_187751_1472" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isModelLevelEvaluable = modelLevelEvaluable(Set(Element){})</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667773036390_464732_2201" name="checkExpressionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651686_908654_42163">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847535422_109919_231" annotatedElement="_19_0_4_12e503d9_1667773036390_464732_2201">
+            <body>&lt;p>An &lt;code>Expression&lt;/code> must directly or indirectly specialize the base &lt;code>Expression&lt;/code> &lt;code>&lt;em>Performances::evaluations&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667773036395_369919_2202" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::evaluations')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1604531017082_183414_869" name="checkExpressionTypeFeaturing" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651686_908654_42163">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604531504001_319135_873" annotatedElement="_19_0_4_12e503d9_1604531017082_183414_869">
+            <body>&lt;p>If this &lt;code>Expression&lt;/code> is owned by a &lt;code>FeatureValue&lt;/code>, then it must have the same &lt;code>featuringTypes&lt;/code> as the &lt;code>featureWithValue&lt;/code> of the &lt;code>FeatureValue&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1604531017082_392918_870" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningMembership &lt;> null and 
+owningMembership.oclIsKindOf(FeatureValue) implies
+    let featureWithValue : Feature = 
+        owningMembership.oclAsType(FeatureValue).featureWithValue in
+    featuringType = featureWithValue.featuringType</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667773053467_270889_2203" name="checkExpressionResultBindingConnector" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651686_908654_42163">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671142445191_306365_101279" annotatedElement="_19_0_4_12e503d9_1667773053467_270889_2203">
+            <body>&lt;p>If an &lt;code>Expression&lt;/code> has an &lt;code>Expression&lt;/code> owned via a &lt;code>ResultExpressionMembership&lt;/code>, then the owning &lt;code>Expression&lt;/code> must also own a &lt;code>BindingConnector&lt;/code> between its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> and the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the result &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667773053475_467644_2204" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMembership.selectByKind(ResultExpressionMembership)->
+    forAll(mem | ownedFeature.selectByKind(BindingConnector)->
+        exists(binding |
+            binding.relatedFeature->includes(result) and
+            binding.relatedFeature->includes(mem.ownedResultExpression.result)))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676499538237_60747_353" name="deriveExpressionResult" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651686_908654_42163">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676499858347_8218_355" annotatedElement="_19_0_4_12e503d9_1676499538237_60747_353">
+            <body>&lt;p>The &lt;code>result&lt;/code> parameter of an &lt;code>Expression&lt;/code> is its &lt;code>parameter&lt;/code> owned (possibly in a supertype) via a &lt;code>ReturnParameterMembership&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676499538250_303472_354" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>result =
+    let resultParams : Sequence(Feature) =
+        featureMemberships->
+            selectByKind(ReturnParameterMembership).
+            ownedMemberParameter in
+    if resultParams->notEmpty() then resultParams->first()
+    else null
+    endif
+</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676499866083_875407_356" name="validateExpressionResultParameterMembership" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651686_908654_42163">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676499955480_112879_358" annotatedElement="_19_0_4_12e503d9_1676499866083_875407_356">
+            <body>&lt;p>An &lt;code>Expression&lt;/code> must have exactly one &lt;code>featureMembership&lt;/code> (owned or inherited) that is a &lt;code>ResultParameterMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676499866095_387305_357" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureMembership->
+    selectByKind(ReturnParameterMembership)->
+    size() = 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695245120138_776499_148" name="validateExpressionResultExpressionMembership" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651686_908654_42163">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695245232152_595534_150" annotatedElement="_19_0_4_12e503d9_1695245120138_776499_148">
+            <body>&lt;p>An &lt;code>Expression&lt;/code> must have at most one &lt;code>ResultExpressionMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695245120154_364389_149" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>membership->selectByKind(ResultExpressionMembership)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1543947918935_170592_20360" general="_18_5_3_b9102da_1536345916995_711141_17306"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543948477241_299049_20934" name="function" visibility="public" type="_18_5_3_12e503d9_1533160651697_513473_42183" isDerived="true" redefinedProperty="_18_5_3_b9102da_1536346315176_954314_17388" association="_18_5_3_12e503d9_1543948477241_6677_20933">
+          <ownedComment xmi:id="_19_0_2_59601fc_1586211300666_816705_401" annotatedElement="_18_5_3_12e503d9_1543948477241_299049_20934">
+            <body>&lt;p>The &lt;code>Function&lt;/code> that types this &lt;code>Expression&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_59601fc_1585936095603_272198_222" annotatedElement="_18_5_3_12e503d9_1543948477241_299049_20934">
+            <body>&lt;p>This is the Function that types the Expression.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543948512960_267001_20974" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543948512960_945596_20975" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1595188071574_902060_363" name="result" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674960_365618_43170 _19_0_2_12e503d9_1595189174990_213826_657" association="_19_0_2_12e503d9_1595188071573_151091_362">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607318972382_982987_11" annotatedElement="_19_0_2_12e503d9_1595188071574_902060_363">
+            <body>&lt;p>&lt;p>An &lt;code>output&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>Expression&lt;/code> whose value is the result of the &lt;code>Expression&lt;/code>. The result of an &lt;code>Expression&lt;/code> is either inherited from its &lt;code>function&lt;/code> or it is related to the &lt;code>Expression&lt;/code> via a &lt;code>ReturnParameterMembership&lt;/code>, in which case it redefines the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of its &lt;code>function&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595188085972_337864_373" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595188085972_56244_374" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1609957047704_424471_48" name="isModelLevelEvaluable" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609972401693_154159_1244" annotatedElement="_19_0_4_12e503d9_1609957047704_424471_48">
+            <body>&lt;p>Whether this &lt;code>Expression&lt;/code> meets the constraints necessary to be evaluated at &lt;em>model level&lt;/em>, that is, using metadata within the model.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665516752162_909455_1465" name="modelLevelEvaluable" visibility="public" bodyCondition="_19_0_4_12e503d9_1665610668617_859509_2645">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665517483151_424279_1470" annotatedElement="_19_0_4_12e503d9_1665516752162_909455_1465">
+            <body>&lt;p>Return whether this &lt;code>Expression&lt;/code> is model-level evaluable. The &lt;code>visited&lt;/code> parameter is used to track possible circular &lt;code>Feature&lt;/code> references made from &lt;code>FeatureReferenceExpressions&lt;/code> (see the redefinition of this operation for &lt;code>FeatureReferenceExpression&lt;/code>). Such circular references are not allowed in model-level evaluable expressions.&lt;/p>
+
+&lt;p>An &lt;code>Expression&lt;/code> that is not otherwise specialized is model-level evaluable if it has no (non-implied) &lt;code>ownedSpecializations&lt;/code> and all its &lt;code>ownedFeatures&lt;/code> are either &lt;code>in&lt;/code> parameters, the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> or a result &lt;code>Expression&lt;/code> owned via a &lt;code>ResultExpressionMembership&lt;/code>. The &lt;code>parameters&lt;/code>  must not have any &lt;code>ownedFeatures&lt;/code> or a &lt;code>FeatureValue&lt;/code>, and the result &lt;code>Expression&lt;/code> must be model-level evaluable.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665610668617_859509_2645" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665610668639_614920_2646" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>ownedSpecialization->forAll(isImplied) and 
+ownedFeature->forAll(f |
+    (directionOf(f) = FeatureDirectionKind::_'in' or f = result) and
+        f.ownedFeature->isEmpty() and f.valuation = null or
+    f.owningFeatureMembership.oclIsKindOf(ResultExpressionMembership) and
+        f.oclAsType(Expression).modelLevelEvaluable(visited)
+    </body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665610394961_39498_2642" name="visited" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665610394978_234775_2643" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665610394981_709424_2644" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665516772993_338617_1469" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1606345564739_966196_237" name="evaluate" visibility="public" bodyCondition="_19_0_4_12e503d9_1665530334868_248711_2616" precondition="_19_0_4_12e503d9_1609973227303_385854_1682">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609873334063_264309_20" annotatedElement="_19_0_4_12e503d9_1606345564739_966196_237">
+            <body>&lt;p>If this &lt;code>Expression&lt;/code> &lt;code>isModelLevelEvaluable&lt;/code>, then evaluate it using the &lt;code>target&lt;/code> as the context &lt;code>Element&lt;/code> for resolving &lt;code>Feature&lt;/code> names and testing classification. The result is a collection of &lt;code>Elements&lt;/code>, which, for a fully evaluable &lt;code>Expression&lt;/code>, will be a &lt;code>LiteralExpression&lt;/code> or a &lt;code>Feature&lt;/code> that is not an &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1609973227303_385854_1682" name="evaluatePre" visibility="public" constrainedElement="_19_0_4_12e503d9_1606345564739_966196_237">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1609973227304_614727_1683" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>isModelLevelEvaluable</body>
+            </specification>
+          </ownedRule>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665530334868_248711_2616" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665530334893_884840_2617" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let resultExprs : Sequence(Expression) =
+    ownedFeatureMembership->
+        selectByKind(ResultExpressionMembership).
+        ownedResultExpression in
+if resultExpr->isEmpty() then Sequence{}
+else resultExprs->first().evaluate(target)
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1606345565002_120405_343" name="target" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1606345565003_337417_344" name="result" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" isOrdered="true" isUnique="false" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1608315993123_584606_296" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1608315993126_333565_297" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1609978212607_504892_1812" name="checkCondition" visibility="public" bodyCondition="_19_0_4_12e503d9_1610036679339_209843_1832">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1609978375982_484014_1817" annotatedElement="_19_0_4_12e503d9_1609978212607_504892_1812">
+            <body>&lt;p>Model-level evaluate this &lt;code>Expression&lt;/code> with the given &lt;code>target&lt;/code>. If the result is a &lt;code>LiteralBoolean&lt;/code>, return its &lt;code>value&lt;/code>. Otherwise return &lt;code>false&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1610036679339_209843_1832" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1610036679348_499074_1833" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let results: Sequence(Element) = evaluate(target) in
+    result->size() = 1 and
+    results->first().oclIsKindOf(LiteralBoolean) and 
+    results->first().oclAsType(LiteralBoolean).value</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609978244311_552677_1814" name="target" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1609978244531_113693_1816" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594868945943_862615_2544" name="A_ownedResultExpression_owningResultExpressionMembership" visibility="public" memberEnd="_19_0_2_12e503d9_1594868945944_989058_2545 _19_0_2_12e503d9_1594868945944_113457_2546">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1594868945944_113457_2546" name="owningResultExpressionMembership" visibility="public" type="_19_0_2_12e503d9_1594868887258_973573_2461" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674970_68441_43223" association="_19_0_2_12e503d9_1594868945943_862615_2544">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594869468156_645105_2599" annotatedElement="_19_0_2_12e503d9_1594868945944_113457_2546">
+            <body>&lt;p>The ResultExpressionMembership that owns the &lt;code>ownedResultExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594869017209_571941_2559" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594869017215_767414_2560" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543948400639_634634_20840" name="A_expression_computedFunction" visibility="public" memberEnd="_18_5_3_12e503d9_1543948400639_301251_20841 _18_5_3_12e503d9_1543948400639_994746_20842">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1543948400639_994746_20842" name="computedFunction" visibility="public" type="_18_5_3_12e503d9_1533160651697_513473_42183" subsettedProperty="_18_5_3_b9102da_1536346067213_746991_17344" association="_18_5_3_12e503d9_1543948400639_634634_20840">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624022861752_525614_37507" annotatedElement="_18_5_3_12e503d9_1543948400639_994746_20842">
+            <body>&lt;p>The Functions that hasve a certain &lt;code>expression&lt;/code> as a step.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543948471642_541951_20917" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543948471643_402292_20918" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651697_513473_42183" name="Function" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1578412050365_701336_1252" annotatedElement="_18_5_3_12e503d9_1533160651697_513473_42183">
+          <body>&lt;p>A &lt;code>Function&lt;/code> is a &lt;code>Behavior&lt;/code> that has an &lt;code>out&lt;/code> &lt;code>parameter&lt;/code> that is identified as its &lt;code>result&lt;/code>. A &lt;code>Function&lt;/code> represents the performance of a calculation that produces the values of its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code>. This calculation may be decomposed into &lt;code>Expressions&lt;/code> that are &lt;code>steps&lt;/code> of the &lt;code>Function&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676500886978_483235_360" name="validateFunctionResultParameterMembership" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651697_513473_42183">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676500886994_84211_364" annotatedElement="_19_0_4_12e503d9_1676500886978_483235_360">
+            <body>&lt;p>A &lt;code>Function&lt;/code> must have exactly one &lt;code>featureMembership&lt;/code> (owned or inherited) that is a &lt;code>ResultParameterMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676500886993_751761_363" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureMembership->
+    selectByKind(ReturnParameterMembership)->
+    size() = 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772948357_586741_2195" name="checkFunctionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651697_513473_42183">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847552693_487217_232" annotatedElement="_19_0_4_12e503d9_1667772948357_586741_2195">
+            <body>&lt;p>A &lt;code>Function&lt;/code> must directly or indirectly specialize the base &lt;code>Function&lt;/code> &lt;code>&lt;em>Performances::Evaluation&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772948369_181156_2196" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::Evaluation')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772969430_826200_2197" name="checkFunctionResultBindingConnector" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651697_513473_42183">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1671143146799_26371_101282" annotatedElement="_19_0_4_12e503d9_1667772969430_826200_2197">
+            <body>&lt;p>If a &lt;code>Function&lt;/code> has an &lt;code>Expression&lt;/code> owned via a &lt;code>ResultExpressionMembership&lt;/code>, then the owning &lt;code>Function&lt;/code> must also own a &lt;code>BindingConnector&lt;/code> between its &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> and the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the result &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772969432_131698_2198" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMembership.selectByKind(ResultExpressionMembership)->
+    forAll(mem | ownedFeature.selectByKind(BindingConnector)->
+        exists(binding |
+            binding.relatedFeature->includes(result) and
+            binding.relatedFeature->includes(mem.ownedResultExpression.result)))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676500886952_314334_359" name="deriveFunctionResult" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651697_513473_42183">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676500886991_830615_362" annotatedElement="_19_0_4_12e503d9_1676500886952_314334_359">
+            <body>&lt;p>The &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of a &lt;code>Function&lt;/code> is its &lt;code>parameter&lt;/code> owned (possibly in a supertype) via a &lt;code>ReturnParameterMembership&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676500886981_868621_361" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>result =
+    let resultParams : Sequence(Feature) =
+        featureMemberships->
+            selectByKind(ReturnParameterMembership).
+            ownedMemberParameter in
+    if resultParams->notEmpty() then resultParams->first()
+    else null
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695245244126_408934_151" name="validateFunctionResultExpressionMembership" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651697_513473_42183">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695245244186_507067_153" annotatedElement="_19_0_4_12e503d9_1695245244126_408934_151">
+            <body>&lt;p>A &lt;code>Function&lt;/code> must have at most one &lt;code>ResultExpressionMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695245244167_908144_152" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>membership->selectByKind(ResultExpressionMembership)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674982_359254_43282" general="_18_5_3_12e503d9_1533160651709_376789_42207"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543948400639_301251_20841" name="expression" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" isDerived="true" subsettedProperty="_18_5_3_b9102da_1536346067212_587255_17343" association="_18_5_3_12e503d9_1543948400639_634634_20840">
+          <ownedComment xmi:id="_19_0_2_59601fc_1586208966995_294525_378" annotatedElement="_18_5_3_12e503d9_1543948400639_301251_20841">
+            <body>&lt;p>The &lt;code>Expressions&lt;/code> that are &lt;code>steps&lt;/code> in the calculation of the &lt;code>result&lt;/code> of this &lt;code>Function&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_59601fc_1585935944017_506043_24" annotatedElement="_18_5_3_12e503d9_1543948400639_301251_20841">
+            <body>&lt;p>The set of expressions that represent computational steps or parts of a system of equations within the Function.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543948448562_417089_20889" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543948448563_972055_20890" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543948912268_88159_21323" name="result" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674960_365618_43170 _18_5_3_12e503d9_1543948010065_362066_20413" association="_18_5_3_12e503d9_1543948912268_676930_21322">
+          <ownedComment xmi:id="_19_0_2_59601fc_1586211093394_59796_399" annotatedElement="_18_5_3_12e503d9_1543948912268_88159_21323">
+            <body>&lt;p>The object or value that is the result of evaluating the Function.&lt;/p></body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_59601fc_1585936054247_977149_216" annotatedElement="_18_5_3_12e503d9_1543948912268_88159_21323">
+            <body>&lt;p>The &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>Function&lt;/code>, which is owned by the &lt;code>Function&lt;/code> via a &lt;code>ReturnParameterMembership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543948960199_553805_21359" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543948960200_760213_21360" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617395221463_139517_26381" name="isModelLevelEvaluable" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617395363909_921332_26384" annotatedElement="_19_0_4_12e503d9_1617395221463_139517_26381">
+            <body>&lt;p>Whether this &lt;code>Function&lt;/code> can be used as the &lt;code>function&lt;/code> of a model-level evaluable &lt;code>InvocationExpression&lt;/code>. Certain &lt;code>Functions&lt;/code> from the Kernel Functions Library are considered to have &lt;code>isModelLevelEvaluable = true&lt;/code>. For all other &lt;code>Functions&lt;/code> it is &lt;code>false&lt;/code>.&lt;/p>
+
+&lt;p>&lt;strong>Note:&lt;/strong> See the specification of the KerML concrete syntax notation for &lt;code>Expressions&lt;/code> for an identification of which library &lt;code>Functions&lt;/code> are model-level evaluable.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543948477241_6677_20933" name="A_function_typedExpression" visibility="public" memberEnd="_18_5_3_12e503d9_1543948477241_299049_20934 _18_5_3_12e503d9_1543948477241_327420_20935">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1543948477241_327420_20935" name="typedExpression" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" isDerived="true" subsettedProperty="_18_5_3_b9102da_1536346315176_644912_17389" association="_18_5_3_12e503d9_1543948477241_6677_20933">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624022823581_36812_37506" annotatedElement="_18_5_3_12e503d9_1543948477241_327420_20935">
+            <body>&lt;p>The Expressions that are typed by a certain &lt;code>function&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543948559224_312412_21006" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543948559224_723478_21007" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1594868887258_973573_2461" name="ResultExpressionMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1594869370841_764958_2597" annotatedElement="_19_0_2_12e503d9_1594868887258_973573_2461">
+          <body>&lt;p>A &lt;code>ResultExpressionMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that indicates that the &lt;code>ownedResultExpression&lt;/code> provides the result values for the &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code> that owns it. The owning &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code> must contain a &lt;code>BindingConnector&lt;/code> between the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>ownedResultExpression&lt;/code> and the &lt;code>result&lt;/code> &lt;code>parameter&lt;/code> of the owning &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676501459525_903835_383" name="validateResultExpressionMembershipOwningType" visibility="public" constrainedElement="_19_0_2_12e503d9_1594868887258_973573_2461">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676501548722_279598_385" annotatedElement="_19_0_4_12e503d9_1676501459525_903835_383">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>ResultExpressionMembership&lt;/code> must be a &lt;code>Function&lt;/code> or &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676501459545_225337_384" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsKindOf(Function) or owningType.oclIsKindOf(Expression)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1594868904789_102189_2488" general="_18_5_3_12e503d9_1533160651715_740575_42237"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594868945944_989058_2545" name="ownedResultExpression" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" aggregation="composite" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674993_898044_43344" association="_19_0_2_12e503d9_1594868945943_862615_2544">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594869438810_217493_2598" annotatedElement="_19_0_2_12e503d9_1594868945944_989058_2545">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> that provides the result for the owner of the &lt;code>ResultExpressionMembership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594869013439_2061_2555" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594869013450_726629_2556" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1578025035147_440149_968" name="A_predicate_typedBooleanExpression" visibility="public" memberEnd="_19_0_2_12e503d9_1578025035149_386_969 _19_0_2_12e503d9_1578025035149_512008_970">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1578025035149_512008_970" name="typedBooleanExpression" visibility="public" type="_19_0_2_12e503d9_1578511256733_336334_354" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1543948477241_327420_20935" association="_19_0_2_12e503d9_1578025035147_440149_968">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578025382108_757967_998" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578025382109_760440_999" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1573083330438_373538_3546" name="Multiplicities" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1573086225407_540120_4572" name="MultiplicityRange" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1573231768075_371417_1697" annotatedElement="_19_0_2_12e503d9_1573086225407_540120_4572">
+          <body>&lt;p>A &lt;code>MultiplicityRange&lt;/code> is a &lt;code>Multiplicity&lt;/code> whose value is defined to be the (inclusive) range of natural numbers given by the result of a &lt;code>lowerBound&lt;/code> &lt;code>Expression&lt;/code> and the result of an &lt;code>upperBound&lt;/code> &lt;code>Expression&lt;/code>. The result of these &lt;code>Expressions&lt;/code> shall be of type &lt;code>&lt;em>Natural&lt;/em>&lt;/code>. If the result of the &lt;code>upperBound&lt;/code> &lt;code>Expression&lt;/code> is the unbounded value &lt;code>*&lt;/code>, then the specified range includes all natural numbers greater than or equal to the &lt;code>lowerBound&lt;/code> value. If no &lt;code>lowerBound&lt;/code> &lt;code>Expression&lt;/code>, then the default is that the lower bound has the same value as the upper bound, except if the &lt;code>upperBound&lt;/code> evaluates to &lt;code>*&lt;/code>, in which case the default for the lower bound is 0.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1605479418509_764031_220" name="checkMultiplicityRangeExpressionTypeFeaturing" visibility="public" constrainedElement="_19_0_2_12e503d9_1573086225407_540120_4572">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1605479535025_49461_222" annotatedElement="_19_0_4_12e503d9_1605479418509_764031_220">
+            <body>&lt;p>The &lt;code>bounds&lt;/code> of a &lt;code>MultiplicityRange&lt;/code> must have the same &lt;code>featuringTypes&lt;/code> as the &lt;code>MultiplicityRange&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1605479418510_892864_221" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>bound->forAll(b | b.featuringType = self.featuringType)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676524580375_237724_570" name="validateMultiplicityRangeBoundResultTypes" visibility="public" constrainedElement="_19_0_2_12e503d9_1573086225407_540120_4572">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676524824163_964180_572" annotatedElement="_19_0_4_12e503d9_1676524580375_237724_570">
+            <body>&lt;p>The &lt;code>results&lt;/code> of the &lt;code>bound&lt;/code> &lt;code>Expression(s)&lt;/code> of a &lt;code>MultiplicityRange&lt;/code> must be typed by &lt;code>&lt;em>ScalarValues::Intger&lt;/em>&lt;/code> from the Kernel Data Types Library. If a &lt;code>bound&lt;/code> is model-level evaluable, then it must evaluate to a non-negative value.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676524580392_829065_571" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>bound->forAll(b |
+    b.result.specializesFromLibrary('ScalarValues::Integer') and
+    let value : UnlimitedNatural = valueOf(b) in
+    value &lt;> null implies value >= 0
+)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676524871505_254907_573" name="deriveMultiplicityRangeLowerBound" visibility="public" constrainedElement="_19_0_2_12e503d9_1573086225407_540120_4572">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676525091873_788909_575" annotatedElement="_19_0_4_12e503d9_1676524871505_254907_573">
+            <body>&lt;p>If a &lt;code>MultiplicityRange&lt;/code> has two &lt;code>ownedMembers&lt;/code> that are &lt;code>Expressions&lt;/code>, then the &lt;code>lowerBound&lt;/code> is the first of these, otherwise it is &lt;code>null&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676524871518_332516_574" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>lowerBound =
+    let ownedExpressions : Sequence(Expression) =
+        ownedMember->selectByKind(Expression) in
+    if ownedExpressions->size() &lt; 2 then null
+    else ownedExpressions->first()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676525095519_452941_576" name="deriveMultiplicityRangeUpperBound" visibility="public" constrainedElement="_19_0_2_12e503d9_1573086225407_540120_4572">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676525420494_984504_578" annotatedElement="_19_0_4_12e503d9_1676525095519_452941_576">
+            <body>&lt;p>If a &lt;code>MultiplicityRange&lt;/code> has one &lt;code>ownedMember&lt;/code> that is an &lt;code>Expression&lt;/code>, then this is the &lt;code>upperBound&lt;/code>. If it has more than one &lt;code>ownedMember&lt;/code> that is an &lt;code>Expression&lt;/code>, then the &lt;code>upperBound&lt;/code> is the second of those. Otherwise, it is null.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676525095526_852697_577" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>upperBound =
+    let ownedExpressions : Sequence(Expression) =
+        ownedMember->selectByKind(Expression) in
+    if ownedExpressions->isEmpty() then null
+    else if ownedExpressions->size() = 1 then ownedExpressions->at(1)
+    else ownedExpressions->at(2)
+    endif endif </body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735342549789_515793_62" name="deriveMultiplicityRangeBound" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735342697514_535642_66" annotatedElement="_2022x_2_12e503d9_1735342549789_515793_62">
+            <body>&lt;p>The &lt;code>bounds&lt;/code> of a &lt;code>MultiplicityRange&lt;/code> are the &lt;code>lowerBound&lt;/code> (if any) followed by the &lt;code>upperBound&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735342549790_155187_63" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>bound =
+    if upperBound = null then Sequence{}
+    else if lowerBound = null then Sequence{upperBound}
+    else Sequence{lowerBound, upperBound}
+    endif endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735281569060_359346_49" name="validateMultiplicityRangeBounds" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735281937634_58429_51" annotatedElement="_2022x_2_12e503d9_1735281569060_359346_49">
+            <body>&lt;p>The &lt;code>lowerBound&lt;/code> (if any) and &lt;code>upperBound&lt;/code> &lt;code>Expressions&lt;/code> must be the first &lt;code>ownedMembers&lt;/code> of a &lt;code>MultiplicityRange&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735281569060_546268_50" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if lowerBound = null then
+    ownedMember->notEmpty() and
+    ownedMember->at(1) = upperBound
+else
+    ownedMember->size() > 1 and
+    ownedMember->at(1) = lowerBound and
+    ownedMember->at(2) = upperBound
+endif</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1573086233597_901391_4615" general="_19_0_2_12e503d9_1573083797505_495205_3879"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1573094905677_801324_4744" name="lowerBound" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1573095221994_519580_5095" association="_19_0_2_12e503d9_1573094905676_119428_4743">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1573231922990_415179_1699" annotatedElement="_19_0_2_12e503d9_1573094905677_801324_4744">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> whose result provides the lower bound of the &lt;code>MultiplicityRange&lt;/code>. If no &lt;code>lowerBound&lt;/code> &lt;code>Expression&lt;/code> is given, then the lower bound shall have the same value as the upper bound, unless the upper bound is unbounded (&lt;code>*&lt;/code>), in which case the lower bound shall be 0.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573094940583_1929_4783" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573094940593_864665_4784" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1573094947427_797440_4796" name="upperBound" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1573095221994_519580_5095" association="_19_0_2_12e503d9_1573094947426_419326_4795">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1573231944332_266524_1700" annotatedElement="_19_0_2_12e503d9_1573094947427_797440_4796">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> whose result is the upper bound of the &lt;code>MultiplicityRange&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573094956010_645865_4820" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573094956012_633012_4821" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1573095221994_519580_5095" name="bound" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_259543_43268" association="_19_0_2_12e503d9_1573095221993_983755_5094">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1573231807641_656305_1698" annotatedElement="_19_0_2_12e503d9_1573095221994_519580_5095">
+            <body>&lt;p>The owned &lt;code>Expressions&lt;/code> of the &lt;code>MultiplicityRange&lt;/code> whose results provide its bounds. These must be the first &lt;code>ownedMembers&lt;/code> of the &lt;code>MultiplicityRange&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573095253271_803111_5125" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573095253272_211437_5126" name="" visibility="public" value="2"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1673301268284_910060_977" name="hasBounds" visibility="public" bodyCondition="_19_0_4_12e503d9_1673301752676_602003_983">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673301707648_410659_982" annotatedElement="_19_0_4_12e503d9_1673301268284_910060_977">
+            <body>&lt;p>Check whether this &lt;code>MultiplicityRange&lt;/code> represents the range bounded by the given values &lt;code>lower&lt;/code> and &lt;code>upper&lt;/code>, presuming the &lt;code>lowerBound&lt;/code> and &lt;code>upperBound&lt;/code> &lt;code>Expressions&lt;/code> are model-level evaluable.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1673301752676_602003_983" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673301752689_790734_984" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>valueOf(upperBound) = upper and
+let lowerValue: UnlimitedNatural = valueOf(lowerBound) in
+(lowerValue = lower or
+ lowerValue = null and 
+    (lower = upper or 
+     lower = 0 and upper = *))
+ </body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673301328431_669573_979" name="lower" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673301328477_468279_980" name="upper" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#UnlimitedNatural"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673301336984_478658_981" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1673302061587_127252_985" name="valueOf" visibility="public" bodyCondition="_19_0_4_12e503d9_1673302530622_541080_997">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676523889188_341307_564" annotatedElement="_19_0_4_12e503d9_1673302061587_127252_985">
+            <body>&lt;p>Evaluate the given &lt;code>bound&lt;/code> &lt;code>Expression&lt;/code> (at model level) and return the result represented as a MOF &lt;code>UnlimitedNatural&lt;/code> value.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1673302530622_541080_997" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673302530644_549898_998" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if bound = null or not bound.isModelLevelEvaluable then 
+    null
+else
+    let boundEval: Sequence(Element) = bound.evaluate(owningType) in
+    if boundEval->size() &lt;> 1 then null else
+        let valueEval: Element = boundEval->at(1) in
+        if valueEval.oclIsKindOf(LiteralInfinity) then *
+        else if valueEval.oclIsKindOf(LiteralInteger) then
+            let value : Integer = 
+                valueEval.oclAsKindOf(LiteralInteger).value in
+            if value >= 0 then value else null endif
+        else null
+        endif endif
+    endif
+endif </body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673302237531_9721_994" name="bound" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1673302237551_269342_995" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1673302237552_874859_996" name="" visibility="public" value="1"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673302101491_547213_988" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#UnlimitedNatural"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1673302101499_144247_989" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1673302101501_702461_990" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1573094905676_119428_4743" name="A_lowerBound_multiplicity" visibility="public" memberEnd="_19_0_2_12e503d9_1573094905677_801324_4744 _19_0_2_12e503d9_1573094905677_410723_4745">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1573094905677_410723_4745" name="multiplicity" visibility="public" type="_19_0_2_12e503d9_1573086225407_540120_4572" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1573095221994_12294_5096" association="_19_0_2_12e503d9_1573094905676_119428_4743">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573094966543_937332_4830" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573094966544_570000_4831" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1573094947426_419326_4795" name="A_upperBound_multiplicity" visibility="public" memberEnd="_19_0_2_12e503d9_1573094947427_797440_4796 _19_0_2_12e503d9_1573094947428_871971_4797">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1573094947428_871971_4797" name="multiplicity" visibility="public" type="_19_0_2_12e503d9_1573086225407_540120_4572" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1573095221994_12294_5096" association="_19_0_2_12e503d9_1573094947426_419326_4795">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573094983465_89488_4846" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573094983468_553218_4847" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1573095221993_983755_5094" name="A_bound_multiplicity" visibility="public" memberEnd="_19_0_2_12e503d9_1573095221994_519580_5095 _19_0_2_12e503d9_1573095221994_12294_5096">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1573095221994_12294_5096" name="multiplicity" visibility="public" type="_19_0_2_12e503d9_1573086225407_540120_4572" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674965_592215_43200" association="_19_0_2_12e503d9_1573095221993_983755_5094">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573232113767_629056_1739" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573232113767_360267_1740" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1533160651674_188631_42139" name="Behaviors" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_b9102da_1536346315175_583442_17387" name="A_behavior_typedStep" visibility="public" memberEnd="_18_5_3_b9102da_1536346315176_954314_17388 _18_5_3_b9102da_1536346315176_644912_17389">
+        <ownedEnd xmi:id="_18_5_3_b9102da_1536346315176_644912_17389" name="typedStep" visibility="public" type="_18_5_3_b9102da_1536345916995_711141_17306" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674973_102139_43242" association="_18_5_3_b9102da_1536346315175_583442_17387">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_b9102da_1536346463600_587963_17425" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_b9102da_1536346463601_277271_17426" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1543948010065_16339_20412" name="A_parameter_parameteredBehavior" visibility="public" memberEnd="_18_5_3_12e503d9_1543948010065_362066_20413 _18_5_3_12e503d9_1543948010066_582406_20414">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1543948010066_582406_20414" name="parameteredBehavior" visibility="public" type="_18_5_3_12e503d9_1533160651709_376789_42207" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674987_297074_43308" association="_18_5_3_12e503d9_1543948010065_16339_20412">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543948161669_123056_20509" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543948161670_557319_20510" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_b9102da_1536345916995_711141_17306" name="Step" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1585936268306_262042_239" annotatedElement="_18_5_3_b9102da_1536345916995_711141_17306">
+          <body>&lt;p>A &lt;code>Step&lt;/code> is a &lt;code>Feature&lt;/code> that is typed by one or more &lt;code>Behaviors&lt;/code>. &lt;code>Steps&lt;/code> may be used by one &lt;code>Behavior&lt;/code> to coordinate the performance of other &lt;code>Behaviors&lt;/code>, supporting a steady refinement of behavioral descriptions. &lt;code>Steps&lt;/code> can be ordered in time and can be connected using &lt;code>Flows&lt;/code> to specify things flowing between their &lt;code>parameters&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772743637_453459_2187" name="checkStepSpecialization" visibility="public" constrainedElement="_18_5_3_b9102da_1536345916995_711141_17306">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847460525_551468_229" annotatedElement="_19_0_4_12e503d9_1667772743637_453459_2187">
+            <body>&lt;p>A &lt;code>Step&lt;/code> must directly or indirectly specialize the base &lt;code>Step&lt;/code> &lt;code>&lt;em>Performances::performances&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772743648_357711_2188" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Performances::performances')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772769395_510623_2189" name="checkStepEnclosedPerformanceSpecialization" visibility="public" constrainedElement="_18_5_3_b9102da_1536345916995_711141_17306">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669935862091_818130_719" annotatedElement="_19_0_4_12e503d9_1667772769395_510623_2189">
+            <body>&lt;p>A&lt;code>Step&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>Behavior&lt;/code> or another &lt;code>Step&lt;/code> must directly or indirectly specialize the &lt;code>Step&lt;/code> &lt;code>&lt;em>Performances::Performance::enclosedPerformance&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772769399_38590_2190" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+    (owningType.oclIsKindOf(Behavior) or
+     owningType.oclIsKindOf(Step)) implies
+    specializesFromLibrary('Performances::Performance::enclosedPerformance')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772897964_884886_2193" name="checkStepOwnedPerformanceSpecialization" visibility="public" constrainedElement="_18_5_3_b9102da_1536345916995_711141_17306">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669936039456_384112_721" annotatedElement="_19_0_4_12e503d9_1667772897964_884886_2193">
+            <body>&lt;p>A composite &lt;code>Step&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>Structure&lt;/code> or a &lt;code>Feature&lt;/code> typed by a &lt;code>Structure&lt;/code> must directly or indirectly specialize the &lt;code>Step&lt;/code> &lt;code>&lt;em>Objects::Object::ownedPerformance&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772897970_41191_2194" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(Structure) or
+ owningType.oclIsKindOf(Feature) and
+ owningType.oclAsType(Feature).type->
+    exists(oclIsKindOf(Structure)) implies
+    specializesFromLibrary('Objects::Object::ownedPerformance')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772806539_735695_2191" name="checkStepSubperformanceSpecialization" visibility="public" constrainedElement="_18_5_3_b9102da_1536345916995_711141_17306">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669935962542_643397_720" annotatedElement="_19_0_4_12e503d9_1667772806539_735695_2191">
+            <body>&lt;p>A&lt;code>Step&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>Behavior&lt;/code> or another &lt;code>Step&lt;/code>, and which is composite, must directly or indirectly specialize the &lt;code>Step&lt;/code> &lt;code>&lt;em>Performances::Performance::subperformance&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772806545_586741_2192" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+    (owningType.oclIsKindOf(Behavior) or
+     owningType.oclIsKindOf(Step)) and
+    self.isComposite implies
+    specializesFromLibrary('Performances::Performance::subperformance')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676497200310_494927_316" name="deriveStepBehavior" visibility="public" constrainedElement="_18_5_3_b9102da_1536345916995_711141_17306">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676497297599_425674_318" annotatedElement="_19_0_4_12e503d9_1676497200310_494927_316">
+            <body>&lt;p>The &lt;code>behaviors&lt;/code> of a &lt;code>Step&lt;/code> are all its &lt;code>types&lt;/code> that are &lt;code>Behaviors&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676497200321_118788_317" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>behavior = type->selectByKind(Behavior)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_b9102da_1536345937196_302561_17337" general="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+        <ownedAttribute xmi:id="_18_5_3_b9102da_1536346315176_954314_17388" name="behavior" visibility="public" type="_18_5_3_12e503d9_1533160651709_376789_42207" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674969_376003_43216" association="_18_5_3_b9102da_1536346315175_583442_17387">
+          <ownedComment xmi:id="_19_0_2_59601fc_1583522168701_432509_754" annotatedElement="_18_5_3_b9102da_1536346315176_954314_17388">
+            <body>&lt;p>The &lt;code>Behaviors&lt;/code> that type this &lt;code>Step&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_b9102da_1536346355696_849374_17410" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_b9102da_1536346355696_299871_17411" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1595189174990_213826_657" name="parameter" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1623952188842_882068_37169" association="_19_0_2_12e503d9_1595189174990_14972_656">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607318803662_537647_10" annotatedElement="_19_0_2_12e503d9_1595189174990_213826_657">
+            <body>&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>Step&lt;/code>, which are defined as its &lt;code>directedFeatures&lt;/code>, whose values are passed into and/or out of a performance of the &lt;code>Step&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595189237799_751304_717" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595189237799_798788_718" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651709_376789_42207" name="Behavior" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1586214061488_638013_436" annotatedElement="_18_5_3_12e503d9_1533160651709_376789_42207">
+          <body>&lt;p>A &lt;code>Behavior &lt;/code>coordinates occurrences of other &lt;code>Behaviors&lt;/code>, as well as changes in objects. &lt;code>Behaviors&lt;/code> can be decomposed into &lt;code>Steps&lt;/code> and be characterized by &lt;code>parameters&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1702143183819_830903_5" name="validateBehaviorSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651709_376789_42207">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1702143727669_339913_12" annotatedElement="_19_0_4_12e503d9_1702143183819_830903_5">
+            <body>&lt;p>A &lt;code>Behavior&lt;/code> must not specialize a &lt;code>Structure&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1702143183839_385436_6" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedSpecialization.general->forAll(not oclIsKindOf(Structure))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1610038215925_634065_1248" name="checkBehaviorSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651709_376789_42207">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847404324_89373_212" annotatedElement="_19_0_4_b9102da_1610038215925_634065_1248">
+            <body>&lt;p>A &lt;code>Behavior&lt;/code> must directly or indirectly specialize the base &lt;code>Behavior&lt;/code> &lt;code>&lt;em>Performances::Performance&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1610038215925_707519_1249" name="" visibility="public">
+            <language>English</language>
+            <body>specializesFromLibrary('Performances::Performance')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676496169138_179617_285" name="deriveBehaviorStep" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651709_376789_42207">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676496278445_179351_287" annotatedElement="_19_0_4_12e503d9_1676496169138_179617_285">
+            <body>&lt;p>The &lt;code>steps&lt;/code> of a &lt;code>Behavior&lt;/code> are its &lt;code>features&lt;/code> that are &lt;code>Steps&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676496169147_241454_286" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>step = feature->selectByKind(Step)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674959_373316_43162" general="_18_5_3_12e503d9_1557527582956_258352_110280"/>
+        <ownedAttribute xmi:id="_18_5_3_b9102da_1536346067212_587255_17343" name="step" visibility="public" type="_18_5_3_b9102da_1536345916995_711141_17306" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674959_326391_43166" association="_18_5_3_b9102da_1536346067212_389011_17342">
+          <ownedComment xmi:id="_19_0_2_59601fc_1583521768099_191241_733" annotatedElement="_18_5_3_b9102da_1536346067212_587255_17343">
+            <body>&lt;p>The &lt;code>Steps&lt;/code> that make up this &lt;code>Behavior&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_b9102da_1536346190768_381817_17365" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_b9102da_1536346190768_877331_17366" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1543948010065_362066_20413" name="parameter" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1623952188842_882068_37169" association="_18_5_3_12e503d9_1543948010065_16339_20412">
+          <ownedComment xmi:id="_19_0_2_59601fc_1583521818613_465791_734" annotatedElement="_18_5_3_12e503d9_1543948010065_362066_20413">
+            <body>&lt;p>The parameters of this &lt;code>Behavior&lt;/code>, which are defined as its &lt;code>directedFeatures&lt;/code>, whose values are passed into and/or out of a performance of the &lt;code>Behavior&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1543948092990_335708_20483" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1543948092990_560434_20484" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1595189174990_14972_656" name="A_parameter_parameteredStep" visibility="public" memberEnd="_19_0_2_12e503d9_1595189174990_213826_657 _19_0_2_12e503d9_1595189174991_690604_658">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1595189174991_690604_658" name="parameteredStep" visibility="public" type="_18_5_3_b9102da_1536345916995_711141_17306" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674987_297074_43308" association="_19_0_2_12e503d9_1595189174990_14972_656">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595189259926_472895_735" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595189259927_737667_736" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_b9102da_1536346067212_389011_17342" name="A_step_featuringBehavior" visibility="public" memberEnd="_18_5_3_b9102da_1536346067212_587255_17343 _18_5_3_b9102da_1536346067213_746991_17344">
+        <ownedEnd xmi:id="_18_5_3_b9102da_1536346067213_746991_17344" name="featuringBehavior" visibility="public" type="_18_5_3_12e503d9_1533160651709_376789_42207" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674987_297074_43308" association="_18_5_3_b9102da_1536346067212_389011_17342">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_b9102da_1536346253060_353286_17377" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_b9102da_1536346253060_41702_17378" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1557527738711_165124_110466" name="ParameterMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591136089756_529860_1663" annotatedElement="_18_5_3_12e503d9_1557527738711_165124_110466">
+          <body>&lt;p>A &lt;code>ParameterMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that identifies its &lt;code>memberFeature&lt;/code> as a parameter, which is always owned, and must have a &lt;code>direction&lt;/code>. A &lt;code>ParameterMembership&lt;/code> must be owned by a &lt;code>Behavior&lt;/code>, a &lt;code>Step&lt;/code>, or the &lt;code>result&lt;/code> parameter of a &lt;code>ConstructorExpression&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676496524040_828309_306" name="validateParameterMembershipParameterDirection" visibility="public" constrainedElement="_18_5_3_12e503d9_1557527738711_165124_110466">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676496764792_279013_315" annotatedElement="_19_0_4_12e503d9_1676496524040_828309_306">
+            <body>&lt;p>The &lt;code>ownedMemberParameter&lt;/code> of a &lt;code>ParameterMembership&lt;/code> must have a  &lt;code>direction&lt;/code> equal to the result of the &lt;code>parameterDirection()&lt;/code> operation.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676496524046_835893_307" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMemberParameter.direction = parameterDirection()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676496621151_204406_310" name="validateParameterMembershipOwningType" visibility="public" constrainedElement="_18_5_3_12e503d9_1557527738711_165124_110466">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676496704395_822924_314" annotatedElement="_19_0_4_12e503d9_1676496621151_204406_310">
+            <body>&lt;p>A &lt;code>ParameterMembership&lt;/code> must be owned by a &lt;code>Behavior&lt;/code>,&lt;code>Step&lt;/code>, or the &lt;code>result&lt;/code> parameter of a &lt;code>ConstructorExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676496621166_4667_311" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsKindOf(Behavior) or owningType.oclIsKindOf(Step) or
+owningType.owningMembership.oclIsKindOf(ReturnParameterMembership) and
+    owningType.owningNamespace.oclIsKindOf(ConstructorExpression)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1557527765569_26618_110514" general="_18_5_3_12e503d9_1533160651715_740575_42237"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1557528016548_548098_110830" name="ownedMemberParameter" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" aggregation="composite" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674993_898044_43344" association="_18_5_3_12e503d9_1557528016548_99231_110829">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1607319621171_30522_15" annotatedElement="_18_5_3_12e503d9_1557528016548_548098_110830">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that is identified as a &lt;code>parameter&lt;/code> by this &lt;code>ParameterMembership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1557528064019_459933_110902" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1557528064019_748218_110903" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1705637204486_718324_854" name="parameterDirection" visibility="public" bodyCondition="_19_0_4_12e503d9_1705637293411_17029_861">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1705637266728_76257_860" annotatedElement="_19_0_4_12e503d9_1705637204486_718324_854">
+            <body>&lt;p>Return the required value of the &lt;code>direction&lt;/code> of the &lt;code>ownedMemberParameter&lt;/code>. By default, this is &lt;code>in&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1705637293411_17029_861" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1705637293435_315064_862" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>FeatureDirectionKind::_'in'</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1705637218102_889623_856" name="" visibility="public" type="_18_5_3_12e503d9_1533160651677_936694_42144" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1705637218159_937568_858" name="" visibility="public" value="1"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1705637218162_367771_859" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_b9102da_1536782559562_819607_21388" name="A_involvesFeature_Behavior" visibility="public" memberEnd="_18_5_3_b9102da_1536782559563_339505_21389 _18_5_3_b9102da_1536782559563_895817_21390" navigableOwnedEnd="_18_5_3_b9102da_1536782559563_339505_21389">
+        <ownedEnd xmi:id="_18_5_3_b9102da_1536782559563_895817_21390" name="" visibility="public" type="_18_5_3_12e503d9_1533160651709_376789_42207" association="_18_5_3_b9102da_1536782559562_819607_21388"/>
+        <ownedEnd xmi:id="_18_5_3_b9102da_1536782559563_339505_21389" name="involvesFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" association="_18_5_3_b9102da_1536782559562_819607_21388">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1555100590970_907842_27443" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_b9102da_1536867986029_821184_17608" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1557528016548_99231_110829" name="A_ownedMemberParameter_owningParameterMembership" visibility="public" memberEnd="_18_5_3_12e503d9_1557528016548_548098_110830 _18_5_3_12e503d9_1557528016548_348211_110831">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1557528016548_348211_110831" name="owningParameterMembership" visibility="public" type="_18_5_3_12e503d9_1557527738711_165124_110466" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674970_68441_43223" association="_18_5_3_12e503d9_1557528016548_99231_110829">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1557528060680_699516_110896" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1557528060681_870337_110897" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_4_12e503d9_1606345839028_469476_2033" name="Metadata" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1645120910786_720932_39" name="Metaclass" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1648591445041_584908_77" annotatedElement="_19_0_4_12e503d9_1645120910786_720932_39">
+          <body>&lt;p>A &lt;code>Metaclass&lt;/code> is a &lt;code>Structure&lt;/code> used to type &lt;code>MetadataFeatures&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667787737820_778399_2232" name="checkMetaclassSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1645120910786_720932_39">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669849473275_47917_282" annotatedElement="_19_0_4_12e503d9_1667787737820_778399_2232">
+            <body>&lt;p>A &lt;code>Metaclass&lt;/code> must directly or indirectly specialize the base &lt;code>Metaclass&lt;/code> &lt;code>&lt;em>Metaobjects::Metaobject&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667787737836_278416_2233" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Metaobjects::Metaobject')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1645120923894_436130_64" general="_19_0_4_b9102da_1609606051359_625961_451"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1606345563822_968574_178" name="MetadataFeature" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1608310278537_384026_278" annotatedElement="_19_0_4_12e503d9_1606345563822_968574_178">
+          <body>&lt;p>A &lt;code>MetadataFeature&lt;/code> is a &lt;code>Feature&lt;/code> that is an &lt;code>AnnotatingElement&lt;/code> used to annotate another &lt;code>Element&lt;/code> with metadata. It is typed by a &lt;code>Metaclass&lt;/code>. All its &lt;code>ownedFeatures&lt;/code> must redefine &lt;code>features&lt;/code> of its &lt;code>metaclass&lt;/code> and any feature bindings must be model-level evaluable.&lt;/p>
+
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1705638308677_768542_1003" name="validateMetadataFeatureMetaclass" visibility="public" constrainedElement="_19_0_4_12e503d9_1606345563822_968574_178">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1705638356082_563387_1005" annotatedElement="_19_0_4_12e503d9_1705638308677_768542_1003">
+            <body>&lt;p>A &lt;code>MetadataFeature&lt;/code> must have exactly one &lt;code>type&lt;/code> that is a &lt;code>Metaclass&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1705638308693_786741_1004" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>type->selectByKind(Metaclass).size() = 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695246087815_369542_182" name="validateMetadataFeatureMetaclassNotAbstract" visibility="public" constrainedElement="_19_0_4_12e503d9_1606345563822_968574_178">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695246143800_294518_184" annotatedElement="_19_0_4_12e503d9_1695246087815_369542_182">
+            <body>&lt;p>The &lt;code>metaclass&lt;/code> of a &lt;code>MetadataFeature&lt;/code> must not be abstract.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695246087831_113876_183" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>not metaclass.isAbstract</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667787778828_597191_2234" name="checkMetadataFeatureSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1606345563822_968574_178">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669849541272_854310_283" annotatedElement="_19_0_4_12e503d9_1667787778828_597191_2234">
+            <body>&lt;p>A &lt;code>MetadataFeature&lt;/code> must directly or indirectly specialize the base &lt;code>MetadataFeature&lt;/code> &lt;code>&lt;em>Metaobjects::metaobjects&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667787778830_636761_2235" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Metaobjects::metaobjects')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695246430764_45012_188" name="validateMetadataFeatureBody" visibility="public" constrainedElement="_19_0_4_12e503d9_1606345563822_968574_178">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695246545730_406961_190" annotatedElement="_19_0_4_12e503d9_1695246430764_45012_188">
+            <body>&lt;p>Each &lt;code>ownedFeature&lt;/code> of a &lt;code>MetadataFeature&lt;/code> must have no declared name, redefine a single &lt;code>Feature&lt;/code>, either have no &lt;code>featureValue&lt;/code> or a &lt;code>featureValue&lt;/code> with a &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> that is model-level evaluable, and only have &lt;code>ownedFeatures&lt;/code> that also meet these restrictions.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695246430777_850739_189" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedFeature->closure(ownedFeature)->forAll(f |
+    f.declaredName = null and f.declaredShortName = null and
+    f.valuation &lt;> null implies f.valuation.value.isModelLevelEvaluable and
+    f.redefinition.redefinedFeature->size() = 1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1705638210155_241836_1000" name="deriveMetadataFeatureMetaclass" visibility="public" constrainedElement="_19_0_4_12e503d9_1606345563822_968574_178">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1705638226628_611885_1002" annotatedElement="_19_0_4_12e503d9_1705638210155_241836_1000">
+            <body>&lt;p>The &lt;code>metaclass&lt;/code> of a &lt;code>MetadataFeature&lt;/code> is one of its &lt;code>types&lt;/code> that is a &lt;code>Metaclass&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1705638210181_570700_1001" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>metaclass = 
+    let metaclassTypes : Sequence(Type) = type->selectByKind(Metaclass) in
+    if metaclassTypes->isEmpty() then null
+    else metaClassTypes->first()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695246164562_639293_185" name="validateMetadataFeatureAnnotatedElement" visibility="public" constrainedElement="_19_0_4_12e503d9_1606345563822_968574_178">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695246420990_314477_187" annotatedElement="_19_0_4_12e503d9_1695246164562_639293_185">
+            <body>&lt;p>The &lt;code>annotatedElements&lt;/code> of a &lt;code>MetadataFeature&lt;/code> must have an abstract syntax metaclass consistent with the &lt;code>annotatedElement&lt;/code> declarations for the &lt;code>MetadataFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695246164582_309211_186" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let baseAnnotatedElementFeature : Feature =
+    resolveGlobal('Metaobjects::Metaobject::annotatedElement').memberElement.
+    oclAsType(Feature) in
+let annotatedElementFeatures : OrderedSet(Feature) = feature->
+    select(specializes(baseAnnotatedElementFeature))->
+    excluding(baseAnnotatedElementFeature) in
+annotatedElementFeatures->notEmpty() implies
+    let annotatedElementTypes : Set(Feature) =
+        annotatedElementFeatures.typing.type->asSet() in
+    let metaclasses : Set(Metaclass) =
+        annotatedElement.oclType().qualifiedName->collect(qn | 
+            resolveGlobal(qn).memberElement.oclAsType(Metaclass)) in
+   metaclasses->forAll(m | annotatedElementTypes->exists(t | m.specializes(t)))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1669909163399_137620_576" name="checkMetadataFeatureSemanticSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1606345563822_968574_178">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669924865990_249228_696" annotatedElement="_19_0_4_12e503d9_1669909163399_137620_576">
+            <body>&lt;p>If this &lt;code>MetadataFeature&lt;/code> is an application of &lt;code>&lt;em>SemanticMetadata&lt;/em>&lt;/code>, then its &lt;code>annotatingElement&lt;/code> must be a &lt;code>Type&lt;/code>. The annotated &lt;code>Type&lt;/code> must then directly or indirectly specialize the specified value of the &lt;code>&lt;em>baseType&lt;/em>&lt;/code>, &lt;em>unless&lt;/em> the &lt;code>Type&lt;/code> is a &lt;code>Classifier&lt;/code> and the &lt;code>&lt;em>baseType&lt;/em>&lt;/code> represents a kind of &lt;code>Feature&lt;/code>, in which case the &lt;code>Classifier&lt;/code> must directly or indirectly specialize each of the &lt;code>types&lt;/code> of the &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669909163415_640301_577" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSemantic() implies
+    let annotatedTypes : Sequence(Type) = 
+        annotatedElement->selectAsKind(Type) in
+    let baseTypes : Sequence(MetadataFeature) = 
+        evaluateFeature(resolveGlobal(
+            'Metaobjects::SemanticMetadata::baseType').
+            memberElement.
+            oclAsType(Feature))->
+        selectAsKind(MetadataFeature) in
+    annotatedTypes->notEmpty() and 
+    baseTypes()->notEmpty() and 
+    baseTypes()->first().isSyntactic() implies
+        let annotatedType : Type = annotatedTypes->first() in
+        let baseType : Element = baseTypes->first().syntaxElement() in
+        if annotatedType.oclIsKindOf(Classifier) and 
+            baseType.oclIsKindOf(Feature) then
+            baseType.oclAsType(Feature).type->
+                forAll(t | annotatedType.specializes(t))
+        else if baseType.oclIsKindOf(Type) then
+            annotatedType.specializes(baseType.oclAsType(Type))
+        else
+            true
+        endif</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1606345564959_65881_329" general="_19_0_2_12e503d9_1594145576693_532940_27"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1606345564959_984473_330" general="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1606345564958_925589_327" name="metaclass" visibility="public" type="_19_0_4_12e503d9_1645120910786_720932_39" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674969_376003_43216" association="_19_0_4_12e503d9_1606345563823_608059_179">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1608310316840_749373_279" annotatedElement="_19_0_4_12e503d9_1606345564958_925589_327">
+            <body>&lt;p>The &lt;code>type&lt;/code> of this &lt;code>MetadataFeature&lt;/code>, which must be a &lt;code>Metaclass&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606345565052_309031_459" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606345565052_124807_458" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669919481413_895086_596" name="evaluateFeature" visibility="public" bodyCondition="_19_0_4_12e503d9_1669932400681_675669_699">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669924044119_484416_681" annotatedElement="_19_0_4_12e503d9_1669919481413_895086_596">
+            <body>&lt;p>If the given &lt;code>baseFeature&lt;/code> is a &lt;code>feature&lt;/code> of this &lt;code>MetadataFeature&lt;/code>, or is directly or indirectly redefined by a &lt;code>feature&lt;/code>, then return the result of evaluating the appropriate (model-level evaluable) &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> for it (if any), with the &lt;code>MetadataFeature&lt;/code> as the target.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1669932400681_675669_699" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669932400707_284826_700" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let selectedFeatures : Sequence(Feature) = feature->
+    select(closure(ownedRedefinition.redefinedFeature)->
+           includes(baseFeature)) in
+if selectedFeatures->isEmpty() then null
+else
+    let selectedFeature : Feature = selectedFeatures->first() in
+    let featureValues : FeatureValue = selectedFeature->
+        closure(ownedRedefinition.redefinedFeature).ownedMember->
+        selectAsKind(FeatureValue) in
+    if featureValues->isEmpty() then null
+    else featureValues->first().value.evaluate(self)
+    endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669919504014_644763_600" name="baseFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669924091125_229779_682" name="" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1669924091134_740694_683" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1669924091137_318324_684" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669909038710_689668_492" name="isSemantic" visibility="public" bodyCondition="_19_0_4_12e503d9_1669909152366_297943_570">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669923842012_162373_679" annotatedElement="_19_0_4_12e503d9_1669909038710_689668_492">
+            <body>&lt;p>Check if this &lt;code>MetadataFeature&lt;/code> has a &lt;code>metaclass&lt;/code> which is a kind of &lt;code>&lt;em>SemanticMetadata&lt;/code>.&lt;p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1669909152366_297943_570" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669909152386_229297_571" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>specializesFromLibrary('Metaobjects::SemanticMetadata')</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669909066905_669331_497" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669919457862_937784_584" name="isSyntactic" visibility="public" bodyCondition="_19_0_4_12e503d9_1669924176941_110684_685">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669923924248_979289_680" annotatedElement="_19_0_4_12e503d9_1669919457862_937784_584">
+            <body>&lt;p>Check if this &lt;code>MetadataFeature&lt;/code> has a &lt;code>metaclass&lt;/code> that is a kind of &lt;code>&lt;em>KerML::Element&lt;/em>&lt;/code> (that is, it is from the reflective abstract syntax model).&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1669924176941_110684_685" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669924176959_669341_686" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>specializesFromLibrary('KerML::Element')</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669919478683_822317_589" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1669919510007_910871_607" name="syntaxElement" visibility="public" bodyCondition="_19_0_4_12e503d9_1676526065053_58559_579" precondition="_19_0_4_12e503d9_1669924456964_79327_694">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669924341089_641386_693" annotatedElement="_19_0_4_12e503d9_1669919510007_910871_607">
+            <body>&lt;p>If this &lt;code>MetadataFeature&lt;/code> reflectively represents a model element, then return the corresponding &lt;code>Element&lt;/code> instance from the MOF abstract syntax representation of the model.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1676526065053_58559_579" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676526065065_371654_580" name="" visibility="public">
+              <language>English</language>
+              <body>No OCL</body>
+            </specification>
+          </ownedRule>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1669924456964_79327_694" name="syntaxElement_pre" visibility="public" constrainedElement="_19_0_4_12e503d9_1669919510007_910871_607">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1669924456983_851807_695" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>isSyntactic()</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1669919581178_739094_616" name="" visibility="public" type="_18_5_3_12e503d9_1533160651703_306405_42199" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1669919581190_115264_617" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1669919581194_42241_618" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1606345563823_608059_179" name="A_metaclass_typedMetadata" visibility="public" memberEnd="_19_0_4_12e503d9_1606345564958_925589_327 _19_0_4_12e503d9_1606345564959_551738_331">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1606345564959_551738_331" name="typedMetadata" visibility="public" type="_19_0_4_12e503d9_1606345563822_968574_178" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674973_102139_43242" association="_19_0_4_12e503d9_1606345563823_608059_179">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1648594912527_329153_894" annotatedElement="_19_0_4_12e503d9_1606345564959_551738_331">
+            <body>&lt;p>The MetadataFeatures whose &lt;code>type&lt;/code> is a certain Metaclass.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1647726145516_22652_1860" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1647726145528_534279_1861" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1557527518556_499681_110193" name="DataTypes" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1557527599533_240072_110321" name="DataType" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1583525594088_261499_363" annotatedElement="_18_5_3_12e503d9_1557527599533_240072_110321">
+          <body>&lt;p>A &lt;code>DataType&lt;/code> is a &lt;code>Classifier&lt;/code> of things (in the universe) that can only be distinguished by how they are related to other things (via Features). This means multiple things classified by the same &lt;code>DataType&lt;/code>&lt;/p>
+
+&lt;ul>
+	&lt;li>Cannot be distinguished when they are related to other things in exactly the same way, even when they are intended to be about different things.&lt;/li>
+	&lt;li>Can be distinguished when they are related to other things in different ways, even when they are intended to be about the same thing.&lt;/li>
+&lt;/ul>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1660171318970_583517_1630" name="validateDataTypeSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1557527599533_240072_110321">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1660171439603_252853_1634" annotatedElement="_19_0_4_12e503d9_1660171318970_583517_1630">
+            <body>&lt;p>A &lt;code>DataType&lt;/code> must not specialize a &lt;code>Class&lt;/code> or an &lt;code>Association&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1660171319008_517650_1631" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedSpecialization.general->
+    forAll(not oclIsKindOf(Class) and 
+           not oclIsKindOf(Association))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1610037889057_449569_1244" name="checkDataTypeSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1557527599533_240072_110321">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1667164373135_395826_84" annotatedElement="_19_0_4_b9102da_1610037889057_449569_1244">
+            <body>&lt;p>A &lt;code>DataType&lt;/code> must directly or indirectly specialize the base &lt;code>DataType&lt;/code> &lt;code>&lt;em>Base::DataValue&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1610037889057_808853_1245" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Base::DataValue')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1557527608945_877250_110363" general="_18_5_3_12e503d9_1533160651676_375105_42143"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1561109886522_470597_23335" name="Associations" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_b9102da_1609608726569_644338_601" name="AssociationStructure" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1676489560419_980864_115" annotatedElement="_19_0_4_b9102da_1609608726569_644338_601">
+          <body>&lt;p>An &lt;code>AssociationStructure&lt;/code> is an &lt;code>Association&lt;/code> that is also a &lt;code>Structure&lt;/code>, classifying link objects that are both links and objects. As objects, link objects can be created and destroyed, and their non-end &lt;code>Features&lt;/code> can change over time. However, the values of the end &lt;code>Features&lt;/code> of a link object are fixed and cannot change over its lifetime.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_b9102da_1610038337019_637534_1256" name="checkAssociationStructureSpecialization" visibility="public" constrainedElement="_19_0_4_b9102da_1609608726569_644338_601">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847172478_728037_205" annotatedElement="_19_0_4_b9102da_1610038337019_637534_1256">
+            <body>&lt;p>An &lt;code>AssociationStructure&lt;/code> must directly or indirectly specialize the base &lt;code>AssociationStructure&lt;/code> &lt;code>&lt;em>Objects::LinkObject&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1610038337020_171048_1257" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Objects::LinkObject')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667165193128_51084_87" name="checkAssociationStructureBinarySpecialization" visibility="public" constrainedElement="_19_0_4_b9102da_1609608726569_644338_601">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847187949_29777_206" annotatedElement="_19_0_4_12e503d9_1667165193128_51084_87">
+            <body>&lt;p>A binary &lt;code>AssociationStructure&lt;/code> must directly or indirectly specialize the base &lt;code>AssociationStructure&lt;/code> &lt;code>&lt;em>Objects::BinaryLinkObject&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667165193148_987910_88" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>endFeature->size() = 2 implies
+    specializesFromLibrary('Objects::BinaryLinkObject')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_b9102da_1609608744443_98193_629" general="_18_5_3_12e503d9_1533160651716_116234_42240"/>
+        <generalization xmi:id="_19_0_4_b9102da_1609608741193_65567_626" general="_19_0_4_b9102da_1609606051359_625961_451"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594939013291_889293_3565" name="A_sourceType_sourceAssociation" visibility="public" memberEnd="_19_0_2_12e503d9_1594939013292_377668_3566 _19_0_2_12e503d9_1594939013294_754077_3567">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1594939013294_754077_3567" name="sourceAssociation" visibility="public" type="_18_5_3_12e503d9_1533160651716_116234_42240" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227 _18_5_3_12e503d9_1533160674995_71608_43351" association="_19_0_2_12e503d9_1594939013291_889293_3565">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594939193685_37293_3672" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594939193686_897642_3673" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651717_989804_42241" name="A_relatedType_association" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674994_4339_43349 _18_5_3_12e503d9_1533160674995_71608_43351">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674995_71608_43351" name="association" visibility="public" type="_18_5_3_12e503d9_1533160651716_116234_42240" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674961_585972_43176" association="_18_5_3_12e503d9_1533160651717_989804_42241">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678386_441467_44136" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678386_130129_44135" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594939237323_268228_3706" name="A_targetType_targetAssociation" visibility="public" memberEnd="_19_0_2_12e503d9_1594939237325_861933_3707 _19_0_2_12e503d9_1594939237326_355461_3708">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1594939237326_355461_3708" name="targetAssociation" visibility="public" type="_18_5_3_12e503d9_1533160651716_116234_42240" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1594939237326_355461_3708 _18_5_3_12e503d9_1533160674995_71608_43351" association="_19_0_2_12e503d9_1594939237323_268228_3706">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594939360060_217393_3755" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594939360062_685874_3756" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1562477648741_78835_22900" name="A_associationEnd_associationWithEnd" visibility="public" memberEnd="_18_5_3_12e503d9_1562477648742_24204_22901 _18_5_3_12e503d9_1562477648742_461919_22902">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1562477648742_461919_22902" name="associationWithEnd" visibility="public" type="_18_5_3_12e503d9_1533160651716_116234_42240" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1562476168386_366266_22107" association="_18_5_3_12e503d9_1562477648741_78835_22900">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565496476466_606900_27034" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565496476466_527765_27035" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651716_116234_42240" name="Association" visibility="public">
+        <ownedComment xmi:id="_18_5_3_59601fc_1555236503843_357426_20533" annotatedElement="_18_5_3_12e503d9_1533160651716_116234_42240">
+          <body>&lt;p>An &lt;code>Association&lt;/code> is a &lt;code>Relationship&lt;/code> and a &lt;code>Classifier&lt;/code> to enable classification of links between things (in the universe). The co-domains (&lt;code>types&lt;/code>) of the &lt;code>associationEnd&lt;/code> &lt;code>Features&lt;/code> are the &lt;code>relatedTypes&lt;/code>, as co-domain and participants (linked things) of an &lt;code>Association&lt;/code> identify each other.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543191580962_437393_26849" name="deriveAssociationRelatedType" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651716_116234_42240">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676488929975_309914_99" annotatedElement="_18_5_3_12e503d9_1543191580962_437393_26849">
+            <body>&lt;p>The &lt;code>relatedTypes&lt;/code> of an &lt;code>Association&lt;/code> are the &lt;code>types&lt;/code> of its &lt;code>associationEnds&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543191580962_885022_26850" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>relatedType = associationEnd.type</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_2_b9102da_1591808473394_763910_75" name="checkAssociationSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651716_116234_42240">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847121400_84110_203" annotatedElement="_19_0_2_b9102da_1591808473394_763910_75">
+            <body>&lt;p>An &lt;code>Association&lt;/code> must directly or indirectly specialize the base &lt;code>Association&lt;/code> &lt;code>&lt;em>Links::Link&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_2_b9102da_1591808473395_976533_76" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Links::Link')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1609609288024_688201_639" name="validateAssociationStructureIntersection" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651716_116234_42240">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676533070727_575425_12680" annotatedElement="_19_0_4_b9102da_1609609288024_688201_639">
+            <body>&lt;p>If an &lt;code>Association&lt;/code> is also a kind of &lt;code>Structure&lt;/code>, then it must be an &lt;code>AssociationStructure&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1609609288025_392285_640" name="" visibility="public">
+            <language>English</language>
+            <body>oclIsKindOf(Structure) = oclIsKindOf(AssociationStructure)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_b9102da_1622129733190_988507_183" name="checkAssociationBinarySpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651716_116234_42240">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847134914_195846_204" annotatedElement="_19_0_4_b9102da_1622129733190_988507_183">
+            <body>&lt;p>A binary &lt;code>Association&lt;/code> must directly or indirectly specialize the base &lt;code>Association&lt;/code> &lt;code>&lt;em>Links::binaryLink&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_b9102da_1622129733191_667585_184" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>associationEnd->size() = 2 implies
+    specializesFromLibrary('Links::BinaryLink')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667168101767_261811_240" name="validateAssociationRelatedTypes" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651716_116234_42240">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1667168275103_711923_242" annotatedElement="_19_0_4_12e503d9_1667168101767_261811_240">
+            <body>&lt;p>If an &lt;code>Association&lt;/code> is concrete (not abstract), then it must have at least two &lt;code>relatedTypes&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667168101783_830737_241" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>not isAbstract implies relatedType->size() >= 2</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673046928480_619191_632" name="validateAssociationBinarySpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651716_116234_42240">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673047147570_592837_634" annotatedElement="_19_0_4_12e503d9_1673046928480_619191_632">
+            <body>&lt;p>If an &lt;code>Association&lt;/code> has more than two &lt;code>associationEnds&lt;/code>, then it must &lt;em>not&lt;/em> specialize, directly or indirectly, the &lt;code>Association&lt;/code> &lt;em>&lt;code>BinaryLink&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673046928502_831794_633" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>associationEnds->size() > 2 implies
+    not specializesFromLibrary('Links::BinaryLink')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676489072332_103337_100" name="deriveAssociationSourceType" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651716_116234_42240">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676489168520_367831_102" annotatedElement="_19_0_4_12e503d9_1676489072332_103337_100">
+            <body>&lt;p>The &lt;code>sourceType&lt;/code> of an &lt;code>Association&lt;/code> is its first &lt;code>relatedType&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676489072344_720993_101" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>sourceType =
+    if relatedType->isEmpty() then null
+    else relatedType->first() endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676489194945_380261_103" name="deriveAssociationTargetType" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651716_116234_42240">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676489194961_139274_104" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>targetType =
+    if relatedType->size() &lt; 2 then OrderedSet{}
+    else 
+        relatedType->
+            subSequence(2, relatedType->size())->
+            asOrderedSet() 
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1735776980756_268762_27" name="validateAssociationEndTypes" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1735777042232_811162_31" annotatedElement="_2022x_2_12e503d9_1735776980756_268762_27">
+            <body>&lt;p>The &lt;code>ownedEndFeatures&lt;/code> of an &lt;code>Association&lt;/code> must have exactly one &lt;code>type&lt;/code>&lt;/p>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1735776980758_112174_28" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedEndFeature->forAll(type->size() = 1)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674959_853303_43164" general="_18_5_3_12e503d9_1533160651676_375105_42143"/>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674985_221597_43295" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674994_4339_43349" name="relatedType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isOrdered="true" isUnique="false" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674961_132339_43177" association="_18_5_3_12e503d9_1533160651717_989804_42241">
+          <ownedComment xmi:id="_18_5_3_12e503d9_1562477201381_516571_22821" annotatedElement="_18_5_3_12e503d9_1533160674994_4339_43349">
+            <body>&lt;p>The &lt;code>types&lt;/code> of the &lt;code>associationEnds&lt;/code> of the &lt;code>Association&lt;/code>, which are the &lt;code>relatedElements&lt;/code> of the &lt;code>Association&lt;/code> considered as a &lt;code>Relationship&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678385_444017_44132" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678385_724150_44131" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594939013292_377668_3566" name="sourceType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" subsettedProperty="_18_5_3_12e503d9_1533160674994_4339_43349" association="_19_0_2_12e503d9_1594939013291_889293_3565">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594939717590_810102_3848" annotatedElement="_19_0_2_12e503d9_1594939013292_377668_3566">
+            <body>&lt;p>The source &lt;code>relatedType&lt;/code> for this &lt;code>Association&lt;/code>. It is the first &lt;code>relatedType&lt;/code> of the &lt;code>Association&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594939123780_338232_3644" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594939123782_341214_3645" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594939237325_861933_3707" name="targetType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" subsettedProperty="_18_5_3_12e503d9_1533160674994_4339_43349" association="_19_0_2_12e503d9_1594939237323_268228_3706">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594939866049_224833_3849" annotatedElement="_19_0_2_12e503d9_1594939237325_861933_3707">
+            <body>&lt;p>The target &lt;code>relatedTypes&lt;/code> for this &lt;code>Association&lt;/code>. This includes all the &lt;code>relatedTypes&lt;/code> other than the &lt;code>sourceType&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594939343607_558379_3737" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594939343610_327881_3738" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1562477648742_24204_22901" name="associationEnd" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1562476168385_824569_22106" association="_18_5_3_12e503d9_1562477648741_78835_22900">
+          <ownedComment xmi:id="_19_0_2_59601fc_1583521450242_288448_700" annotatedElement="_18_5_3_12e503d9_1562477648742_24204_22901">
+            <body>&lt;p>The &lt;code>features&lt;/code> of the &lt;code>Association&lt;/code> that identify the things that can be related by it. A concrete &lt;code>Association&lt;/code> must have at least two &lt;code>associationEnds&lt;/code>. When it has exactly two, the &lt;code>Association&lt;/code> is called a &lt;em>binary&lt;/em> &lt;code>Association&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1562477782739_620292_23056" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1562477782740_217929_23057" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1573078402186_585588_1007" name="FeatureValues" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1573079011690_472222_1723" name="A_featureWithValue_valuation" visibility="public" memberEnd="_19_0_2_12e503d9_1573079011690_119762_1724 _19_0_2_12e503d9_1573079011691_672417_1725">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1573079011691_672417_1725" name="valuation" visibility="public" type="_18_5_3_12e503d9_1543180279304_499907_20659" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674979_190614_43269" association="_19_0_2_12e503d9_1573079011690_472222_1723">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604529810711_352358_820" annotatedElement="_19_0_2_12e503d9_1573079011691_672417_1725">
+            <body>&lt;p>The (at most one) &lt;code>ownedMembership&lt;/code> of this Feature that is the FeatureValue that provides the value of the Feature.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573079061448_456696_1772" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573079061449_935832_1773" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1573081851611_108698_3235" name="A_value_expressedValuation" visibility="public" memberEnd="_19_0_2_12e503d9_1573081851611_231043_3236 _19_0_2_12e503d9_1573081851612_947716_3237">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1573081851612_947716_3237" name="expressedValuation" visibility="public" type="_18_5_3_12e503d9_1543180279304_499907_20659" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674972_622493_43236" association="_19_0_2_12e503d9_1573081851611_108698_3235">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604530172290_800046_821" annotatedElement="_19_0_2_12e503d9_1573081851612_947716_3237">
+            <body>&lt;p>The FeatureValue that owns the &lt;code>value&lt;/code> Expression.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573081935452_28373_3288" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573081935453_390474_3289" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1543180279304_499907_20659" name="FeatureValue" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1573231483622_323142_1686" annotatedElement="_18_5_3_12e503d9_1543180279304_499907_20659">
+          <body>&lt;p>A &lt;code>FeatureValue&lt;/code> is a &lt;code>Membership&lt;/code> that identifies a particular member &lt;code>Expression&lt;/code> that provides the value of the &lt;code>Feature&lt;/code> that owns the &lt;code>FeatureValue&lt;/code>. The value is specified as either a bound value or an initial value, and as either a concrete or default value. A &lt;code>Feature&lt;/code> can have at most one &lt;code>FeatureValue&lt;/code>.&lt;/p>
+
+&lt;p>The result of the &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> is bound to the &lt;code>featureWithValue&lt;/code> using a &lt;code>BindingConnector&lt;/code>. If &lt;code>isInitial = false&lt;/code>, then the &lt;code>featuringType&lt;/code> of the &lt;code>BindingConnector&lt;/code> is the same as the &lt;code>featuringType&lt;/code> of the &lt;code>featureWithValue&lt;/code>. If &lt;code>isInitial = true&lt;/code>, then the &lt;code>featuringType&lt;/code> of the &lt;code>BindingConnector&lt;/code> is restricted to its &lt;code>startShot&lt;/code>.
+
+&lt;p>If &lt;code>isDefault = false&lt;/code>, then the above semantics of the &lt;code>FeatureValue&lt;/code> are realized for the given &lt;code>featureWithValue&lt;/code>. Otherwise, the semantics are realized for any individual of the &lt;code>featuringType&lt;/code> of the &lt;code>featureWithValue&lt;/code>, unless another value is explicitly given for the &lt;code>featureWithValue&lt;/code> for that individual.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1604530543844_232492_852" name="checkFeatureValueBindingConnector" visibility="public" constrainedElement="_18_5_3_12e503d9_1543180279304_499907_20659">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604530796244_186535_854" annotatedElement="_19_0_4_12e503d9_1604530543844_232492_852">
+            <body>&lt;p>If &lt;code>isDefault = false&lt;/code>, then the &lt;code>featureWithValue&lt;/code> must have an &lt;code>ownedMember&lt;/code> that is a &lt;code>BindingConnector&lt;/code> whose &lt;code>relatedElements&lt;/code> are the &lt;code>featureWithValue&lt;/code> and a feature chain consisting of the &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> and its &lt;code>result&lt;/code>. If &lt;code>isInitial = false&lt;/code>, then this &lt;code>BindingConnector&lt;/code> must have &lt;code>featuringTypes&lt;/code> that are the same as those of the &lt;code>featureWithValue&lt;/code>. If &lt;code>isInitial = true&lt;/code>, then the &lt;code>BindingConnector&lt;/code> must have &lt;code>&lt;em>that.startShot&lt;/em>&lt;code> as its &lt;code>featuringType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1604530543858_173234_853" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>not isDefault implies
+    featureWithValue.ownedMember->
+        selectByKind(BindingConnector)->exists(b |
+            b.relatedFeature->includes(featureWithValue) and
+            b.relatedFeature->exists(f | 
+                f.chainingFeature = Sequence{value, value.result}) and
+            if not isInitial then 
+                b.featuringType = featureWithValue.featuringType
+            else 
+                b.featuringType->exists(t |
+                    t.oclIsKindOf(Feature) and
+                    t.oclAsType(Feature).chainingFeature =
+                        Sequence{
+                            resolveGlobal('Base::things::that').
+                                memberElement,
+                            resolveGlobal('Occurrences::Occurrence::startShot').
+                                memberElement
+                        }
+                )
+            endif)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1695245971937_372735_179" name="validateFeatureValueOverriding" visibility="public" constrainedElement="_18_5_3_12e503d9_1543180279304_499907_20659">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1695246053038_841509_181" annotatedElement="_19_0_4_12e503d9_1695245971937_372735_179">
+            <body>&lt;p>All &lt;code>Features&lt;/code> directly or indirectly redefined by the &lt;code>featureWithValue&lt;/code> of a &lt;code>FeatureValue&lt;/code> must have only default &lt;code>FeatureValues&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1695245971956_634850_180" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureWithValue.redefinition.redefinedFeature->
+    closure(redefinition.redefinedFeature).valuation->
+    forAll(isDefault)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740172917285_310769_172" name="validateFeatureValueIsInitial" visibility="public" constrainedElement="_18_5_3_12e503d9_1543180279304_499907_20659">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740172980242_310818_174" annotatedElement="_2022x_2_12e503d9_1740172917285_310769_172">
+            <body>&lt;p>If a &lt;code>FeatureValue&lt;/code> has &lt;code>isInitial = true&lt;/code>, then its &lt;code>featureWithValue&lt;/code> must have &lt;code>isVariable = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740172917287_580016_173" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isInitial implies featureWithValue.isVariable</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1543180700495_930452_21351" general="_19_0_4_12e503d9_1648180804650_933390_31"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1573079011690_119762_1724" name="featureWithValue" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674965_193857_43197" association="_19_0_2_12e503d9_1573079011690_472222_1723">
+          <ownedComment xmi:id="_19_0_2_59601fc_1586211159665_680166_400" annotatedElement="_19_0_2_12e503d9_1573079011690_119762_1724">
+            <body>&lt;p>The Feature to be provided a value.&lt;/p></body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_59601fc_1585935962161_502701_25" annotatedElement="_19_0_2_12e503d9_1573079011690_119762_1724">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> to be provided a value.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573079057526_286750_1768" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573079057527_8050_1769" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1573081851611_231043_3236" name="value" visibility="public" type="_18_5_3_12e503d9_1533160651686_908654_42163" aggregation="composite" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674965_501750_43196" association="_19_0_2_12e503d9_1573081851611_108698_3235">
+          <ownedComment xmi:id="_19_0_2_59601fc_1586212897309_825632_430" annotatedElement="_19_0_2_12e503d9_1573081851611_231043_3236">
+            <body>&lt;p>The Expression that provides the value as a result.&lt;/p></body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_59601fc_1585936166113_667765_224" annotatedElement="_19_0_2_12e503d9_1573081851611_231043_3236">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> that provides the value of the &lt;code>featureWithValue&lt;/code> as its &lt;code>result&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1573081907447_264427_3260" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1573081907448_226991_3261" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1623940148216_422105_36473" name="isInitial" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1623941560246_429793_36523" annotatedElement="_19_0_4_12e503d9_1623940148216_422105_36473">
+            <body>&lt;p>Whether this &lt;code>FeatureValue&lt;/code> specifies a bound value or an initial value for the &lt;code>featureWithValue&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1623940263230_949883_36522" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1623940132054_842266_36467" name="isDefault" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1623941633531_482182_36524" annotatedElement="_19_0_4_12e503d9_1623940132054_842266_36467">
+            <body>&lt;p>Whether this &lt;code>FeatureValue&lt;/code> is a concrete specification of the bound or initial value of the &lt;code>featureWithValue&lt;/code>, or just a default value that may be overridden.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1623940256423_163084_36521" name="" visibility="public"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1533160651675_410136_42140" name="Connectors" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1533160651698_598377_42185" name="Connector" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1583525582620_427832_362" annotatedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <body>&lt;p>A &lt;code>Connector&lt;/code> is a usage of &lt;code>Associations&lt;/code>, with links restricted according to instances of the &lt;code>Type&lt;/code> in which they are used (domain of the &lt;code>Connector&lt;/code>). The &lt;code>associations&lt;/code> of the &lt;code>Connector&lt;/code> restrict what kinds of things might be linked. The &lt;code>Connector&lt;/code> further restricts these links to be between values of &lt;code>Features&lt;/code> on instances of its domain.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_18_5_3_12e503d9_1543204552722_992965_28411" name="deriveConnectorRelatedFeature" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604678164917_978423_83" annotatedElement="_18_5_3_12e503d9_1543204552722_992965_28411">
+            <body>&lt;p>The &lt;code>relatedFeatures&lt;/code> of a &lt;code>Connector&lt;/code> are the referenced &lt;code>Features&lt;/code> of its &lt;code>connectorEnds&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_18_5_3_12e503d9_1543204552722_860694_28412" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>relatedFeature = connectorEnd.ownedReferenceSubsetting->
+    select(s | s &lt;> null).subsettedFeature</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1604534021791_822858_936" name="checkConnectorTypeFeaturing" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604534219021_699609_938" annotatedElement="_19_0_4_12e503d9_1604534021791_822858_936">
+            <body>&lt;p>Each &lt;code>relatedFeature&lt;/code> of a &lt;code>Connector&lt;/code> must have each &lt;code>featuringType&lt;/code> of the &lt;code>Connector&lt;/code> as a direct or indirect &lt;code>featuringType&lt;/code> (where a &lt;code>Feature&lt;/code> with no &lt;code>featuringType&lt;/code> is treated as if the &lt;code>Classifier&lt;/code> &lt;code>&lt;em>Base::Anything&lt;/em>&lt;/code> was its &lt;code>featuringType&lt;/code>).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1604534021792_314301_937" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>relatedFeature->forAll(f | 
+    if featuringType->isEmpty() then f.isFeaturedWithin(null)
+    else featuringType->forAll(t | f.isFeaturedWithin(t))
+    endif)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1604678521444_38860_108" name="deriveConnectorSourceFeature" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604683304419_609268_115" annotatedElement="_19_0_4_12e503d9_1604678521444_38860_108">
+            <body>&lt;p>The &lt;code>sourceFeature&lt;/code> of a &lt;code>Connector&lt;/code> is its first &lt;code>relatedFeature&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1604678521449_697924_109" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>sourceFeature = 
+    if relatedFeature->isEmpty() then null 
+    else relatedFeature->first() 
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1604683038537_856662_112" name="deriveConnectorTargetFeature" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1604683173417_64283_114" annotatedElement="_19_0_4_12e503d9_1604683038537_856662_112">
+            <body>&lt;p>The &lt;code>targetFeatures&lt;/code> of a &lt;code>Connector&lt;/code> are the &lt;code>relatedFeatures&lt;/code> other than the &lt;code>sourceFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1604683038550_113422_113" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>targetFeature =
+    if relatedFeature->size() &lt; 2 then OrderedSet{}
+    else 
+        relatedFeature->
+            subSequence(2, relatedFeature->size())->
+            asOrderedSet()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667168290638_650990_243" name="validateConnectorRelatedFeatures" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1667168290656_586315_245" annotatedElement="_19_0_4_12e503d9_1667168290638_650990_243">
+            <body>&lt;p>If a &lt;code>Connector&lt;/code> is concrete (not abstract), then it must have at least two &lt;code>relatedFeatures&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667168290650_600210_244" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>not isAbstract implies relatedFeature->size() >= 2</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772441958_441349_2175" name="checkConnectorSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847252373_40483_208" annotatedElement="_19_0_4_12e503d9_1667772441958_441349_2175">
+            <body>&lt;p>A &lt;code>Connector&lt;/code> must directly or indirectly specialize the base &lt;code>Connector&lt;/code> &lt;code>&lt;em>Links::links&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772441971_898944_2176" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Links::links')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772490890_104519_2179" name="checkConnectorObjectSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847294188_536767_209" annotatedElement="_19_0_4_12e503d9_1667772490890_104519_2179">
+            <body>&lt;p>A &lt;code>Connector&lt;/code> for an &lt;code>AssociationStructure&lt;/code> must directly or indirectly specialize the base &lt;code>Connector&lt;/code> &lt;code>&lt;em>Objects::linkObjects&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772490895_445444_2180" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>association->exists(oclIsKindOf(AssociationStructure)) implies
+    specializesFromLibrary('Objects::linkObjects')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772526436_708756_2181" name="checkConnectorBinaryObjectSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847369969_394641_211" annotatedElement="_19_0_4_12e503d9_1667772526436_708756_2181">
+            <body>&lt;p>A binary &lt;code>Connector&lt;/code> for an &lt;code>AssociationStructure&lt;/code>  must directly or indirectly specialize the base &lt;code>Connector&lt;/code> &lt;code>&lt;em>Objects::binaryLinkObjects&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772526444_170514_2182" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>connectorEnds->size() = 2 and
+association->exists(oclIsKindOf(AssociationStructure)) implies
+    specializesFromLibrary('Objects::binaryLinkObjects')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772472369_69146_2177" name="checkConnectorBinarySpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847317622_174218_210" annotatedElement="_19_0_4_12e503d9_1667772472369_69146_2177">
+            <body>&lt;p>A binary &lt;code>Connector&lt;/code> must directly or indirectly specialize the base &lt;code>Connector&lt;/code> &lt;code>&lt;em>Links::binaryLinks&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772472371_636982_2178" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>connectorEnd->size() = 2 implies
+    specializesFromLibrary('Links::binaryLinks')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673047167939_107213_637" name="validateConnectorBinarySpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673047167953_616535_639" annotatedElement="_19_0_4_12e503d9_1673047167939_107213_637">
+            <body>&lt;p>If a &lt;code>Connector&lt;/code> has more than two &lt;code>connectorEnds&lt;/code>, then it must &lt;em>not&lt;/em> specialize, directly or indirectly, the &lt;code>Association&lt;/code> &lt;em>&lt;code>BinaryLink&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673047167950_810307_638" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>connectorEnds->size() > 2 implies
+    not specializesFromLibrary('Links::BinaryLink')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740172556718_356770_169" name="deriveConnectorDefaultFeaturingType" visibility="public" constrainedElement="_18_5_3_12e503d9_1533160651698_598377_42185">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740172655488_989877_171" annotatedElement="_2022x_2_12e503d9_1740172556718_356770_169">
+            <body>&lt;p>The &lt;code>defaultFeaturingType&lt;/code> of a &lt;code>Connector&lt;/code> is the innermost common direct or indirect &lt;code>featuringType&lt;/code> of the &lt;code>relatedFeatures&lt;/code> of the &lt;code>Connector&lt;/code>, so that each &lt;code>relatedElement&lt;/code> is featured within the &lt;code>defaultFeaturingType&lt;/code>, if such exists.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740172556720_181133_170" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let commonFeaturingTypes : OrderedSet(Type) = 
+    relatedFeature->closure(featuringType)->select(t | 
+        relatedFeature->forAll(f | f.isFeaturedWithin(t))
+    ) in
+let nearestCommonFeaturingTypes : OrderedSet(Type) =
+    commonFeaturingTypes->reject(t1 | 
+        commonFeaturingTypes->exists(t2 | 
+            t2 &lt;> t1 and t2->closure(featuringType)->contains(t1)
+    )) in
+if nearestCommonFeaturingTypes->isEmpty() then null
+else nearestCommonFeaturingTypes->first()
+endif</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674968_563033_43211" general="_18_5_3_12e503d9_1533160651684_893483_42160"/>
+        <generalization xmi:id="_18_5_3_12e503d9_1533160674982_316507_43283" general="_18_5_3_12e503d9_1533160651700_869737_42192"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674968_916334_43210" name="relatedFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isUnique="false" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674961_132339_43177" association="_18_5_3_12e503d9_1533160651683_67028_42159">
+          <ownedComment xmi:id="_19_0_2_59601fc_1583521341414_794343_696" annotatedElement="_18_5_3_12e503d9_1533160674968_916334_43210">
+            <body>&lt;p>The &lt;code>Features&lt;/code> that are related by this &lt;code>Connector&lt;/code> considered as a &lt;code>Relationship&lt;/code> and that restrict the links it identifies, given by the referenced &lt;code>Features&lt;/code> of the &lt;code>connectorEnds&lt;/code> of the &lt;code>Connector&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678365_614925_43995" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678365_995074_43994" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1533160674983_471497_43284" name="association" visibility="public" type="_18_5_3_12e503d9_1533160651716_116234_42240" isOrdered="true" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674969_376003_43216" association="_18_5_3_12e503d9_1533160651717_418077_42242">
+          <ownedComment xmi:id="_19_0_2_59601fc_1583521369366_952301_697" annotatedElement="_18_5_3_12e503d9_1533160674983_471497_43284">
+            <body>&lt;p>The &lt;code>Associations&lt;/code> that type the &lt;code>Connector&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678378_638100_44076" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678378_730975_44075" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1556735067666_827798_21922" name="connectorEnd" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1562476168385_824569_22106" association="_18_5_3_12e503d9_1556735067666_300733_21921">
+          <ownedComment xmi:id="_19_0_2_59601fc_1583521405709_579389_699" annotatedElement="_18_5_3_12e503d9_1556735067666_827798_21922">
+            <body>&lt;p>The &lt;code>endFeatures&lt;/code> of a &lt;code>Connector&lt;/code>, which redefine the &lt;code>endFeatures&lt;/code> of the &lt;code>associations&lt;/code> of the &lt;code>Connector&lt;/code>. The &lt;code>connectorEnds&lt;/code> determine via &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationships&lt;/code> which &lt;code>Features&lt;/code> are related by the &lt;code>Connector&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1556735357224_647868_21968" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1556735357224_996345_21969" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594953058873_558253_3897" name="sourceFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674971_696758_43228" subsettedProperty="_18_5_3_12e503d9_1533160674968_916334_43210" association="_19_0_2_12e503d9_1594953058872_140346_3896">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594953852495_965462_4218" annotatedElement="_19_0_2_12e503d9_1594953058873_558253_3897">
+            <body>&lt;p>The source &lt;code>relatedFeature&lt;/code> for this &lt;code>Connector&lt;/code>. It is the first &lt;code>relatedFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594953112294_263635_3927" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594953112295_656794_3928" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594953128207_991867_3946" name="targetFeature" visibility="public" type="_18_5_3_12e503d9_1533160651684_893483_42160" isOrdered="true" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1533160674961_138197_43179" subsettedProperty="_18_5_3_12e503d9_1533160674968_916334_43210" association="_19_0_2_12e503d9_1594953128207_537819_3945">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594953880570_357419_4219" annotatedElement="_19_0_2_12e503d9_1594953128207_991867_3946">
+            <body>&lt;p>The target &lt;code>relatedFeatures&lt;/code> for this &lt;code>Connector&lt;/code>. This includes all the &lt;code>relatedFeatures&lt;/code> other than the &lt;code>sourceFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594953177888_303422_4006" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594953177889_698625_4007" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1737751598145_444042_71" name="defaultFeaturingType" visibility="public" type="_18_5_3_71301a1_1537895141427_270492_15579" isDerived="true" association="_2022x_2_12e503d9_1737751598145_760805_70">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1737751785168_423294_91" annotatedElement="_2022x_2_12e503d9_1737751598145_444042_71">
+            <body>&lt;p>The innermost &lt;code>Type&lt;/code> that is a common direct or indirect &lt;code>featuringType&lt;/code> of the &lt;code>relatedFeatures&lt;/code>, such that, if it exists and was the &lt;code>featuringType&lt;/code> of this &lt;code>Connector&lt;/code>, the &lt;code>Connector&lt;/code> would satisfy the &lt;code>checkConnectorTypeFeaturing&lt;/code> constraint.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1737751621488_815905_81" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1737751621489_470653_82" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651717_418077_42242" name="A_association_typedConnector" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674983_471497_43284 _18_5_3_12e503d9_1533160674995_282523_43352">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674995_282523_43352" name="typedConnector" visibility="public" type="_18_5_3_12e503d9_1533160651698_598377_42185" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674973_102139_43242" association="_18_5_3_12e503d9_1533160651717_418077_42242">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678386_503792_44138" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678386_813108_44137" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1533160651683_67028_42159" name="A_relatedFeature_connector" visibility="public" memberEnd="_18_5_3_12e503d9_1533160674968_916334_43210 _18_5_3_12e503d9_1533160674967_983329_43209">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1533160674967_983329_43209" name="connector" visibility="public" type="_18_5_3_12e503d9_1533160651698_598377_42185" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674961_585972_43176" association="_18_5_3_12e503d9_1533160651683_67028_42159">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1533160678365_808531_43993" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1533160678365_936747_43992" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_b9102da_1543591219823_238592_17680" name="BindingConnector" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1583525563491_248319_360" annotatedElement="_18_5_3_b9102da_1543591219823_238592_17680">
+          <body>&lt;p>A &lt;code>BindingConnector&lt;/code> is a binary &lt;code>Connector&lt;/code> that requires its &lt;code>relatedFeatures&lt;/code> to identify the same things (have the same values).&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676492379474_997186_130" name="validateBindingConnectorIsBinary" visibility="public" constrainedElement="_18_5_3_b9102da_1543591219823_238592_17680">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676492442793_5588_132" annotatedElement="_19_0_4_12e503d9_1676492379474_997186_130">
+            <body>&lt;p>A &lt;code>BindingConnector&lt;/code> must be binary.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676492379506_480205_131" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>relatedFeature->size() = 2</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772642537_67309_2183" name="checkBindingConnectorSpecialization" visibility="public" constrainedElement="_18_5_3_b9102da_1543591219823_238592_17680">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669847237365_224609_207" annotatedElement="_19_0_4_12e503d9_1667772642537_67309_2183">
+            <body>&lt;p>A &lt;code>BindingConnector&lt;/code> must directly or indirectly specialize the base &lt;code>BindingConnector&lt;/code> &lt;code>&lt;em>Links::selfLinks&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772642550_103306_2184" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Links::selfLinks')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_b9102da_1543591232861_723762_17708" general="_18_5_3_12e503d9_1533160651698_598377_42185"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1556735067666_300733_21921" name="A_connectorEnd_featuringConnector" visibility="public" memberEnd="_18_5_3_12e503d9_1556735067666_827798_21922 _18_5_3_12e503d9_1556735067667_716674_21923">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1556735067667_716674_21923" name="featuringConnector" visibility="public" type="_18_5_3_12e503d9_1533160651698_598377_42185" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1562476168386_366266_22107" association="_18_5_3_12e503d9_1556735067666_300733_21921">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1556737589472_487978_21214" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1556737589473_600450_21215" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_71301a1_1536100248189_622183_16479" name="Succession" visibility="public">
+        <ownedComment xmi:id="_19_0_2_59601fc_1583525387282_432059_354" annotatedElement="_18_5_3_71301a1_1536100248189_622183_16479">
+          <body>&lt;p>A &lt;code>Succession&lt;/code> is a binary &lt;code>Connector&lt;/code> that requires its &lt;code>relatedFeatures&lt;/code> to happen separately in time.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1667772678204_499026_2185" name="checkSuccessionSpecialization" visibility="public" constrainedElement="_18_5_3_71301a1_1536100248189_622183_16479">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1669851085328_56141_308" annotatedElement="_19_0_4_12e503d9_1667772678204_499026_2185">
+            <body>&lt;p>A &lt;code>Succession&lt;/code> must directly or indirectly specialize the Feature &lt;code>&lt;em>Occurrences::happensBeforeLinks&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1667772678209_647018_2186" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Occurrences::happensBeforeLinks')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_b9102da_1536239131344_438042_16476" general="_18_5_3_12e503d9_1533160651698_598377_42185"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594953058872_140346_3896" name="A_sourceFeature_sourceConnector" visibility="public" memberEnd="_19_0_2_12e503d9_1594953058873_558253_3897 _19_0_2_12e503d9_1594953058873_925217_3898">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1594953058873_925217_3898" name="sourceConnector" visibility="public" type="_18_5_3_12e503d9_1533160651698_598377_42185" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674971_80547_43227 _18_5_3_12e503d9_1533160674967_983329_43209" association="_19_0_2_12e503d9_1594953058872_140346_3896">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594953162932_139395_3990" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594953162933_322535_3991" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594953128207_537819_3945" name="A_targetFeature_targetConnector" visibility="public" memberEnd="_19_0_2_12e503d9_1594953128207_991867_3946 _19_0_2_12e503d9_1594953128207_697754_3947">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1594953128207_697754_3947" name="targetConnector" visibility="public" type="_18_5_3_12e503d9_1533160651698_598377_42185" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1533160674967_983329_43209 _18_5_3_12e503d9_1533160674961_537222_43178" association="_19_0_2_12e503d9_1594953128207_537819_3945">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594953204988_607117_4036" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594953204991_181205_4037" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_2022x_2_12e503d9_1737751598145_760805_70" name="A_defaultFeaturingType_featuredConnector" visibility="public" memberEnd="_2022x_2_12e503d9_1737751598145_444042_71 _2022x_2_12e503d9_1737751598146_294997_72">
+        <ownedEnd xmi:id="_2022x_2_12e503d9_1737751598146_294997_72" name="featuredConnector" visibility="public" type="_18_5_3_12e503d9_1533160651698_598377_42185" isDerived="true" association="_2022x_2_12e503d9_1737751598145_760805_70">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1737751836303_369316_92" annotatedElement="_2022x_2_12e503d9_1737751598146_294997_72">
+            <body>&lt;p>A &lt;code>Connector&lt;/code> with a certain &lt;code>defaultFeaturingType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1737751660238_910792_87" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1737751660238_876217_88" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+  </packagedElement>
+</uml:Model>

--- a/resources/SySML2/PrimitiveTypes.xmi
+++ b/resources/SySML2/PrimitiveTypes.xmi
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.omg.org/spec/UML/20161101" xmlns:mofext="http://www.omg.org/spec/MOF/20131001">
+	<uml:Package xmi:type="uml:Package" xmi:id="_0" name="PrimitiveTypes" URI="http://www.omg.org/spec/PrimitiveTypes/20161101">
+		<packagedElement xmi:type="uml:PrimitiveType" xmi:id="Boolean" name="Boolean">
+			<ownedComment xmi:type="uml:Comment" xmi:id="Boolean-_ownedComment.0" annotatedElement="Boolean">
+				<body>Boolean is used for logical expressions, consisting of the predefined values true and false.</body>
+			</ownedComment>
+		</packagedElement>
+		<packagedElement xmi:type="uml:PrimitiveType" xmi:id="Integer" name="Integer">
+			<ownedComment xmi:type="uml:Comment" xmi:id="Integer-_ownedComment.0" annotatedElement="Integer">
+				<body>Integer is a primitive type representing integer values.</body>
+			</ownedComment>
+		</packagedElement>
+		<packagedElement xmi:type="uml:PrimitiveType" xmi:id="Real" name="Real">
+			<ownedComment xmi:type="uml:Comment" xmi:id="Real-_ownedComment.0" annotatedElement="Real">
+				<body>Real is a primitive type representing the mathematical concept of real.</body>
+			</ownedComment>
+		</packagedElement>
+		<packagedElement xmi:type="uml:PrimitiveType" xmi:id="String" name="String">
+			<ownedComment xmi:type="uml:Comment" xmi:id="String-_ownedComment.0" annotatedElement="String">
+				<body>String is a sequence of characters in some suitable character set used to display information about the model. Character sets may include non-Roman alphabets and characters.</body>
+			</ownedComment>
+		</packagedElement>
+		<packagedElement xmi:type="uml:PrimitiveType" xmi:id="UnlimitedNatural" name="UnlimitedNatural">
+			<ownedComment xmi:type="uml:Comment" xmi:id="UnlimitedNatural-_ownedComment.0" annotatedElement="UnlimitedNatural">
+				<body>UnlimitedNatural is a primitive type representing unlimited natural values.</body>
+			</ownedComment>
+		</packagedElement>
+	</uml:Package>
+	<mofext:Tag xmi:type="mofext:Tag" xmi:id="_1" name="org.omg.xmi.nsPrefix" value="primitives" element="_0"/>
+	<mofext:Tag xmi:type="mofext:Tag" xmi:id="_2" name="org.omg.xmi.schemaType" value="http://www.w3.org/2001/XMLSchema#boolean" element="Boolean"/>
+	<mofext:Tag xmi:type="mofext:Tag" xmi:id="_3" name="org.omg.xmi.schemaType" value="http://www.w3.org/2001/XMLSchema#integer" element="Integer"/>
+	<mofext:Tag xmi:type="mofext:Tag" xmi:id="_4" name="org.omg.xmi.schemaType" value="http://www.w3.org/2001/XMLSchema#double" element="Real"/>
+	<mofext:Tag xmi:type="mofext:Tag" xmi:id="_5" name="org.omg.xmi.schemaType" value="http://www.w3.org/2001/XMLSchema#string" element="String"/>
+	<mofext:Tag xmi:type="mofext:Tag" xmi:id="_6" name="org.omg.xmi.schemaType" value="http://www.w3.org/2001/XMLSchema#string" element="UnlimitedNatural"/>
+</xmi:XMI>

--- a/resources/SySML2/SysML_only_xmi.uml
+++ b/resources/SySML2/SysML_only_xmi.uml
@@ -1,0 +1,8554 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_mczcUFn3EfG_XZTXp4TXuA" name="SysML" URI="https://www.omg.org/spec/SysML/20250201">
+  <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1565469595465_233190_19811" name="Systems" visibility="public" URI="">
+    <packageImport xmi:id="_19_0_4_12e503d9_1597695863785_392680_5982">
+      <importedPackage href="KerML_only_xmi.uml#_18_5_3_12e503d9_1561108539241_462450_22354"/>
+    </packageImport>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1565476457718_958098_21807" name="Ports" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565492704639_896080_24992" name="PortUsage" visibility="public">
+        <ownedComment xmi:id="_18_5_3_12e503d9_1565495753037_153961_26259" annotatedElement="_18_5_3_12e503d9_1565492704639_896080_24992">
+          <body>&lt;p>A &lt;code>PortUsage&lt;/code> is a usage of a &lt;code>PortDefinition&lt;/code>. A &lt;code>PortUsage&lt;/code> itself as well as all its &lt;code>nestedUsages&lt;/code> must be referential (non-composite).&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1651682009013_529666_204" name="validatePortUsageNestedUsagesNotComposite" visibility="public" constrainedElement="_18_5_3_12e503d9_1565492704639_896080_24992">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651682109687_463980_206" annotatedElement="_19_0_4_12e503d9_1651682009013_529666_204">
+            <body>&lt;p>The &lt;code>nestedUsages&lt;/code> of a &lt;code>PortUsage&lt;/code> that are not themselves &lt;code>PortUsages&lt;/code> must not be composite.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1651682009041_59361_205" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedUsage->
+    reject(oclIsKindOf(PortUsage))->
+    forAll(not isComposite)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673569216644_948561_25906" name="checkPortUsageSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565492704639_896080_24992">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673569322404_476943_25918" annotatedElement="_19_0_4_12e503d9_1673569216644_948561_25906">
+            <body>&lt;p>A &lt;code>PortUsage&lt;/code> must directly or indirectly specialize the &lt;code>PortUsage&lt;/code> &lt;em>&lt;code>Ports::ports&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673569216652_515095_25907" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Ports::ports')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673569402716_653477_25919" name="checkPortUsageSubportSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565492704639_896080_24992">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673569550148_405351_25921" annotatedElement="_19_0_4_12e503d9_1673569402716_653477_25919">
+            <body>&lt;p>A composite &lt;code>PortUsage&lt;/code> with an &lt;code>owningType&lt;/code> that is a &lt;code>PortDefinition&lt;/code> or &lt;code>PortUsage&lt;/code> must directly or indirectly specialize the &lt;code>PortUsage&lt;/code> &lt;em>&lt;code>Ports::Port::subports&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673569402720_704107_25920" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(PortDefinition) or
+ owningType.oclIsKindOf(PortUsage)) implies
+    specializesFromLibrary('Ports::Port::subports')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673584724410_867700_25926" name="validatePortUsageIsReference" visibility="public" constrainedElement="_18_5_3_12e503d9_1565492704639_896080_24992">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673584866418_948748_25928" annotatedElement="_19_0_4_12e503d9_1673584724410_867700_25926">
+            <body>&lt;p>Unless a &lt;code>PortUsage&lt;/code> has an &lt;code>owningType&lt;/code> that is a &lt;code>PortDefinition&lt;/code> or a &lt;code>PortUsage&lt;/code>, it must be referential (non-composite).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673584724462_949876_25927" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType = null or
+not owningType.oclIsKindOf(PortDefinition) and
+not owningType.oclIsKindOf(PortUsage) implies
+    isReference</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1736984149953_744853_532" name="checkPortUsageOwnedPortSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565492704639_896080_24992">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736984212773_943296_534" annotatedElement="_2022x_2_12e503d9_1736984149953_744853_532">
+            <body>&lt;p>A &lt;code>PortUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>PartDefinition&lt;/code> or &lt;code>PartUsage&lt;/code> must directly or indirectly specialize the &lt;code>PortUsage&lt;/code> &lt;em>&lt;code>Parts::Part::ownedPorts&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736984149954_76674_533" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(PartDefinition) or
+ owningType.oclIsKindOf(PartUsage)) implies
+    specializesFromLibrary('Parts::Part::ownedPorts')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565492713652_454201_25020" general="_19_0_4_12e503d9_1618943737195_33207_138"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565492740124_880100_25026" name="portDefinition" visibility="public" type="_18_5_3_12e503d9_1565478005829_611481_22375" isOrdered="true" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1618943843466_158863_236" association="_18_5_3_12e503d9_1565492740123_825374_25025">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586299602333_617266_517" annotatedElement="_18_5_3_12e503d9_1565492740124_880100_25026">
+            <body>&lt;p>The &lt;code>occurrenceDefinitions&lt;/code> of this &lt;code>PortUsage&lt;/code>, which must all be &lt;code>PortDefinitions&lt;code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565492758877_444971_25048" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565492758877_12774_25049" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565492740123_825374_25025" name="A_portDefinition_definedPort" visibility="public" memberEnd="_18_5_3_12e503d9_1565492740124_880100_25026 _18_5_3_12e503d9_1565492740124_262673_25027">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565492740124_262673_25027" name="definedPort" visibility="public" type="_18_5_3_12e503d9_1565492704639_896080_24992" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943843466_481041_237" association="_18_5_3_12e503d9_1565492740123_825374_25025">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586300763895_479960_524" annotatedElement="_18_5_3_12e503d9_1565492740124_262673_25027">
+            <body>&lt;p>The PortUsages that are typed by a certain PortDefinition.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565492761804_679051_25054" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565492761804_696292_25055" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565478005829_611481_22375" name="PortDefinition" visibility="public">
+        <ownedComment xmi:id="_18_5_3_12e503d9_1565494714588_753533_26144" annotatedElement="_18_5_3_12e503d9_1565478005829_611481_22375">
+          <body>&lt;p>A &lt;code>PortDefinition&lt;/code> defines a point at which external entities can connect to and interact with a system or part of a system. Any &lt;code>ownedUsages&lt;/code> of a &lt;code>PortDefinition&lt;/code>, other than &lt;code>PortUsages&lt;/code>, must not be composite.&lt;/p>
+
+
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597201535820_389003_73627" name="derivePortDefinitionConjugatedPortDefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1565478005829_611481_22375">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673568676263_822061_25898" annotatedElement="_19_0_4_12e503d9_1597201535820_389003_73627">
+            <body>&lt;p>The &lt;code>conjugatedPortDefinition&lt;/code> of a &lt;code>PortDefinition&lt;/code> is the &lt;code>ownedMember&lt;/code> that is a &lt;code>ConjugatedPortDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597201535821_109538_73628" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>conjugatedPortDefinition = 
+let conjugatedPortDefinitions : OrderedSet(ConjugatedPortDefinition) =
+    ownedMember->selectByKind(ConjugatedPortDefinition) in
+if conjugatedPortDefinitions->isEmpty() then null
+else conjugatedPortDefinitions->first()
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1651681885565_537474_201" name="validatePortDefinitionOwnedUsagesNotComposite" visibility="public" constrainedElement="_18_5_3_12e503d9_1565478005829_611481_22375">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1651682144520_565659_207" annotatedElement="_19_0_4_12e503d9_1651681885565_537474_201">
+            <body>&lt;p>The &lt;code>ownedUsages&lt;/code> of a &lt;code>PortDefinition&lt;/code> that are not &lt;code>PortUsages&lt;/code> must not be composite.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1651681885586_745415_202" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedUsage->
+    reject(oclIsKindOf(PortUsage))->
+    forAll(not isComposite)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673568827636_594257_25899" name="validatePortDefinitionConjugatedPortDefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1565478005829_611481_22375">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673568945309_193981_25901" annotatedElement="_19_0_4_12e503d9_1673568827636_594257_25899">
+            <body>&lt;p>Unless it is a &lt;code>ConjugatedPortDefinition&lt;/code>, a &lt;code>PortDefinition&lt;/code> must have exactly one &lt;code>ownedMember&lt;/code> that is a &lt;code>ConjugatedPortDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673568827658_75365_25900" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>not oclIsKindOf(ConjugatedPortDefinition) implies
+    ownedMember->
+        selectByKind(ConjugatedPortDefinition)->
+        size() = 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673568962957_548715_25902" name="checkPortDefinitionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565478005829_611481_22375">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673569059943_886808_25904" annotatedElement="_19_0_4_12e503d9_1673568962957_548715_25902">
+            <body>&lt;p>A &lt;code>PortDefinition&lt;/code> must directly or indirectly specialize the &lt;code>PortDefinition&lt;/code> &lt;em>&lt;code>Ports::Port&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673568962965_715074_25903" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Ports::Port')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565478052584_906636_22403" general="_19_0_4_12e503d9_1618943693347_790503_111"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1624030877576_789941_39312">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_b9102da_1609606051359_625961_451"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575484364015_206236_989" name="conjugatedPortDefinition" visibility="public" type="_19_0_2_12e503d9_1575484160733_882684_674" isDerived="true" association="_19_0_2_12e503d9_1575484364014_116197_988">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1575499855190_697257_2369" annotatedElement="_19_0_2_12e503d9_1575484364015_206236_989">
+            <body>&lt;p>The &lt;code>ConjugatedPortDefinition&lt;/code> that is conjugate to this &lt;code>PortDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575485019034_313681_1627" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575485019040_320816_1628" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674979_259543_43268"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575484364014_116197_988" name="A_conjugatedPortDefinition_originalPortDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1575484364015_206236_989 _19_0_2_12e503d9_1575484364017_387810_990"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575484331997_345386_916" name="A_originalPortDefinition_portConjugation" visibility="public" memberEnd="_19_0_2_12e503d9_1575484331999_998721_917 _19_0_2_12e503d9_1575484332001_809802_918">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1575484332001_809802_918" name="portConjugation" visibility="public" type="_19_0_2_12e503d9_1575484318404_705000_871" association="_19_0_2_12e503d9_1575484331997_345386_916">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586300824090_737686_525" annotatedElement="_19_0_2_12e503d9_1575484332001_809802_918">
+            <body>&lt;p>The PortConjugation that relates a certain PortDefinition to its ConjugatedPortDefinition (if any).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575484933049_185930_1575" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575484933049_206246_1576" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1575482354188_693124_238"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1575484160733_882684_674" name="ConjugatedPortDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1575499628230_280244_2362" annotatedElement="_19_0_2_12e503d9_1575484160733_882684_674">
+          <body>&lt;p>A &lt;code>ConjugatedPortDefinition&lt;/code> is a &lt;code>PortDefinition&lt;/code> that is a &lt;code>PortDefinition&lt;/code> of its original &lt;code>PortDefinition&lt;/code>. That is, a &lt;code>ConjugatedPortDefinition&lt;/code> inherits all the &lt;code>features&lt;/code> of the original &lt;code>PortDefinition&lt;/code>, but input &lt;code>flows&lt;/code> of the original &lt;code>PortDefinition&lt;/code> become outputs on the &lt;code>ConjugatedPortDefinition&lt;/code> and output &lt;code>flows&lt;/code> of the original &lt;code>PortDefinition&lt;/code> become inputs on the &lt;code>ConjugatedPortDefinition&lt;/code>. Every &lt;code>PortDefinition&lt;/code> (that is not itself a &lt;code>&lt;code>ConjugatedPortDefinition&lt;/code>&lt;/code>) has exactly one corresponding &lt;code>ConjugatedPortDefinition&lt;/code>, whose effective name is the name of the &lt;code>originalPortDefinition&lt;/code>, with the character &lt;code>~&lt;/code> prepended.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597201730651_692616_73653" name="validateConjugatedPortDefinitionOriginalPortDefinition" visibility="public" constrainedElement="_19_0_2_12e503d9_1575484160733_882684_674">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673568393389_715886_25897" annotatedElement="_19_0_4_12e503d9_1597201730651_692616_73653">
+            <body>&lt;p>The &lt;code>originalPortDefinition&lt;/code> of the &lt;code>ownedPortConjugator&lt;/code> of a &lt;code>ConjugatedPortDefinition&lt;/code> must be the &lt;code>originalPortDefinition&lt;/code> of the &lt;code>ConjugatedPortDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597201730652_524047_73654" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedPortConjugator.originalPortDefinition = originalPortDefinition</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597201765287_375473_73661" name="validateConjugatedPortDefinitionConjugatedPortDefinitionIsEmpty" visibility="public" constrainedElement="_19_0_2_12e503d9_1575484160733_882684_674">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673568321881_895395_25896" annotatedElement="_19_0_4_12e503d9_1597201765287_375473_73661">
+            <body>&lt;p>A &lt;code>ConjugatedPortDefinition&lt;/code> must not itself have a &lt;code>conjugatedPortDefinition&lt;/code>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597201765287_782391_73662" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>conjugatedPortDefinition = null</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1575484198173_630010_721" general="_18_5_3_12e503d9_1565478005829_611481_22375"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575484364017_387810_990" name="originalPortDefinition" visibility="public" type="_18_5_3_12e503d9_1565478005829_611481_22375" isDerived="true" association="_19_0_2_12e503d9_1575484364014_116197_988">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1575499825862_5475_2368" annotatedElement="_19_0_2_12e503d9_1575484364017_387810_990">
+            <body>&lt;p>The original &lt;code>PortDefinition&lt;/code> for this &lt;code>ConjugatedPortDefinition&lt;/code>, which is the &lt;code>owningNamespace&lt;/code> of the &lt;code>ConjugatedPortDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575484980782_50853_1601" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575484980783_130609_1602" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674986_474739_43306"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575484344901_850046_947" name="ownedPortConjugator" visibility="public" type="_19_0_2_12e503d9_1575484318404_705000_871" isDerived="true" association="_19_0_2_12e503d9_1575484344899_264172_945">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586298615996_445171_494" annotatedElement="_19_0_2_12e503d9_1575484344901_850046_947">
+            <body>&lt;p>The &lt;code>PortConjugation&lt;/code> that is the &lt;code>ownedConjugator&lt;/code> of this &lt;code>ConjugatedPortDefinition&lt;/code>, linking it to its &lt;code>originalPortDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575484904662_70683_1541" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575484904663_978285_1542" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1575482646809_280165_440"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1653430735794_8707_24" name="effectiveName" visibility="public" bodyCondition="_19_0_4_12e503d9_1653431018641_56165_107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1653430940253_377541_104" annotatedElement="_19_0_4_12e503d9_1653430735794_8707_24">
+            <body>&lt;p>If the &lt;code>name&lt;/code> of the &lt;code>originalPortDefinition&lt;/code> is non-empty, then return that with the character &lt;code>~&lt;/code> prepended.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1653431018641_56165_107" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1653431018670_178254_108" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let originalName : String = originalPortDefinition.name in
+if originalName = null then null
+else '~' + originalName
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1653430743839_991857_27" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1653430743880_86374_28" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1653430743887_37383_29" name="" visibility="public" value="1"/>
+          </ownedParameter>
+          <redefinedOperation href="KerML_only_xmi.uml#_19_0_4_12e503d9_1617479751670_738886_26879"/>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1575484318404_705000_871" name="PortConjugation" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1575499751936_122597_2363" annotatedElement="_19_0_2_12e503d9_1575484318404_705000_871">
+          <body>&lt;p>A &lt;code>PortConjugation&lt;/code> is a &lt;code>Conjugation&lt;/code> &lt;code>Relationship&lt;/code> between a &lt;code>PortDefinition&lt;/code> and its corresponding &lt;code>ConjugatedPortDefinition&lt;/code>. As a result of this &lt;code>Relationship&lt;/code>, the &lt;code>ConjugatedPortDefinition&lt;/code> inherits all the &lt;code>features&lt;/code> of the original &lt;code>PortDefinition&lt;/code>, but input &lt;code>flows&lt;/code> of the original &lt;code>PortDefinition&lt;/code> become outputs on the &lt;code>ConjugatedPortDefinition&lt;/code> and output &lt;code>flows&lt;/code> of the original &lt;code>PortDefinition&lt;/code> become inputs on the &lt;code>ConjugatedPortDefinition&lt;/code>.&lt;/code>&lt;/p>
+</body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_2_12e503d9_1575484399453_235200_1057">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_2_12e503d9_1575482328287_696279_181"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575484331999_998721_917" name="originalPortDefinition" visibility="public" type="_18_5_3_12e503d9_1565478005829_611481_22375" association="_19_0_2_12e503d9_1575484331997_345386_916">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1575499775830_686280_2366" annotatedElement="_19_0_2_12e503d9_1575484331999_998721_917">
+            <body>&lt;p>The &lt;code>PortDefinition&lt;/code> being conjugated.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575484567270_296077_1453" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575484567274_722308_1454" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1575482354187_108424_237"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575484344899_880331_946" name="conjugatedPortDefinition" visibility="public" type="_19_0_2_12e503d9_1575484160733_882684_674" isDerived="true" association="_19_0_2_12e503d9_1575484344899_264172_945">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1575499809717_245944_2367" annotatedElement="_19_0_2_12e503d9_1575484344899_880331_946">
+            <body>&lt;p>The &lt;code>ConjugatedPortDefinition&lt;/code> that is conjugate to the &lt;code>originalPortDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575484641192_729288_1495" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575484641193_822295_1496" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1575482646809_778895_441"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575484344899_264172_945" name="A_conjugatedPortDefinition_ownedPortConjugator" visibility="public" memberEnd="_19_0_2_12e503d9_1575484344899_880331_946 _19_0_2_12e503d9_1575484344901_850046_947"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1577914899997_653496_45" name="ConjugatedPortTyping" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1577916906930_674215_683" annotatedElement="_19_0_2_12e503d9_1577914899997_653496_45">
+          <body>&lt;p>A &lt;code>ConjugatedPortTyping&lt;/code> is a &lt;code>FeatureTyping&lt;/code> whose &lt;code>type&lt;/code> is a &lt;code>ConjugatedPortDefinition&lt;/code>. (This relationship is intended to be an abstract-syntax marker for a special surface notation for conjugated typing of ports.)&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597201665919_666820_73640" name="deriveConjugatedPortTypingPortDefinition" visibility="public" constrainedElement="_19_0_2_12e503d9_1577914899997_653496_45">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676645703979_320854_516" annotatedElement="_19_0_4_12e503d9_1597201665919_666820_73640">
+            <body>&lt;p>The &lt;code>portDefinition&lt;/code> of a &lt;code>ConjugatedPortTyping&lt;/code> is the &lt;code>originalPortDefinition&lt;/code> of the &lt;code>conjugatedPortDefinition&lt;/code> of the &lt;code>ConjugatedPortTyping&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597201665920_322518_73641" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>portDefinition = conjugatedPortDefinition.originalPortDefinition</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1577914967773_834005_117">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543180339807_437641_20928"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1577915013583_787601_133" name="portDefinition" visibility="public" type="_18_5_3_12e503d9_1565478005829_611481_22375" isDerived="true" association="_19_0_2_12e503d9_1577915013582_325235_132">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586299024268_978012_505" annotatedElement="_19_0_2_12e503d9_1577915013583_787601_133">
+            <body>&lt;p>The &lt;code>originalPortDefinition&lt;/code> of the &lt;code>conjugatedPortDefinition&lt;/code> of this &lt;code>ConjugatedPortTyping&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1577915053352_700799_162" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1577915053352_165890_163" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1577915017970_186033_146" name="conjugatedPortDefinition" visibility="public" type="_19_0_2_12e503d9_1575484160733_882684_674" association="_19_0_2_12e503d9_1577915017970_176257_145">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586299127616_419207_506" annotatedElement="_19_0_2_12e503d9_1577915017970_186033_146">
+            <body>&lt;p>The &lt;code>type&lt;/code> of this &lt;code>ConjugatedPortTyping&lt;/code> considered as a &lt;code>FeatureTyping&lt;/code>, which must be a &lt;code>ConjugatedPortDefinition&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1577915046817_187379_158" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1577915046818_16378_159" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543180520185_480887_21131"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1577915017970_176257_145" name="A_conjugatedPortDefinition_typingByConjugatedPort" visibility="public" memberEnd="_19_0_2_12e503d9_1577915017970_186033_146 _19_0_2_12e503d9_1577915017970_844299_147">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1577915017970_844299_147" name="typingByConjugatedPort" visibility="public" type="_19_0_2_12e503d9_1577914899997_653496_45" association="_19_0_2_12e503d9_1577915017970_176257_145">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586300959638_749402_527" annotatedElement="_19_0_2_12e503d9_1577915017970_844299_147">
+            <body>&lt;p>The ConjugatedPortTypings whose &lt;code>conjugatedPortDefinition&lt;/code> a certain ConjugatedPortDefinition.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1577915416356_723225_234" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1577915416356_329099_235" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543180520185_90900_21132"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1577915013582_325235_132" name="A_portDefinition_conjugatedPortTyping" visibility="public" memberEnd="_19_0_2_12e503d9_1577915013583_787601_133 _19_0_2_12e503d9_1577915013583_567398_134">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1577915013583_567398_134" name="conjugatedPortTyping" visibility="public" type="_19_0_2_12e503d9_1577914899997_653496_45" isDerived="true" association="_19_0_2_12e503d9_1577915013582_325235_132">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586300907476_136826_526" annotatedElement="_19_0_2_12e503d9_1577915013583_567398_134">
+            <body>&lt;p>The ConjugatedPortTypings whose &lt;code>portDefinition&lt;/code> is a certain PortDefinition.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1577915505799_529314_268" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1577915505799_92579_269" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674961_537222_43178"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1565473083082_241892_21329" name="Attributes" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565471213468_167708_20650" name="AttributeDefinition" visibility="public">
+        <ownedComment xmi:id="_18_5_3_12e503d9_1565495591941_694572_26208" annotatedElement="_18_5_3_12e503d9_1565471213468_167708_20650">
+          <body>&lt;p>An &lt;code>AttributeDefinition&lt;/code> is a &lt;code>Definition&lt;/code> and a &lt;code>DataType&lt;/code> of information about a quality or characteristic of a system or part of a system that has no independent identity other than its value. All &lt;code>features&lt;/code> of an &lt;code>AttributeDefinition&lt;/code> must be referential (non-composite).&lt;/p>
+
+&lt;p>As a &lt;code>DataType&lt;/code>, an &lt;code>AttributeDefinition&lt;/code> must specialize, directly or indirectly, the base &lt;code>DataType&lt;/code> &lt;code>&lt;em>Base::DataValue&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672269023022_892446_92" name="validateAttributeDefinitionFeatures" visibility="public" constrainedElement="_18_5_3_12e503d9_1565471213468_167708_20650">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672269132086_137291_94" annotatedElement="_19_0_4_12e503d9_1672269023022_892446_92">
+            <body>&lt;p>All &lt;code>features&lt;/code> of an &lt;code>AttributeDefinition&lt;/code> must be non-composite.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672269023034_268917_93" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>feature->forAll(not isComposite)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565471222569_27900_20678">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557527599533_240072_110321"/>
+        </generalization>
+        <generalization xmi:id="_18_5_3_12e503d9_1565479798793_137309_23381" general="_18_5_3_12e503d9_1565479032244_336549_22524"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565471811428_179735_20974" name="A_attributeDefinition_definedAttribute" visibility="public" memberEnd="_18_5_3_12e503d9_1565471811429_523492_20975 _18_5_3_12e503d9_1565471811429_191039_20976">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565471811429_191039_20976" name="definedAttribute" visibility="public" type="_18_5_3_12e503d9_1565471291545_950196_20762" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591477641253_520897_959" association="_18_5_3_12e503d9_1565471811428_179735_20974">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316988799_429207_849" annotatedElement="_18_5_3_12e503d9_1565471811429_191039_20976">
+            <body>&lt;p>The AttributeUsages that are typed by a certain DataType.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565471848444_988567_21009" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565471848444_707126_21010" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565471291545_950196_20762" name="AttributeUsage" visibility="public">
+        <ownedComment xmi:id="_18_5_3_12e503d9_1565473257677_140958_21330" annotatedElement="_18_5_3_12e503d9_1565471291545_950196_20762">
+          <body>&lt;p>An &lt;code>AttributeUsage&lt;/code> is a &lt;code>Usage&lt;/code> whose type is a &lt;code>DataType&lt;/code>. Nominally, if the type is an &lt;code>AttributeDefinition&lt;/code>, an &lt;code>AttributeUsage&lt;/code> is a usage of a &lt;code>AttributeDefinition&lt;/code> to represent the value of some system quality or characteristic. However, other kinds of kernel &lt;code>DataTypes&lt;/code> are also allowed, to permit use of &lt;code>DataTypes&lt;/code> from the Kernel Model Libraries. An &lt;code>AttributeUsage&lt;/code> itself as well as all its nested &lt;code>features&lt;/code> must be referential (non-composite).&lt;/p>
+
+&lt;p>An &lt;code>AttributeUsage&lt;/code> must specialize, directly or indirectly, the base &lt;code>Feature&lt;/code> &lt;code>&lt;em>Base::dataValues&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672351282003_113968_104" name="validateAttributeUsageIsReference" visibility="public" constrainedElement="_18_5_3_12e503d9_1565471291545_950196_20762">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672351282102_230212_106" annotatedElement="_19_0_4_12e503d9_1672351282003_113968_104">
+            <body>&lt;p>An &lt;code>AttributeUsage&lt;/code> is always referential.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672351282062_9342_105" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isReference</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672269137258_793917_95" name="validateAttributeUsageFeatures" visibility="public" constrainedElement="_18_5_3_12e503d9_1565471291545_950196_20762">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672269137297_656364_97" annotatedElement="_19_0_4_12e503d9_1672269137258_793917_95">
+            <body>&lt;p>All &lt;code>features&lt;/code> of an &lt;code>AttributeUsage&lt;/code> must be non-composite.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672269137290_839044_96" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>feature->forAll(not isComposite)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672442693001_879704_134" name="checkAttributeUsageSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565471291545_950196_20762">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672443762365_302357_139" annotatedElement="_19_0_4_12e503d9_1672442693001_879704_134">
+            <body>&lt;p>An &lt;code>AttributeUsage&lt;/code> must directly or indirectly specialize &lt;code>&lt;em>Base::dataValues&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672442693013_645307_135" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Base::dataValues')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565493447093_754020_25273" general="_18_5_3_12e503d9_1565469997820_598571_19982"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565471811429_523492_20975" name="attributeDefinition" visibility="public" isOrdered="true" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1591477641252_179221_958" association="_18_5_3_12e503d9_1565471811428_179735_20974">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316963982_900816_848" annotatedElement="_18_5_3_12e503d9_1565471811429_523492_20975">
+            <body>&lt;p>The &lt;code>DataTypes&lt;/code> that are the types of this &lt;code>AttributeUsage&lt;/code>. Nominally, these are &lt;code>AttributeDefinitions&lt;/code>, but other kinds of kernel &lt;code>DataTypes&lt;/code> are also allowed, to permit use of &lt;code>DataTypes&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557527599533_240072_110321"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565471836970_553123_20997" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565471836970_6595_20998" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624050661138_649455_27" name="isReference" visibility="public" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1624035114787_488767_41423">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624050705483_81971_30" annotatedElement="_19_0_4_12e503d9_1624050661138_649455_27">
+            <body>&lt;p>Always true for an &lt;code>AttributeUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1624050678304_660740_29" name="" visibility="public" value="true"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1565502971141_445815_33340" name="Actions" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1567740791820_948082_18016" name="A_performedAction_performingAction" visibility="public" memberEnd="_19_0_2_12e503d9_1567740791820_867719_18017 _19_0_2_12e503d9_1567740791820_137197_18018">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1567740791820_137197_18018" name="performingAction" visibility="public" type="_18_5_3_12e503d9_1565503273042_472885_33822" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1622831790393_898128_196" association="_19_0_2_12e503d9_1567740791820_948082_18016">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313419732_851993_673" annotatedElement="_19_0_2_12e503d9_1567740791820_137197_18018">
+            <body>&lt;p>The PerformActionUsages that have a certain ActionUsage as their &lt;code>performedAction&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1586313383443_236726_669" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1586313383444_823270_670" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565503089035_106795_33475" name="AcceptActionUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567742035187_166435_18109" annotatedElement="_18_5_3_12e503d9_1565503089035_106795_33475">
+          <body>&lt;p>An &lt;code>AcceptActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that specifies the acceptance of an &lt;em>&lt;code>incomingTransfer&lt;/code>&lt;/em> from the &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> given by the result of its &lt;code>receiverArgument&lt;/code> Expression. (If no &lt;code>receiverArgument&lt;/code> is provided, the default is the &lt;em>&lt;code>this&lt;/code>&lt;/em> context of the AcceptActionUsage.) The payload of the accepted &lt;em>&lt;code>Transfer&lt;/em>&lt;/code> is output on its &lt;code>payloadParameter&lt;/code>. Which &lt;em>&lt;code>Transfers&lt;/em>&lt;/code> may be accepted is determined by conformance to the typing and (potentially) binding of the &lt;code>payloadParameter&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1665508310690_815204_1111" name="validateAcceptActionUsageParameters" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503089035_106795_33475">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665508507451_978456_1113" annotatedElement="_19_0_4_12e503d9_1665508310690_815204_1111">
+            <body>&lt;p>An &lt;code>AcceptUsageAction&lt;/code> must have at least on input &lt;code>parameter&lt;/code>, corresponding to its &lt;em>&lt;code>payload&lt;/code>&lt;/em> (even if it has no &lt;code>FeatureValue&lt;/code>). (Note that the &lt;code>payloadParameter&lt;/code> is an input as well as an output.)&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665508310709_893602_1112" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>inputParameters()->notEmpty()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1665507906329_816450_1102" name="deriveAcceptActionUsageReceiverArgument" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503089035_106795_33475">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665507984619_828432_1104" annotatedElement="_19_0_4_12e503d9_1665507906329_816450_1102">
+            <body>&lt;p>The &lt;code>receiverArgument&lt;/code> of an &lt;code>AcceptUsageAction&lt;/code> is its second argument &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665507906343_150802_1103" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>receiverArgument = argument(2)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1665508047104_536461_1105" name="deriveAcceptActionUsagePayloadArgument" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503089035_106795_33475">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665508183930_426374_1107" annotatedElement="_19_0_4_12e503d9_1665508047104_536461_1105">
+            <body>&lt;p>The &lt;code>payloadArgument&lt;/code> of an &lt;code>AcceptUsageAction&lt;/code> is its first argument &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665508047126_738774_1106" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>payloadArgument = argument(1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1665508220375_444978_1108" name="deriveAcceptActionUsagePayloadParameter" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503089035_106795_33475">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665508298897_993479_1110" annotatedElement="_19_0_4_12e503d9_1665508220375_444978_1108">
+            <body>&lt;p>The &lt;code>payloadParameter&lt;/code> of an &lt;code>AcceptActionUsage&lt;code> is its first &lt;code>parameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665508220383_809408_1109" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>payloadParameter = 
+ if parameter->isEmpty() then null
+ else parameter->first() endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673481691644_517214_1088" name="checkAcceptActionUsageSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503089035_106795_33475">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673492862710_177027_1114" annotatedElement="_19_0_4_12e503d9_1673481691644_517214_1088">
+            <body>&lt;p>An &lt;code>AcceptActionUsage&lt;/code> that is not the &lt;code>triggerAction&lt;/code> of a &lt;code>TransitionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::acceptActions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673481691660_440250_1089" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>not isTriggerAction() implies
+    specializesFromLibrary('Actions::acceptActions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673492735232_213155_1112" name="checkAcceptActionUsageSubactionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503089035_106795_33475">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673492968802_338322_1115" annotatedElement="_19_0_4_12e503d9_1673492735232_213155_1112">
+            <body>&lt;p>A composite &lt;code>AcceptActionUsage&lt;/code> that is a subaction usage, but is &lt;em>not&lt;/em> the &lt;code>triggerAction&lt;/code> of a &lt;code>TransitionUsage&lt;/code>, must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::acceptSubactions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673492735248_413670_1113" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSubactionUsage() and not isTriggerAction() implies
+    specializesFromLibrary('Actions::Action::acceptSubactions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673492974865_560260_1116" name="checkAcceptActionUsageTriggerActionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503089035_106795_33475">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673493154930_953925_1118" annotatedElement="_19_0_4_12e503d9_1673492974865_560260_1116">
+            <body>&lt;p>An &lt;code>AcceptActionUsage&lt;/code> that is the &lt;code>triggerAction&lt;/code> of &lt;code>TransitionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::TransitionAction::accepter&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673492974879_509779_1117" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isTriggerAction() implies
+    specializesFromLibrary('Actions::TransitionAction::accepter')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673494134115_91942_1124" name="checkAcceptActionUsageReceiverBindingConnector" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503089035_106795_33475">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673494371725_894749_1126" annotatedElement="_19_0_4_12e503d9_1673494134115_91942_1124">
+            <body>&lt;p>If the &lt;code>payloadArgument&lt;/code> of an &lt;code>AcceptActionUsage&lt;/code> is a &lt;code>TriggerInvocationExpression&lt;/code>, then the &lt;code>AcceptActionusage&lt;/code> must have an &lt;code>ownedFeature&lt;/code> that is a &lt;code>BindingConnector&lt;/code> between its &lt;code>&lt;em>receiver&lt;/em>&lt;/code> &lt;code>parameter&lt;/code> and the &lt;code>&lt;em>receiver&lt;/em>&lt;/code> &lt;code>parameter&lt;/code> of the &lt;code>TriggerInvocationExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673494134123_355207_1125" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>payloadArgument &lt;> null and
+payloadArgument.oclIsKindOf(TriggerInvocationExpression) implies
+    let invocation : Expression =
+        payloadArgument.oclAsType(Expression) in
+    parameter->size() >= 2 and
+    invocation.parameter->size() >= 2 and        
+    ownedFeature->selectByKind(BindingConnector)->exists(b |
+        b.relatedFeatures->includes(parameter->at(2)) and
+        b.relatedFeatures->includes(invocation.parameter->at(2)))</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565503195810_386379_33677" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1612814670555_311543_168" name="receiverArgument" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1612814670554_450768_167">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1612841006881_409818_32" annotatedElement="_19_0_4_12e503d9_1612814670555_311543_168">
+            <body>&lt;p>An &lt;code>Expression&lt;/code> whose &lt;code>result&lt;/code> is bound to the &lt;em>&lt;code>receiver&lt;/code>&lt;/em> input &lt;code>parameter&lt;/code> of this &lt;code>AcceptActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1612814711184_372655_178" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1612814711185_241496_179" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1642701018287_478584_4462" name="payloadParameter" visibility="public" type="_19_0_2_12e503d9_1591477377905_618531_857" isDerived="true" association="_19_0_4_12e503d9_1642701018280_486257_4461">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1642703121646_292691_4877" annotatedElement="_19_0_4_12e503d9_1642701018287_478584_4462">
+            <body>&lt;p>The &lt;code>nestedReference&lt;/code> of this &lt;code>AcceptActionUsage&lt;/code> that redefines the &lt;code>payload&lt;/code> output &lt;code>parameter&lt;/code> of the base &lt;code>AcceptActionUsage&lt;/code> &lt;em>&lt;code>AcceptAction&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1642701274356_155587_4474" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1642701274376_193621_4475" name="" visibility="public" value="1"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591477541360_47573_933"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174990_213826_657"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1642710978429_81558_4948" name="payloadArgument" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1642710978426_592787_4947">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1642711121142_405624_4964" annotatedElement="_19_0_4_12e503d9_1642710978429_81558_4948">
+            <body>&lt;p>An &lt;code>Expression&lt;/code> whose &lt;code>result&lt;/code> is bound to the &lt;code>&lt;em>payload&lt;/em>&lt;/code> &lt;code>parameter&lt;/code> of this &lt;code>AcceptActionUsage&lt;/code>. If provided, the &lt;code>AcceptActionUsage&lt;/code> will only accept a &lt;code>&lt;em>Transfer&lt;/em>&lt;/code> with exactly this &lt;code>&lt;em>payload&lt;/em>&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1642710996728_956230_4958" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1642710996731_546241_4959" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1673482757089_704509_1102" name="isTriggerAction" visibility="public" bodyCondition="_19_0_4_12e503d9_1673482881349_851654_1107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673482813322_647678_1106" annotatedElement="_19_0_4_12e503d9_1673482757089_704509_1102">
+            <body>&lt;p>Check if this &lt;code>AcceptActionUsage&lt;/code> is the &lt;code>triggerAction&lt;/code> of a &lt;code>TransitionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1673482881349_851654_1107" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673482881360_891074_1108" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>owningType &lt;> null and 
+owningType.oclIsKindOf(TransitionUsage) and
+owningType.oclAsType(TransitionUsage).triggerAction->includes(self)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673482772180_507873_1105" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1567742374929_849093_18140" name="A_receiverArgument_sendActionUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1567742374932_10504_18141 _19_0_2_12e503d9_1567742374933_369875_18142">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1567742374933_369875_18142" name="sendActionUsage" visibility="public" type="_18_5_3_12e503d9_1565505727349_597544_34143" isDerived="true" association="_19_0_2_12e503d9_1567742374929_849093_18140">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313362753_745718_666" annotatedElement="_19_0_2_12e503d9_1567742374933_369875_18142">
+            <body>&lt;p>The &lt;code>SendActionUsage&lt;/code> that has a certain &lt;code>Expression&lt;code> as its &lt;code>receiverArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1586313315759_393458_661" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1586313315759_717157_662" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565505727349_597544_34143" name="SendActionUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567742450997_733799_18155" annotatedElement="_18_5_3_12e503d9_1565505727349_597544_34143">
+          <body>&lt;p>A &lt;code>SendActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that specifies the sending of a payload given by the result of its &lt;code>payloadArgument&lt;/code> &lt;code>Expression&lt;/code> via a &lt;em>&lt;code>MessageTransfer&lt;/code>&lt;/em> whose &lt;em>&lt;code>source&lt;/code>&lt;/em> is given by the result of the &lt;code>senderArgument&lt;/code> &lt;code>Expression&lt;/code> and whose &lt;code>target&lt;/code> is given by the result of the &lt;code>receiverArgument&lt;/code> &lt;code>Expression&lt;/code>. If no &lt;code>senderArgument&lt;/code> is provided, the default is the &lt;em>&lt;code>this&lt;/code>&lt;/em> context for the action. If no &lt;code>receiverArgument&lt;/code> is given, then the receiver is to be determined by, e.g., outgoing &lt;em>&lt;code>Connections&lt;/code>&lt;/em> from the sender.&lt;/p> 
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1665507309548_321296_1085" name="deriveSendActionUsageSenderArgument" visibility="public" constrainedElement="_18_5_3_12e503d9_1565505727349_597544_34143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665507309599_987519_1087" annotatedElement="_19_0_4_12e503d9_1665507309548_321296_1085">
+            <body>&lt;p>The &lt;code>senderArgument&lt;/code> of a &lt;code>SendActionUsage&lt;/code> is its second argument &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665507309588_925064_1086" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>senderArgument = argument(2)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1665505406320_68117_973" name="deriveSendActionUsagePayloadArgument" visibility="public" constrainedElement="_18_5_3_12e503d9_1565505727349_597544_34143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665505943691_896945_1007" annotatedElement="_19_0_4_12e503d9_1665505406320_68117_973">
+            <body>&lt;p>The &lt;code>payloadArgument&lt;/code> of a &lt;code>SendActionUsage&lt;/code> is its first argument &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665505406340_994317_974" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>payloadArgument = argument(1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1665507661284_710591_1091" name="validateSendActionUsagePayloadArgument" visibility="public" constrainedElement="_18_5_3_12e503d9_1565505727349_597544_34143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665507784263_479345_1093" annotatedElement="_19_0_4_12e503d9_1665507661284_710591_1091">
+            <body>&lt;p>If a &lt;code>SendActionUsage&lt;/code> is owned via a &lt;code>StateSubactionMembership&lt;/code> or a &lt;code>TransitionFeatureMembership&lt;/code>, then it must have a &lt;code>payloadArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665507661302_910185_1092" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningFeatureMembership &lt;> null and
+(owningFeatureMembership.oclIsKindOf(StateSubactionMembership) or
+ owningFeatureMembership.oclIsKindOf(TransitionFeatureMembership)) implies
+    payloadArgument &lt;> null</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1665507530235_589295_1088" name="deriveSendActionUsageReceiverArgument" visibility="public" constrainedElement="_18_5_3_12e503d9_1565505727349_597544_34143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665507530264_130243_1090" annotatedElement="_19_0_4_12e503d9_1665507530235_589295_1088">
+            <body>&lt;p>The &lt;code>receiverArgument&lt;/code> of a &lt;code>SendActionUsage&lt;/code> is its third argument &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665507530259_368981_1089" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>receiverArgument = argument(3)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673468438828_845581_1067" name="checkSendActionUsageSubactionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565505727349_597544_34143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675125453304_278953_319" annotatedElement="_19_0_4_12e503d9_1673468438828_845581_1067">
+            <body>&lt;p>A composite &lt;code>SendActionUsage&lt;/code> that is a subaction must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::sendSubactions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673468438852_150536_1068" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSubactionUsage() implies
+    specializesFromLibrary('Actions::Action::acceptSubactions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673467849016_612152_1062" name="checkSendActionUsageSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565505727349_597544_34143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673467989663_691467_1064" annotatedElement="_19_0_4_12e503d9_1673467849016_612152_1062">
+            <body>&lt;p>A &lt;code>SendActionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::sendActions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673467849030_235133_1063" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::sendActions')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565505742396_618041_34189" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1567742374932_10504_18141" name="receiverArgument" visibility="public" isDerived="true" association="_19_0_2_12e503d9_1567742374929_849093_18140">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1567742620460_796939_18156" annotatedElement="_19_0_2_12e503d9_1567742374932_10504_18141">
+            <body>&lt;p>An &lt;code>Expression&lt;/code> whose result is bound to the &lt;em>&lt;code>receiver&lt;/code>&lt;/em> input parameter of this &lt;code>SendActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1567742427623_225049_18151" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1567742427625_355165_18152" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1612814399422_336683_143" name="payloadArgument" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1612814399420_305432_142">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1612841041982_608356_33" annotatedElement="_19_0_4_12e503d9_1612814399422_336683_143">
+            <body>&lt;p>An &lt;code>Expression&lt;/code> whose result is bound to the &lt;code>&lt;em>payload&lt;/em>&lt;/code> input parameter of this &lt;code>SendActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1612814596371_254161_159" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1612814596371_949294_160" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1665504224536_894018_944" name="senderArgument" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1665504224524_746163_943">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665504806560_336424_964" annotatedElement="_19_0_4_12e503d9_1665504224536_894018_944">
+            <body>&lt;p>An &lt;code>Expression&lt;/code> whose result is bound to the &lt;em>&lt;code>sender&lt;/code>&lt;/em> input parameter of this &lt;code>SendActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665504255976_26443_954" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665504256001_821982_955" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565503273042_472885_33822" name="PerformActionUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567723307149_372278_17999" annotatedElement="_18_5_3_12e503d9_1565503273042_472885_33822">
+          <body>&lt;p>A &lt;code>PerformActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that represents the performance of an &lt;code>ActionUsage&lt;/code>. Unless it is the &lt;code>PerformActionUsage&lt;/code> itself, the &lt;code>ActionUsage&lt;/code> to be performed is related to the &lt;code>PerformActionUsage&lt;/code> by a &lt;code>ReferenceSubsetting&lt;/code> relationship. A &lt;code>PerformActionUsage&lt;/code> is also an &lt;code>EventOccurrenceUsage&lt;/code>, with its &lt;code>performedAction&lt;/code> as the &lt;code>eventOccurrence&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673064728053_209868_687" name="validatePerformActionUsageReference" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503273042_472885_33822">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673064728082_85192_693" annotatedElement="_19_0_4_12e503d9_1673064728053_209868_687">
+            <body>&lt;p>If a &lt;code>PerformActionUsage&lt;/code> has an &lt;code>ownedReferenceSubsetting&lt;/code>, then the &lt;code>featureTarget&lt;/code> of the &lt;code>referencedFeature&lt;/code> must be an &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673064728081_8013_692" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referencedFeatureTarget() &lt;> null implies
+    referencedFeatureTarget().oclIsKindOf(ActionUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673064728014_263072_685" name="checkPerformActionUsageSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503273042_472885_33822">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673064728074_694326_689" annotatedElement="_19_0_4_12e503d9_1673064728014_263072_685">
+            <body>&lt;p>If a &lt;code>PerformActionUsage&lt;/code> has an &lt;code>owningType&lt;/code> that is a &lt;code>PartDefinition&lt;/code> or &lt;code>PartUsage&lt;/code>, then it must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;code>&lt;em>Parts::Part::performedActions&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673064728054_240897_688" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(PartDefinition) or
+ owningType.oclIsKindOf(PartUsage)) implies
+    specializesFromLibrary('Parts::Part::performedActions')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565503286904_517940_33868" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1624032092360_317949_39899" general="_19_0_4_12e503d9_1622831611763_442921_132"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1567740791820_867719_18017" name="performedAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1622831790393_676695_195" association="_19_0_2_12e503d9_1567740791820_948082_18016">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1567741025428_248952_18031" annotatedElement="_19_0_2_12e503d9_1567740791820_867719_18017">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> to be performed by this &lt;code>PerformedActionUsage&lt;/code>. It is the &lt;code>eventOccurrence&lt;/code> of the &lt;code>PerformActionUsage&lt;/code> considered as an &lt;code>EventOccurrenceUsage&lt;/code>, which must be an &lt;code>ActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1567740809765_188876_18027" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1567740809927_795737_18028" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1617484231900_658382_27221" name="namingFeature" visibility="public" bodyCondition="_19_0_4_12e503d9_1617484231904_512589_27222" redefinedOperation="_19_0_4_12e503d9_1617482356453_410307_26991">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617484231909_289539_27224" annotatedElement="_19_0_4_12e503d9_1617484231900_658382_27221">
+            <body>&lt;p>The naming &lt;code>Feature&lt;/code> of a &lt;code>PerformActionUsage&lt;/code> is its &lt;code>performedAction&lt;/code>, if this is different than the &lt;code>PerformActionUsage&lt;/code>. If the &lt;code>PerformActionUsage&lt;/code> is its own &lt;code>performedAction&lt;/code>, then the naming &lt;code>Feature&lt;/code> is the same as the usual default for a &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617484231904_512589_27222" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617484231910_294337_27225" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if performedAction &lt;> self then performedAction
+else self.oclAsType(Usage).namingFeature()
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617484231908_869149_27223" name="" visibility="public" direction="return">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617484231916_688374_27227" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617484231914_880406_27226" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565503181274_818459_33629" name="ForkNode" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567744124281_97117_18171" annotatedElement="_18_5_3_12e503d9_1565503181274_818459_33629">
+          <body>&lt;p>A &lt;code>ForkNode&lt;/code> is a &lt;code>ControlNode&lt;/code> that must be followed by successor &lt;code>Actions&lt;/code> as given by all its outgoing &lt;code>Successions&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597202580855_150041_73724" name="validateForkNodeIncomingSuccessions" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503181274_818459_33629">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1597202609624_566465_73726" annotatedElement="_19_0_4_12e503d9_1597202580855_150041_73724">
+            <body>&lt;p>A &lt;code>ForkNode&lt;/code> may have at most one incoming &lt;code>Succession&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597202580855_391965_73725" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>targetConnector->selectByKind(Succession)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673305117647_917082_1016" name="checkForkNodeSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503181274_818459_33629">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673305554585_6960_1021" annotatedElement="_19_0_4_12e503d9_1673305117647_917082_1016">
+            <body>&lt;p>A &lt;code>ForkNode&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::forks&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673305117655_846136_1017" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::Action::forks')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565503210031_974624_33714" general="_19_0_2_12e503d9_1567281323333_776611_544"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565503134270_392089_33594" name="JoinNode" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567743583110_313281_18170" annotatedElement="_18_5_3_12e503d9_1565503134270_392089_33594">
+          <body>&lt;p>A &lt;code>JoinNode&lt;/code> is a &lt;code>ControlNode&lt;/code> that waits for the completion of all the predecessor &lt;code>Actions&lt;/code> given by incoming &lt;code>Successions&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597202536485_673649_73721" name="validateJoinNodeOutgoingSuccessions" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503134270_392089_33594">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1597202571944_948510_73723" annotatedElement="_19_0_4_12e503d9_1597202536485_673649_73721">
+            <body>&lt;p>A &lt;code>JoinNode&lt;/code> may have at most one outgoing &lt;code>Succession&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597202536485_691737_73722" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>sourceConnector->selectByKind(Succession)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673304964579_760105_1014" name="checkJoinNodeSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503134270_392089_33594">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673305583621_121480_1022" annotatedElement="_19_0_4_12e503d9_1673304964579_760105_1014">
+            <body>&lt;p>A &lt;code>JoinNode&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::joins&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673304964605_963137_1015" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::Action::join')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565503206599_147052_33705" general="_19_0_2_12e503d9_1567281323333_776611_544"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1567281323333_776611_544" name="ControlNode" visibility="public" isAbstract="true">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567742729496_172255_18167" annotatedElement="_19_0_2_12e503d9_1567281323333_776611_544">
+          <body>&lt;p>A &lt;code>ControlNode&lt;/code> is an &lt;code>ActionUsage&lt;/code> that does not have any inherent behavior but provides constraints on incoming and outgoing &lt;code>Successions&lt;/code> that are used to control other &lt;code>Actions&lt;/code>. A &lt;code>ControlNode&lt;/code> must be a composite owned &lt;code>usage&lt;/code> of an &lt;code>ActionDefinition&lt;/code> or &lt;code>ActionUsage&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673300606609_888940_927" name="validateControlNodeOutgoingSuccessions" visibility="public" constrainedElement="_19_0_2_12e503d9_1567281323333_776611_544">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673300866524_583255_949" annotatedElement="_19_0_4_12e503d9_1673300606609_888940_927">
+            <body>&lt;p>All outgoing &lt;code>Successions&lt;/code> from a &lt;code>ControlNode&lt;/code> must have a source &lt;code>multiplicity&lt;/code> of &lt;code>1..1&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673300606616_131749_928" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>sourceConnector->selectByKind(Succession)->
+    collect(connectorEnd->at(1).multiplicity)->
+    forAll(sourceMult | 
+        multiplicityHasBounds(sourceMult, 1, 1))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673300364660_250413_921" name="validateControlNodeOwningType" visibility="public" constrainedElement="_19_0_2_12e503d9_1567281323333_776611_544">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673300481529_295393_923" annotatedElement="_19_0_4_12e503d9_1673300364660_250413_921">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>ControlNode&lt;/code> must be an &lt;code>ActionDefinition&lt;/code> or &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673300364684_364966_922" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and 
+(owningType.oclIsKindOf(ActionDefinition) or
+ owningType.oclIsKindOf(ActionUsage))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673300873084_380033_950" name="validateControlNodeIncomingSuccessions" visibility="public" constrainedElement="_19_0_2_12e503d9_1567281323333_776611_544">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673300911354_939370_952" annotatedElement="_19_0_4_12e503d9_1673300873084_380033_950">
+            <body>&lt;p>All incoming &lt;code>Successions&lt;/code> to a &lt;code>ControlNode&lt;/code> must have a target &lt;code>multiplicity&lt;/code> of &lt;code>1..1&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673300873092_196513_951" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>targetConnector->selectByKind(Succession)->
+    collect(connectorEnd->at(2).multiplicity)->
+    forAll(targetMult | 
+        multiplicityHasBounds(targetMult, 1, 1))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673300485106_866107_924" name="checkControlNodeSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1567281323333_776611_544">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673300586674_637917_926" annotatedElement="_19_0_4_12e503d9_1673300485106_866107_924">
+            <body>&lt;p>A &lt;code>ControlNode&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::control&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673300485116_138323_925" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Action::Action::controls')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740257892182_952081_375" name="validateControlNodeIsComposite" visibility="public" constrainedElement="_19_0_2_12e503d9_1567281323333_776611_544">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740257934319_141615_377" annotatedElement="_2022x_2_12e503d9_1740257892182_952081_375">
+            <body>&lt;p>A &lt;code>ControlNode&lt;/code> must be composite.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740257892183_313477_376" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1567281758200_167873_622" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1673303800873_997606_1003" name="multiplicityHasBounds" visibility="public" bodyCondition="_19_0_4_12e503d9_1673304120119_868676_1012">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676648456830_371091_604" annotatedElement="_19_0_4_12e503d9_1673303800873_997606_1003">
+            <body>&lt;p>Check that the given &lt;code>Multiplicity&lt;/code> has &lt;code>lowerBound&lt;/code> and &lt;code>upperBound&lt;/code> expressions that are model-level evaluable to the given &lt;code>lower&lt;/code> and &lt;code>upper&lt;/code> values.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1673304120119_868676_1012" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673304120146_219730_1013" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>mult &lt;> null and
+if mult.oclIsKindOf(MultiplicityRange) then
+    mult.oclAsType(MultiplicityRange).hasBounds(lower, upper)
+else
+    mult.allSuperTypes()->exists(
+        oclisKindOf(MultiplicityRange) and
+        oclAsType(MultiplicityRange).hasBounds(lower, upper)
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673303948979_154414_1008" name="mult" visibility="public">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_2_12e503d9_1573083797505_495205_3879"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673303949056_500152_1009" name="lower" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673303949090_941836_1010" name="upper" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#UnlimitedNatural"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1673303949106_950265_1011" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565500580749_954926_30405" name="ActionUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567722871191_469944_17996" annotatedElement="_18_5_3_12e503d9_1565500580749_954926_30405">
+          <body>&lt;p>An &lt;code>ActionUsage&lt;/code> is a &lt;code>Usage&lt;/code> that is also a &lt;code>Step&lt;/code>, and, so, is typed by a &lt;code>Behavior&lt;/code>. Nominally, if the type is an &lt;code>ActionDefinition&lt;/code>, an &lt;code>ActionUsage&lt;/code> is a &lt;code>Usage&lt;/code> of that &lt;code>ActionDefinition&lt;/code> within a system. However, other kinds of kernel &lt;code>Behaviors&lt;/code> are also allowed, to permit use of &lt;code>Behaviors&lt;/code> from the Kernel Model Libraries.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673062634327_305255_659" name="checkActionUsageSubactionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565500580749_954926_30405">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673062828284_676966_661" annotatedElement="_19_0_4_12e503d9_1673062634327_305255_659">
+            <body>&lt;p>A composite &lt;code>ActionUsage&lt;/code> that is a subaction usage must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::subactions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673062634344_188876_660" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSubactionUsage() implies
+    specializesFromLibrary('Actions::Action::subactions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673062393587_445257_656" name="checkActionUsageSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565500580749_954926_30405">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673062486841_394435_658" annotatedElement="_19_0_4_12e503d9_1673062393587_445257_656">
+            <body>&lt;p>An &lt;code>ActionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::actions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673062393597_456211_657" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::actions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673062860537_784793_662" name="checkActionUsageOwnedActionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565500580749_954926_30405">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676648137912_481994_593" annotatedElement="_19_0_4_12e503d9_1673062860537_784793_662">
+            <body>&lt;p>A composite &lt;code>ActionUsage&lt;/code> whose &lt;code>owningType&lt;/code> is  &lt;code>PartDefinition&lt;/code> or &lt;code>PartUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Parts::Part::ownedActions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673062860549_508127_663" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(PartDefinition) or
+ owningType.oclIsKindOf(PartUsage)) implies
+    specializesFromLibrary('Parts::Part::ownedActions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675369739456_563290_288" name="checkActionUsageStateActionRedefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1565500580749_954926_30405">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675370127860_736261_290" annotatedElement="_19_0_4_12e503d9_1675369739456_563290_288">
+            <body>&lt;p>An &lt;code>ActionUsage&lt;/code> that is the &lt;code>&lt;em>entry&lt;/em>&lt;/code>, &lt;code>&lt;em>do&lt;/em>&lt;/code>, or &lt;code>&lt;em>exit&lt;/em>&lt;/code> &lt;code>&lt;em>Action&lt;/em>&lt;/code> of a &lt;code>StateDefinition&lt;/code> or &lt;code>StateUsage&lt;/code> must redefine the &lt;code>entryAction&lt;/code>, &lt;code>doAction&lt;/code>, or &lt;code>exitAction&lt;/code> &lt;code>feature&lt;/code>, respectively, of the &lt;code>StateDefinition&lt;/code> &lt;code>&lt;em>States::StateAction&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675369739473_94063_289" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningFeatureMembership &lt;> null and
+owningFeatureMembership.oclIsKindOf(StateSubactionMembership) implies
+    let kind : StateSubactionKind = 
+        owningFeatureMembership.oclAsType(StateSubactionMembership).kind in
+    if kind = StateSubactionKind::entry then
+        redefinesFromLibrary('States::StateAction::entryAction')
+    else if kind = StateSubactionKind::do then
+        redefinesFromLibrary('States::StateAction::doAction')
+    else
+        redefinesFromLibrary('States::StateAction::exitAction')
+    endif endif</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565501047163_957198_30933">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_b9102da_1536345916995_711141_17306"/>
+        </generalization>
+        <generalization xmi:id="_18_5_3_12e503d9_1565500717530_152510_30650" general="_19_0_4_12e503d9_1618943737195_33207_138"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565500905804_589845_30779" name="actionDefinition" visibility="public" isOrdered="true" isDerived="true" association="_18_5_3_12e503d9_1565500905803_760605_30778">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586293861541_399148_333" annotatedElement="_18_5_3_12e503d9_1565500905804_589845_30779">
+            <body>&lt;p>The &lt;code>Behaviors&lt;/code> that are the &lt;code>types&lt;/code> of this &lt;code>ActionUsage&lt;/code>. Nominally, these would be &lt;code>ActionDefinitions&lt;/code>, but other kinds of Kernel &lt;code>Behaviors&lt;/code> are also allowed, to permit use of &lt;code>Behaviors&lt;/code> from the Kernel Model Libraries.&lt;/p> 
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651709_376789_42207"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565501090938_492651_30956" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565501090938_677500_30957" name="" visibility="public" value="*"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_b9102da_1536346315176_954314_17388"/>
+          <redefinedProperty href="#_19_0_4_12e503d9_1618943843466_158863_236"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665506734080_865908_1064" name="inputParameters" visibility="public" bodyCondition="_19_0_4_12e503d9_1665507000825_353279_1083">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665506895821_980275_1080" annotatedElement="_19_0_4_12e503d9_1665506734080_865908_1064">
+            <body>&lt;p>Return the owned input &lt;code>parameters&lt;/code> of this &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665507000825_353279_1083" name="inputParametersBody" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665507000843_189078_1084" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>input->select(f | f.owner = self)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665506760088_539772_1067" name="" visibility="public" direction="return">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665506760096_363027_1068" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665506760108_901149_1069" name="" visibility="public" value="*"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1674960065927_85836_80" name="inputParameter" visibility="public" bodyCondition="_19_0_4_12e503d9_1674960228128_821090_98">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674960173798_816189_95" annotatedElement="_19_0_4_12e503d9_1674960065927_85836_80">
+            <body>&lt;p>Return the &lt;code>i&lt;/code>-th owned input &lt;code>parameter&lt;/code> of the &lt;code>ActionUsage&lt;/code>. Return null if the &lt;code>ActionUsage&lt;/code> has less than &lt;code>i&lt;/code> owned input &lt;code>parameters&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1674960228128_821090_98" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674960228172_977312_99" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if inputParameters()->size() &lt; i then null
+else inputParameters()->at(i)
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1674960095903_234503_83" name="i" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1674960095983_211890_84" name="" visibility="public" direction="return" isStream="true">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1674960096234_797477_85" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1674960096242_492292_86" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665506092698_896725_1053" name="argument" visibility="public" bodyCondition="_19_0_4_12e503d9_1665506611977_46929_1060">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665506286621_172719_1059" annotatedElement="_19_0_4_12e503d9_1665506092698_896725_1053">
+            <body>&lt;p>Return the &lt;code>i&lt;/code>-th argument &lt;code>Expression&lt;/code> of an &lt;code>ActionUsage&lt;/code>, defined as the &lt;code>value&lt;/code> &lt;code>Expression&lt;/code> of the &lt;code>FeatureValue&lt;/code> of the &lt;code>i&lt;/code>-th owned input &lt;code>parameter&lt;/code> of the &lt;code>ActionUsage&lt;/code>. Return null if the &lt;code>ActionUsage&lt;/code> has less than &lt;code>i&lt;/code> owned input &lt;code>parameters&lt;/code> or the &lt;code>i&lt;/code>-th owned input &lt;code>parameter&lt;/code> has no &lt;code>FeatureValue&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665506611977_46929_1060" name="argumentBody" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665506611991_731863_1061" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if inputParameter(i) = null then null
+else
+    let featureValue : Sequence(FeatureValue) = inputParameter(i).
+        ownedMembership->select(oclIsKindOf(FeatureValue)) in
+    if featureValue->isEmpty() then null
+    else featureValue->at(1).value
+    endif
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665506122994_174439_1055" name="i" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665506123018_162642_1056" name="" visibility="public" direction="return">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665506123027_422230_1057" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665506123035_467643_1058" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1675037362718_895109_172" name="isSubactionUsage" visibility="public" bodyCondition="_19_0_4_12e503d9_1675037623200_134722_192">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675037396166_999635_174" annotatedElement="_19_0_4_12e503d9_1675037362718_895109_172">
+            <body>&lt;p>Check if this &lt;code>ActionUsage&lt;/code> is composite and has an &lt;code>owningType&lt;/code> that is an &lt;code>ActionDefinition&lt;/code> or &lt;code>ActionUsage&lt;/code> but is &lt;em>not&lt;/em> the &lt;code>entryAction&lt;/code> or &lt;code>exitAction&lt;/em>&lt;/code> of a &lt;code>StateDefinition&lt;/code> or &lt;code>StateUsage&lt;/code>. If so, then it represents an &lt;code>&lt;em>Action&lt;/em>&lt;/code> that is a &lt;code>&lt;em>subaction&lt;/em>&lt;/code> of another &lt;code>&lt;em>Action&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1675037623200_134722_192" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675037623215_161270_193" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(ActionDefinition) or
+ owningType.oclIsKindOf(ActionUsage)) and
+(owningFeatureMembership.oclIsKindOf(StateSubactionMembership) implies
+ owningFeatureMembership.oclAsType(StateSubactionMembership).kind = 
+    StateSubactionKind::do)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1675037431660_703714_176" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565500809065_340396_30687" name="A_action_featuringActionDefinition" visibility="public" memberEnd="_18_5_3_12e503d9_1565500809065_170841_30688 _18_5_3_12e503d9_1565500809066_425637_30689">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565500809066_425637_30689" name="featuringActionDefinition" visibility="public" type="_18_5_3_12e503d9_1565500542970_17430_30342" isDerived="true" association="_18_5_3_12e503d9_1565500809065_340396_30687">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313448223_152231_674" annotatedElement="_18_5_3_12e503d9_1565500809066_425637_30689">
+            <body>&lt;p>The Activities that feature a certain ActionUsage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565500899408_628752_30764" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565500899408_83113_30765" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_b9102da_1536346067213_746991_17344"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_18876_27787"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565503118756_203952_33551" name="DecisionNode" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567743569037_273592_18169" annotatedElement="_18_5_3_12e503d9_1565503118756_203952_33551">
+          <body>&lt;p>A &lt;code>DecisionNode&lt;/code> is a &lt;code>ControlNode&lt;/code> that makes a selection from its outgoing &lt;code>Successions&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597202494048_706773_73718" name="validateDecisionNodeIncomingSuccessions" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503118756_203952_33551">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1597202527417_631959_73720" annotatedElement="_19_0_4_12e503d9_1597202494048_706773_73718">
+            <body>&lt;p>A &lt;code>DecisionNode&lt;/code> may have at most one incoming &lt;code>Succession&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597202494048_472159_73719" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>targetConnector->selectByKind(Succession)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673306045348_851737_1029" name="validateDecisionNodeOutgoingSuccessions" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503118756_203952_33551">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673306633329_5057_1037" annotatedElement="_19_0_4_12e503d9_1673306045348_851737_1029">
+            <body>&lt;p>All outgoing &lt;code>Successions&lt;/code> from a &lt;code>DecisionNode&lt;/code> must have a target &lt;code>multiplicity&lt;/code> of &lt;code>0..1&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673306045366_245447_1030" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>sourceConnector->selectAsKind(Succession)->
+    collect(connectorEnd->at(2))->
+    forAll(targetMult |
+        multiplicityHasBounds(targetMult, 0, 1))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673305614481_766160_1023" name="checkDecisionNodeSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503118756_203952_33551">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673305642646_403041_1025" annotatedElement="_19_0_4_12e503d9_1673305614481_766160_1023">
+            <body>&lt;p>A &lt;code>DecisionNode&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::decisions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673305614485_673403_1024" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::Action::decisions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673306234843_386043_1031" name="checkDecisionNodeOutgoingSuccessionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503118756_203952_33551">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673306320887_787440_1033" annotatedElement="_19_0_4_12e503d9_1673306234843_386043_1031">
+            <body>&lt;p>All outgoing &lt;code>Successions&lt;/code> from a &lt;code>DecisionNode&lt;/code> must subset the inherited &lt;em>&lt;code>outgoingHBLink&lt;/code>&lt;/em> &lt;code>feature&lt;/code> of the &lt;code>DecisionNode&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673306234864_511244_1032" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>sourceConnector->selectByKind(Succession)->
+    forAll(subsetsChain(self, 
+        resolveGlobal('ControlPerformances::DecisionPerformance::outgoingHBLink')))</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565503202954_930464_33696" general="_19_0_2_12e503d9_1567281323333_776611_544"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565503106899_225416_33510" name="MergeNode" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567743227213_664109_18168" annotatedElement="_18_5_3_12e503d9_1565503106899_225416_33510">
+          <body>&lt;p>A &lt;code>MergeNode&lt;/code> is a &lt;code>ControlNode&lt;/code> that asserts the merging of its incoming &lt;code>Successions&lt;/code>. A &lt;code>MergeNode&lt;/code> may have at most one outgoing &lt;code>Successions&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597202427538_667936_73715" name="validateMergeNodeOutgoingSuccessions" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503106899_225416_33510">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1597202476002_598858_73717" annotatedElement="_19_0_4_12e503d9_1597202427538_667936_73715">
+            <body>&lt;p>A &lt;code>MergeNode&lt;/code> may have at most one outgoing &lt;code>Succession&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597202427538_768212_73716" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>sourceConnector->selectAsKind(Succession)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673305845418_936784_1026" name="validateMergeNodeIncomingSuccessions" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503106899_225416_33510">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673305960447_728732_1028" annotatedElement="_19_0_4_12e503d9_1673305845418_936784_1026">
+            <body>&lt;p>All incoming &lt;code>Successions&lt;/code> to a &lt;code>MergeNode&lt;/code> must have a source &lt;code>multiplicity&lt;/code> of &lt;code>0..1&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673305845433_5199_1027" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>targetConnector->selectByKind(Succession)->
+    collect(connectorEnd->at(1))->
+    forAll(sourceMult |
+        multiplicityHasBounds(sourceMult, 0, 1))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673306467994_78411_1034" name="checkMergeNodeIncomingSuccessionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503106899_225416_33510">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673306581711_116397_1036" annotatedElement="_19_0_4_12e503d9_1673306467994_78411_1034">
+            <body>&lt;p>All incoming &lt;code>Successions&lt;/code> to a &lt;code>MergeNode&lt;/code> must subset the inherited &lt;em>&lt;code>incomingHBLink&lt;/code>&lt;/em> &lt;code>feature&lt;/code> of the &lt;code>MergeNode&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673306468008_712215_1035" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>targetConnector->selectByKind(Succession)->
+    forAll(subsetsChain(self, 
+        resolveGlobal('ControlPerformances::MergePerformance::incomingHBLink')))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673305433893_766026_1018" name="checkMergeNodeSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565503106899_225416_33510">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673305528378_250838_1020" annotatedElement="_19_0_4_12e503d9_1673305433893_766026_1018">
+            <body>&lt;p>A &lt;code>MergeNode&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::merges&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673305433914_997573_1019" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::Action::merges')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565503199240_377600_33687" general="_19_0_2_12e503d9_1567281323333_776611_544"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565500905803_760605_30778" name="A_actionDefinition_definedAction" visibility="public" memberEnd="_18_5_3_12e503d9_1565500905804_589845_30779 _18_5_3_12e503d9_1565500905804_571076_30780">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565500905804_571076_30780" name="definedAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_18_5_3_12e503d9_1565500905803_760605_30778">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586298053348_97525_460" annotatedElement="_18_5_3_12e503d9_1565500905804_571076_30780">
+            <body>&lt;p>The ActionUsages being typed by a certain Behavior.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565501113910_14118_30982" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565501113910_995623_30983" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_b9102da_1536346315176_644912_17389"/>
+          <subsettedProperty href="#_19_0_4_12e503d9_1618943843466_481041_237"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565500542970_17430_30342" name="ActionDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567722816897_823612_17995" annotatedElement="_18_5_3_12e503d9_1565500542970_17430_30342">
+          <body>&lt;p>An &lt;code>ActionDefinition&lt;/code> is a &lt;code>Definition&lt;/code> that is also a &lt;code>Behavior&lt;/code> that defines an &lt;em>&lt;code>Action&lt;/code>&lt;/em> performed by a system or part of a system.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673062273106_764204_653" name="checkActionDefinitionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565500542970_17430_30342">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673062378271_49931_655" annotatedElement="_19_0_4_12e503d9_1673062273106_764204_653">
+            <body>&lt;p>An &lt;code>ActionDefinition&lt;/code> must directly or indirectly specialize the &lt;code>ActionDefinition&lt;/code> &lt;em>&lt;code>Actions::Action&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673062273123_806051_654" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::Action')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673062945244_713818_672" name="deriveActionDefinitionAction" visibility="public" constrainedElement="_18_5_3_12e503d9_1565500542970_17430_30342">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673063114198_591620_674" annotatedElement="_19_0_4_12e503d9_1673062945244_713818_672">
+            <body>&lt;p> The &lt;code>actions&lt;/code> of a &lt;code>ActionDefinition&lt;/code> are those of its &lt;code>usages&lt;/code> that are &lt;code>ActionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673062945267_118324_673" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>action = usage->selectByKind(ActionUsage)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565500563701_399866_30393">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651709_376789_42207"/>
+        </generalization>
+        <generalization xmi:id="_18_5_3_12e503d9_1565500559093_873243_30384" general="_19_0_4_12e503d9_1618943693347_790503_111"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565500809065_170841_30688" name="action" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isOrdered="true" isDerived="true" association="_18_5_3_12e503d9_1565500809065_340396_30687">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586294058097_693105_336" annotatedElement="_18_5_3_12e503d9_1565500809065_170841_30688">
+            <body>&lt;p>The &lt;code>ActionUsages&lt;/code> that are &lt;code>steps&lt;/code> in this &lt;code>ActionDefinition&lt;/code>, which define the actions that specify the behavior of the &lt;code>ActionDefinition&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565500825306_927883_30730" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565500825306_927821_30731" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_b9102da_1536346067212_587255_17343"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_48981_27786"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1612814399420_305432_142" name="A_payloadArgument_sendingActionUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1612814399422_336683_143 _19_0_4_12e503d9_1612814399422_295795_144">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1612814399422_295795_144" name="sendingActionUsage" visibility="public" type="_18_5_3_12e503d9_1565505727349_597544_34143" isDerived="true" association="_19_0_4_12e503d9_1612814399420_305432_142">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1612841115851_522270_35" annotatedElement="_19_0_4_12e503d9_1612814399422_295795_144">
+            <body>&lt;p>The &lt;code>SendActionUsage&lt;/code> that has a certain &lt;code>Expression&lt;/code> as its &lt;code>itemsArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1612814569029_336527_153" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1612814569044_68780_154" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1612814670554_450768_167" name="A_receiverArgument_acceptActionUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1612814670555_311543_168 _19_0_4_12e503d9_1612814670556_230916_169">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1612814670556_230916_169" name="acceptActionUsage" visibility="public" type="_18_5_3_12e503d9_1565503089035_106795_33475" isDerived="true" association="_19_0_4_12e503d9_1612814670554_450768_167">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1612841086589_380322_34" annotatedElement="_19_0_4_12e503d9_1612814670556_230916_169">
+            <body>&lt;p>The AcceptActionUsage that has a certain Expression as its &lt;code>receiverArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1612814751151_892860_187" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1612814751151_766948_188" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624202269069_287735_3108" name="A_referent_assignment" visibility="public" memberEnd="_19_0_4_12e503d9_1624202269076_561550_3109 _19_0_4_12e503d9_1624202269076_664022_3110">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624202269076_664022_3110" name="assignment" visibility="public" type="_19_0_4_12e503d9_1624201606942_142574_2658" isDerived="true" association="_19_0_4_12e503d9_1624202269069_287735_3108">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624297424979_693874_4343" annotatedElement="_19_0_4_12e503d9_1624202269076_664022_3110">
+            <body>&lt;p>The AssignmentActionUsages that gave a certain &lt;code>referent&lt;/code> Expression.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624202580672_216117_3225" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624202580673_590540_3226" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674980_717955_43271"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624306920911_401496_5768" name="A_seqArgument_forLoopAction" visibility="public" memberEnd="_19_0_4_12e503d9_1624306920911_355291_5769 _19_0_4_12e503d9_1624306920912_657771_5770">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624306920912_657771_5770" name="forLoopAction" visibility="public" type="_19_0_4_12e503d9_1624306893649_489444_5711" isDerived="true" association="_19_0_4_12e503d9_1624306920911_401496_5768">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624307455457_371517_5900" annotatedElement="_19_0_4_12e503d9_1624306920912_657771_5770">
+            <body>&lt;p>The &lt;code>ForLoopActionUsage&lt;/code> that has a certain &lt;code>Expression&lt;/code> as its &lt;code>seqArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624307023325_526560_5887" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624307023325_478232_5888" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624203546797_456808_3484" name="IfActionUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624290881739_271415_4309" annotatedElement="_19_0_4_12e503d9_1624203546797_456808_3484">
+          <body>&lt;p>An &lt;code>IfActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that specifies that the &lt;code>thenAction&lt;/code> &lt;code>ActionUsage&lt;/code> should be performed if the result of the &lt;code>ifArgument&lt;/code> &lt;code>Expression&lt;/code> is true. It may also optionally specify an &lt;code>elseAction&lt;/code> &lt;code>ActionUsage&lt;/code> that is performed if the result of the &lt;code>ifArgument&lt;/code> is false.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675030948127_754090_153" name="deriveIfActionUsageThenAction" visibility="public" constrainedElement="_19_0_4_12e503d9_1624203546797_456808_3484">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675030991339_417582_155" annotatedElement="_19_0_4_12e503d9_1675030948127_754090_153">
+            <body>&lt;p>The &lt;code>thenAction&lt;/code> of an &lt;code>ifActionUsage&lt;/code> is its second &lt;code>parameter&lt;/code>, which must be an &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675030948140_536184_154" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>thenAction = 
+    let parameter : Feature = inputParameter(2) in
+    if parameter &lt;> null and parameter.oclIsKindOf(ActionUsage) then
+        parameter.oclAsType(ActionUsage)
+    else
+        null
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675037281081_628641_170" name="checkIfActionUsageSubactionSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624203546797_456808_3484">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675037744320_251691_206" annotatedElement="_19_0_4_12e503d9_1675037281081_628641_170">
+            <body>&lt;p>A composite &lt;code>IfActionUsage&lt;/code> that is a subaction usage must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::ifSubactions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675037281090_664201_171" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSubactionUsage() implies
+    specializesFromLibrary('Actions::Action::ifSubactions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675037024961_158897_167" name="checkIfActionUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624203546797_456808_3484">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675037265823_739951_169" annotatedElement="_19_0_4_12e503d9_1675037024961_158897_167">
+            <body>&lt;p>A &lt;code>IfActionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::ifThenActions&lt;/code>&lt;/em> from the Systems Model Library. If it has an &lt;code>elseAction&lt;/code>, then it must directly or indirectly specialize &lt;em>&lt;code>Actions::ifThenElseActions&lt;/code>&lt;/em>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675037024989_731883_168" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if elseAction = null then
+    specializesFromLibrary('Actions::ifThenActions')
+else
+    specializesFromLibrary('Actions::ifThenElseActions')
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675031016576_286415_158" name="deriveIfActionUsageIfArgument" visibility="public" constrainedElement="_19_0_4_12e503d9_1624203546797_456808_3484">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675031091700_295019_162" annotatedElement="_19_0_4_12e503d9_1675031016576_286415_158">
+            <body>&lt;p>The &lt;code>ifArgument&lt;/code> of an &lt;code>ifActionUsage&lt;/code> is its first &lt;code>parameter&lt;/code>, which must be an &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675031016585_707474_159" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ifArgument = 
+    let parameter : Feature = inputParameter(1) in
+    if parameter &lt;> null and parameter.oclIsKindOf(Expression) then
+        parameter.oclAsType(Expression)
+    else
+        null
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675030370795_804977_148" name="deriveIfActionUsageElseAction" visibility="public" constrainedElement="_19_0_4_12e503d9_1624203546797_456808_3484">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675030782500_602108_152" annotatedElement="_19_0_4_12e503d9_1675030370795_804977_148">
+            <body>&lt;p>The &lt;code>elseAction&lt;/code> of an &lt;code>ifActionUsage&lt;/code> is its third &lt;code>parameter&lt;/code>, if there is one, which must then be an &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675030370824_38021_149" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>elseAction = 
+    let parameter : Feature = inputParameter(3) in
+    if parameter &lt;> null and parameter.oclIsKindOf(ActionUsage) then
+        parameter.oclAsType(ActionUsage)
+    else
+        null
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698944398159_398840_92" name="validateIfActionUsageParameters" visibility="public" constrainedElement="_19_0_4_12e503d9_1624203546797_456808_3484">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698944475252_852755_94" annotatedElement="_19_0_4_12e503d9_1698944398159_398840_92">
+            <body>&lt;p>An &lt;code>IfActionUsage&lt;/code> must have at least two owned &lt;code>input&lt;/code> &lt;code>parameters&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698944398177_440705_93" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>inputParameters()->size() >= 2</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1624203652488_895962_3579" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624203816178_273125_3723" name="elseAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_4_12e503d9_1624203816178_439626_3722">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624292780024_578674_4319" annotatedElement="_19_0_4_12e503d9_1624203816178_273125_3723">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> that is to be performed if the result of the &lt;code>ifArgument&lt;/code> is false. It is the (optional) third &lt;code>parameter&lt;/code> of the &lt;code>IfActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624204573234_233070_4073" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624204573235_961248_4074" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624203835062_413118_3748" name="thenAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_4_12e503d9_1624203835062_684597_3747">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624292731963_509077_4318" annotatedElement="_19_0_4_12e503d9_1624203835062_413118_3748">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> that is to be performed if the result of the &lt;code>ifArgument&lt;/code> is true. It is the second &lt;code>parameter&lt;code> of the &lt;code>IfActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624204580078_990505_4077" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624204580078_405183_4078" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624203866872_328861_3821" name="ifArgument" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1624203866872_75806_3820">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624292387410_757773_4316" annotatedElement="_19_0_4_12e503d9_1624203866872_328861_3821">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> whose result determines whether the &lt;code>thenAction&lt;/code> or (optionally) the &lt;code>elseAction&lt;/code> is performed. It is the first &lt;code>parameter&lt;code> of the &lt;code>IfActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624204288519_925469_3975" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624204288519_592521_3976" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624201786353_90013_2834" name="A_targetArgument_assignmentAction" visibility="public" memberEnd="_19_0_4_12e503d9_1624201786354_844501_2835 _19_0_4_12e503d9_1624201786354_432_2836">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624201786354_432_2836" name="assignmentAction" visibility="public" type="_19_0_4_12e503d9_1624201606942_142574_2658" isDerived="true" association="_19_0_4_12e503d9_1624201786353_90013_2834">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624297391621_547555_4341" annotatedElement="_19_0_4_12e503d9_1624201786354_432_2836">
+            <body>&lt;p>The AssignmentActionUsage that has a certain Expression as its &lt;code>targetArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624201994948_496642_2956" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624201994948_173334_2957" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624290717707_879119_4194" name="A_untilArgument_untilLoopAction" visibility="public" memberEnd="_19_0_4_12e503d9_1624290717721_449719_4195 _19_0_4_12e503d9_1624290717726_441312_4196">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624290717726_441312_4196" name="untilLoopAction" visibility="public" type="_19_0_4_12e503d9_1624306821108_998562_5594" isDerived="true" association="_19_0_4_12e503d9_1624290717707_879119_4194">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624293777868_97548_4328" annotatedElement="_19_0_4_12e503d9_1624290717726_441312_4196">
+            <body>&lt;p>The &lt;code>WhileLoopActionUsage&lt;/code> that has a certain &lt;code>Expression&lt;/code> as its &lt;code>untilArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624290777047_252865_4257" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624290777048_274756_4258" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624203871924_992943_3841" name="A_whileArgument_whileLoopAction" visibility="public" memberEnd="_19_0_4_12e503d9_1624203871924_371126_3842 _19_0_4_12e503d9_1624203871924_754644_3843">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624203871924_754644_3843" name="whileLoopAction" visibility="public" type="_19_0_4_12e503d9_1624306821108_998562_5594" isDerived="true" association="_19_0_4_12e503d9_1624203871924_992943_3841">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624293771096_261446_4327" annotatedElement="_19_0_4_12e503d9_1624203871924_754644_3843">
+            <body>&lt;p>The &lt;code>WhileLoopActionUsage&lt;/code> that has a certain &lt;code>Expression&lt;/code> as its &lt;code>whileArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624204404003_513265_4011" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624204404003_399932_4012" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624203902575_637089_3868" name="A_bodyAction_loopAction" visibility="public" memberEnd="_19_0_4_12e503d9_1624203902575_509097_3869 _19_0_4_12e503d9_1624203902576_714809_3870">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624203902576_714809_3870" name="loopAction" visibility="public" type="_19_0_4_12e503d9_1624203585458_610400_3524" isDerived="true" association="_19_0_4_12e503d9_1624203902575_637089_3868">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624293758631_841377_4326" annotatedElement="_19_0_4_12e503d9_1624203902576_714809_3870">
+            <body>&lt;p>The &lt;code>LoopActionUsage&lt;/code> that has a certain &lt;code>ActionUsage&lt;/code> as its &lt;code>bodyAction&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624204466319_533004_4047" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624204466320_569853_4048" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624203816178_439626_3722" name="A_elseAction_ifElseAction" visibility="public" memberEnd="_19_0_4_12e503d9_1624203816178_273125_3723 _19_0_4_12e503d9_1624203816179_272530_3724">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624203816179_272530_3724" name="ifElseAction" visibility="public" type="_19_0_4_12e503d9_1624203546797_456808_3484" isDerived="true" association="_19_0_4_12e503d9_1624203816178_439626_3722">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624293725633_32639_4324" annotatedElement="_19_0_4_12e503d9_1624203816179_272530_3724">
+            <body>&lt;p>The IfActionUsage that has a certain ActionUsage as its &lt;code>elseAction&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624204616114_582722_4089" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624204616115_496859_4090" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624203866872_75806_3820" name="A_ifArgument_ifAction" visibility="public" memberEnd="_19_0_4_12e503d9_1624203866872_328861_3821 _19_0_4_12e503d9_1624203866873_323741_3822">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624203866873_323741_3822" name="ifAction" visibility="public" type="_19_0_4_12e503d9_1624203546797_456808_3484" isDerived="true" association="_19_0_4_12e503d9_1624203866872_75806_3820">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624292687946_988505_4317" annotatedElement="_19_0_4_12e503d9_1624203866873_323741_3822">
+            <body>&lt;p>The &lt;code>IfActionUsage&lt;/code> that has a certain &lt;code>Expression&lt;/code> as its &lt;code>ifArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624204377384_313742_3999" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624204377384_388617_4000" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624203835062_684597_3747" name="A_thenAction_ifThenAction" visibility="public" memberEnd="_19_0_4_12e503d9_1624203835062_413118_3748 _19_0_4_12e503d9_1624203835062_454803_3749">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624203835062_454803_3749" name="ifThenAction" visibility="public" type="_19_0_4_12e503d9_1624203546797_456808_3484" isDerived="true" association="_19_0_4_12e503d9_1624203835062_684597_3747">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624293732032_829528_4325" annotatedElement="_19_0_4_12e503d9_1624203835062_454803_3749">
+            <body>&lt;p>The &lt;code>IfActionUsage&lt;/code> that has a certain &lt;code>ActionUsage&lt;/code> as its &lt;code>thenAction&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624204633680_253786_4101" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624204633681_461361_4102" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624203585458_610400_3524" name="LoopActionUsage" visibility="public" isAbstract="true">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624292838545_690371_4320" annotatedElement="_19_0_4_12e503d9_1624203585458_610400_3524">
+          <body>&lt;p>A &lt;code>LoopActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that specifies that its &lt;code>bodyAction&lt;/code> should be performed repeatedly. Its subclasses &lt;code>WhileLoopActionUsage&lt;/code> and &lt;code>ForLoopActionUsage&lt;/code> provide different ways to determine how many times the &lt;code>bodyAction&lt;/code> should be performed.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675126265750_355313_337" name="deriveLoopActionUsageBodyAction" visibility="public" constrainedElement="_19_0_4_12e503d9_1624203585458_610400_3524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675126265755_238537_344" annotatedElement="_19_0_4_12e503d9_1675126265750_355313_337">
+            <body>&lt;p>The &lt;code>bodyAction&lt;/code> of a &lt;code>LoopActionUsage&lt;/code> is its second input &lt;code>parameter&lt;/code>, which must be an &lt;code>Action&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675126265755_544785_343" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>bodyAction =
+    let parameter : Feature = inputParameter(2) in
+    if parameter &lt;> null and parameter.oclIsKindOf(Action) then
+        parameter.oclAsType(Action)
+    else
+        null
+    endif
+</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1624203656580_414092_3588" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624203902575_509097_3869" name="bodyAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_4_12e503d9_1624203902575_637089_3868">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624293692344_307653_4323" annotatedElement="_19_0_4_12e503d9_1624203902575_509097_3869">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> to be performed repeatedly by the &lt;code>LoopActionUsage&lt;/code>. It is the second &lt;code>parameter&lt;/code> of the &lt;code>LoopActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624204448830_609245_4029" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624204448830_874622_4030" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624201792995_378713_2855" name="A_valueExpression_assigningAction" visibility="public" memberEnd="_19_0_4_12e503d9_1624201792996_104394_2856 _19_0_4_12e503d9_1624201792997_24851_2857">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624201792997_24851_2857" name="assigningAction" visibility="public" type="_19_0_4_12e503d9_1624201606942_142574_2658" isDerived="true" association="_19_0_4_12e503d9_1624201792995_378713_2855">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624297405281_383384_4342" annotatedElement="_19_0_4_12e503d9_1624201792997_24851_2857">
+            <body>&lt;p>The AssignmentActionUsage that has a certain Expression as its &lt;code>valueArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624202015834_932237_2968" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624202015834_425605_2969" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624306893649_489444_5711" name="ForLoopActionUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624307348269_617325_5896" annotatedElement="_19_0_4_12e503d9_1624306893649_489444_5711">
+          <body>&lt;p>A &lt;code>ForLoopActionUsage&lt;/code> is a &lt;code>LoopActionUsage&lt;/code> that specifies that its &lt;code>bodyAction&lt;/code> &lt;code>ActionUsage&lt;/code> should be performed once for each value, in order, from the sequence of values obtained as the result of the &lt;code>seqArgument&lt;/code> &lt;code>Expression&lt;/code>, with the &lt;code>loopVariable&lt;/code> set to the value for each iteration.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675126265751_562447_339" name="deriveForLoopActionUsageSeqArgument" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306893649_489444_5711">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675126265756_860054_348" annotatedElement="_19_0_4_12e503d9_1675126265751_562447_339">
+            <body>&lt;p>The &lt;code>seqArgument&lt;/code> of a &lt;code>ForLoopActionUsage&lt;/code> is its first argument &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675126265756_316707_347" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>seqArgument = argument(1)
+</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675126265749_30190_336" name="checkForLoopActionUsageSubactionSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306893649_489444_5711">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675126513060_874240_350" annotatedElement="_19_0_4_12e503d9_1675126265749_30190_336">
+            <body>&lt;p>A composite &lt;code>ForLoopActionUsage&lt;/code> that is a subaction usage must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::forLoops&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675126265755_733349_342" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSubactionUsage() implies
+    specializesFromLibrary('Actions::Action::forLoops')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675128894763_638292_393" name="checkForLoopActionUsageVarRedefinition" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306893649_489444_5711">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675129133468_866380_395" annotatedElement="_19_0_4_12e503d9_1675128894763_638292_393">
+            <body>&lt;p>The &lt;code>loopVariable&lt;/code> of a &lt;code>ForLoopActionUsage&lt;/code> must redefine the &lt;code>ActionUsage&lt;/code> &lt;code>&lt;em>Actions::ForLoopAction::var&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675128894775_492614_394" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>loopVariable &lt;> null and
+loopVariable.redefinesFromLibrary('Actions::ForLoopAction::var')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675126265718_212654_335" name="checkForLoopActionUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306893649_489444_5711">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675126265754_87667_341" annotatedElement="_19_0_4_12e503d9_1675126265718_212654_335">
+            <body>&lt;p>A &lt;code>ForLoopActionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::forLoopActions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675126265751_727332_340" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::forLoopActions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675129251077_235821_404" name="deriveForLoopActionUsageLoopVariable" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306893649_489444_5711">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675129465881_203684_406" annotatedElement="_19_0_4_12e503d9_1675129251077_235821_404">
+            <body>&lt;p>The &lt;code>loopVariable&lt;/code> of a &lt;code>ForLoopActionUsage&lt;/code> is its first &lt;code>ownedFeature&lt;/code>, which must be a &lt;code>ReferenceUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675129251093_713129_405" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>loopVariable =
+    if ownedFeature->isEmpty() or 
+        not ownedFeature->first().oclIsKindOf(ReferenceUsage) then 
+        null
+    else 
+        ownedFeature->first().oclAsType(ReferenceUsage)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698944203755_982948_86" name="validateForLoopActionUsageLoopVariable" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306893649_489444_5711">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698944277383_375978_88" annotatedElement="_19_0_4_12e503d9_1698944203755_982948_86">
+            <body>&lt;p>The first &lt;code>ownedFeature&lt;/code> of a &lt;code>ForLoopActionUsage&lt;/code> must be a &lt;code>ReferenceUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698944203776_94941_87" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedFeature->notEmpty() and
+ownedFeature->at(1).oclIsKindOf(ReferenceUsage)
+</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698944289278_586430_89" name="validateForLoopActionUsageParameters" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306893649_489444_5711">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698944350354_720813_91" annotatedElement="_19_0_4_12e503d9_1698944289278_586430_89">
+            <body>&lt;p>A &lt;code>ForLoopActionUsage&lt;/code> must have two owned &lt;code>input&lt;/code> &lt;code>parameters&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698944289301_456683_90" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>inputParameters()->size() = 2</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1624306940982_154982_5809" general="_19_0_4_12e503d9_1624203585458_610400_3524"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624306920911_355291_5769" name="seqArgument" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1624306920911_401496_5768">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624307430362_255754_5897" annotatedElement="_19_0_4_12e503d9_1624306920911_355291_5769">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> whose result provides the sequence of values to which the &lt;code>loopVariable&lt;/code> is set for each iterative performance of the &lt;code>bodyAction&lt;/code>. It is the &lt;code>Expression&lt;/code> whose &lt;code>result&lt;/code> is bound to the &lt;em>&lt;code>seq&lt;/code>&lt;/em> &lt;code>input&lt;/code> &lt;code>parameter&lt;/code> of this &lt;code>ForLoopActionUsage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624306936310_482199_5799" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624306936310_199051_5800" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1640325378400_227367_3662" name="loopVariable" visibility="public" type="_19_0_2_12e503d9_1591477377905_618531_857" isDerived="true" association="_19_0_4_12e503d9_1640325378394_421584_3661">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1640325624701_690255_3682" annotatedElement="_19_0_4_12e503d9_1640325378400_227367_3662">
+            <body>&lt;p>The &lt;code>ownedFeature&lt;/code> of this &lt;co>ForLoopActionUsage&lt;/code> that acts as the loop variable, which is assigned the successive values of the input sequence on each iteration. It is the &lt;code>ownedFeature&lt;/code> that redefines &lt;em>&lt;code>ForLoopAction::var&lt;/code>&lt;/em>.&lt;/p> </body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1640325405652_552591_3672" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1640325405661_270441_3673" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624201606942_142574_2658" name="AssignmentActionUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624294869276_615967_4337" annotatedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <body>&lt;p>An &lt;code>AssignmentActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that is defined, directly or indirectly, by the &lt;code>ActionDefinition&lt;/code> &lt;em>&lt;code>AssignmentAction&lt;/code>&lt;/em> from the Systems Model Library. It specifies that the value of the &lt;code>referent&lt;/code> &lt;code>Feature&lt;/code>, relative to the target given by the result of the &lt;code>targetArgument&lt;/code> &lt;code>Expression&lt;/code>, should be set to the result of the &lt;code>valueExpression&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674957873052_177415_25" name="checkAssignmentActionUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674958092595_403764_27" annotatedElement="_19_0_4_12e503d9_1674957873052_177415_25">
+            <body>&lt;p>An &lt;code>AssignmentActionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::assignmentActions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674957873063_368304_26" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::assignmentActions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674958852288_641547_35" name="checkAssignmentActionUsageStartingAtRedefinition" visibility="public" constrainedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674959356606_372051_47" annotatedElement="_19_0_4_12e503d9_1674958852288_641547_35">
+            <body>&lt;p>The first &lt;code>ownedFeature&lt;/code> of the first &lt;code>parameter&lt;/code> of an &lt;code>AssignmentActionUsage&lt;/code> must redefine &lt;code>&lt;em>AssignmentAction::target::startingAt&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674958852299_435385_36" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let targetParameter : Feature = inputParameter(1) in
+targetParameter &lt;> null and
+targetParameter.ownedFeature->notEmpty() and
+targetParameter.ownedFeature->first().
+    redefinesFromLibrary('AssignmentAction::target::startingAt')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674956037538_57931_13" name="deriveAssignmentActionUsageValueExpression" visibility="public" constrainedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674956467122_209314_15" annotatedElement="_19_0_4_12e503d9_1674956037538_57931_13">
+            <body>&lt;p>The &lt;code>valueExpression&lt;/code> of a &lt;code>AssignmentActionUsage&lt;/code> is its second argument &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674956037545_326795_14" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>valueExpression = argument(2)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674955888438_441029_8" name="deriveAssignmentUsageTargetArgument" visibility="public" constrainedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674955984354_387733_10" annotatedElement="_19_0_4_12e503d9_1674955888438_441029_8">
+            <body>&lt;p>The &lt;code>targetArgument&lt;/code> of a &lt;code>AssignmentActionUsage&lt;/code> is its first argument &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674955888458_261909_9" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>targetArgument = argument(1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674958125016_342870_28" name="checkAssignmentActionUsageSubactionSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674958169459_25250_30" annotatedElement="_19_0_4_12e503d9_1674958125016_342870_28">
+            <body>&lt;p>A composite &lt;code>AssignmentActionUsage&lt;/code> that is a subaction usage must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::assignments&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674958125023_738654_29" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSubactionUsage() implies
+    specializesFromLibrary('Actions::Action::assignments')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674959097686_963884_41" name="checkAssignmentActionUsageAccessedFeatureRedefinition" visibility="public" constrainedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674959394307_360194_48" annotatedElement="_19_0_4_12e503d9_1674959097686_963884_41">
+            <body>&lt;p>The first &lt;code>ownedFeature&lt;/code> of the first &lt;code>ownedFeature&lt;/code> of the first &lt;code>parameter&lt;/code> of an &lt;code>AssignmentActionUsage&lt;/code> must redefine &lt;code>&lt;em>AssignmentAction::target::startingAt::accessedFeature&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674959097725_519041_42" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let targetParameter : Feature = inputParameter(1) in
+targetParameter &lt;> null and
+targetParameter.ownedFeature->notEmpty() and
+targetParameter.ownedFeature->first().ownedFeature->notEmpty() and
+targetParameter.ownedFeature->first().ownedFeature->first().
+    redefinesFromLibrary('AssigmentAction::target::startingAt::accessedFeature')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674958281465_694660_31" name="checkAssignmentActionUsageReferentRedefinition" visibility="public" constrainedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674959429903_596074_49" annotatedElement="_19_0_4_12e503d9_1674958281465_694660_31">
+            <body>&lt;p>The first &lt;code>ownedFeature&lt;/code> of the first &lt;code>ownedFeature&lt;/code> of the first &lt;code>parameter&lt;/code> of an &lt;code>AssignmentActionUsage&lt;/code> must redefine the &lt;code>referent&lt;/code> of the &lt;code>AssignmentActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674958281473_917704_32" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let targetParameter : Feature = inputParameter(1) in
+targetParameter &lt;> null and
+targetParameter.ownedFeature->notEmpty() and
+targetParameter.ownedFeature->first().ownedFeature->notEmpty() and
+targetParameter.ownedFeature->first().ownedFeature->first().redefines(referent)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1674956645906_875721_16" name="deriveAssignmentActionUsageReferent" visibility="public" constrainedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1674956853123_86185_18" annotatedElement="_19_0_4_12e503d9_1674956645906_875721_16">
+            <body>&lt;p>The &lt;code>referent&lt;/code> of an &lt;code>AssignmentActionUsage&lt;/code> is the first &lt;code>Feature&lt;/code> that is not a &lt;code>MetadataFeature&lt;/code> and is the &lt;code>memberElement&lt;/code> of a &lt;code>ownedMembership&lt;/code> that is not a &lt;code>FeatureMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1674956645926_259295_17" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referent =
+    let unownedFeatures : Sequence(Feature) = ownedMembership->
+        reject(oclIsKindOf(FeatureMembership)).memberElement->
+        select(oclIsKindOf(Feature) and 
+               not oclIsKindOf(MetadataFeature)) in
+    if unownedFeatures->isEmpty() then null
+    else unownedFeatures->first().oclAsType(Feature)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698944029755_995232_83" name="validateAssignmentActionUsageReferent" visibility="public" constrainedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698944175082_821403_85" annotatedElement="_19_0_4_12e503d9_1698944029755_995232_83">
+            <body>&lt;p>An &lt;code>AssignmentActionUsage&lt;/code> must have an &lt;code>ownedMembership&lt;/code> that is not an &lt;code>OwningMembership&lt;/code> and whose &lt;code>memberElement&lt;/code> is a &lt;code>Feature&lt;/code> but not a &lt;code>MetadataFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698944029774_397778_84" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMembership->exists(
+    not oclIsKindOf(OwningMembership) and 
+    memberElement.oclIsKindOf(Feature) and
+    not memberElement.oclIsKindOf(MetadataFeature))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740254369948_698349_128" name="validateAssignmentActionUsageReferentIsTimeVarying" visibility="public" constrainedElement="_19_0_4_12e503d9_1624201606942_142574_2658">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740254406455_976589_130" annotatedElement="_2022x_2_12e503d9_1740254369948_698349_128">
+            <body>&lt;p>The &lt;code>featureTarget&lt;/code> of the &lt;code>referent&lt;/code> of an &lt;code>AssignmentActionUsage&lt;/code> must be able to have time-varying values.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740254369950_249303_129" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referent &lt;> null implies referent.featureTarget.isVariable</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1624201660640_940970_2773" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624201786354_844501_2835" name="targetArgument" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1624201786353_90013_2834">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624297349511_862616_4340" annotatedElement="_19_0_4_12e503d9_1624201786354_844501_2835">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> whose value is an occurrence in the domain of the &lt;code>referent&lt;/code> &lt;code>Feature&lt;/code>, for which the value of the &lt;code>referent&lt;/code> will be set to the result of the &lt;code>valueExpression&lt;/code> by this &lt;code>AssignmentActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624201891233_908931_2898" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624201891236_364328_2899" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624201792996_104394_2856" name="valueExpression" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1624201792995_378713_2855">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624297237330_330834_4338" annotatedElement="_19_0_4_12e503d9_1624201792996_104394_2856">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> whose result is to be assigned to the &lt;code>referent&lt;/code> &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624201939953_264659_2920" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624201939954_520414_2921" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624202269076_561550_3109" name="referent" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1624202269069_287735_3108">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624297252246_203014_4339" annotatedElement="_19_0_4_12e503d9_1624202269076_561550_3109">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> whose value is to be set.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624202612538_482807_3255" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624202612538_398293_3256" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674979_644335_43267"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624306821108_998562_5594" name="WhileLoopActionUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624307160091_20549_5895" annotatedElement="_19_0_4_12e503d9_1624306821108_998562_5594">
+          <body>&lt;p>A &lt;code>WhileLoopActionUsage&lt;/code> is a &lt;code>LoopActionUsage&lt;/code> that specifies that the &lt;code>bodyAction&lt;/code> &lt;code>ActionUsage&lt;/code> should be performed repeatedly while the result of the &lt;code>whileArgument&lt;/code> &lt;code>Expression&lt;/code> is true or until the result of the &lt;code>untilArgument&lt;/code> &lt;code>Expression&lt;/code> (if provided) is true. The &lt;code>whileArgument&lt;/code> &lt;code>Expression&lt;/code> is evaluated before each (possible) performance of the &lt;code>bodyAction&lt;/code>, and the &lt;code>untilArgument&lt;/code> &lt;code>Expression&lt;/code> is evaluated after each performance of the &lt;code>bodyAction&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675125211242_678441_314" name="checkWhileLoopActionUsageSubactionSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306821108_998562_5594">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675126409763_191502_349" annotatedElement="_19_0_4_12e503d9_1675125211242_678441_314">
+            <body>&lt;p>A composite &lt;code>WhileLoopActionUsage&lt;/code> that is a subaction usage must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::whileLoops&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675125211253_575662_315" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSubactionUsage() implies
+    specializesFromLibrary('Actions::Action::whileLoops')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675124626174_988614_264" name="deriveWhileLoopActionUsageUntilArgument" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306821108_998562_5594">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675124626230_546972_266" annotatedElement="_19_0_4_12e503d9_1675124626174_988614_264">
+            <body>&lt;p>The &lt;code>whileArgument&lt;/code> of a &lt;code>WhileLoopActionUsage&lt;/code> is its third input &lt;code>parameter&lt;/code>, which, if it exists, must be an &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675124626224_913048_265" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>untilArgument =
+    let parameter : Feature = inputParameter(3) in
+    if parameter &lt;> null and parameter.oclIsKindOf(Expression) then
+        parameter.oclAsType(Expression)
+    else
+        null
+    endif
+</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675125021863_577889_296" name="checkWhileLoopActionUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306821108_998562_5594">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675125393256_96836_318" annotatedElement="_19_0_4_12e503d9_1675125021863_577889_296">
+            <body>&lt;p>A &lt;code>WhileLoopActionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::whileLoopActions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675125021881_531144_297" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::whileLoopActions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675124106115_20476_235" name="deriveWhileLoopActionUsageWhileArgument" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306821108_998562_5594">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675124618138_395480_263" annotatedElement="_19_0_4_12e503d9_1675124106115_20476_235">
+            <body>&lt;p>The &lt;code>whileArgument&lt;/code> of a &lt;code>WhileLoopActionUsage&lt;/code> is its first input &lt;code>parameter&lt;/code>, which must be an &lt;code>Expression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675124106139_353860_236" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>whileArgument =
+    let parameter : Feature = inputParameter(1) in
+    if parameter &lt;> null and parameter.oclIsKindOf(Expression) then
+        parameter.oclAsType(Expression)
+    else
+        null
+    endif
+</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698944895059_523296_104" name="validateWhileLoopActionUsage" visibility="public" constrainedElement="_19_0_4_12e503d9_1624306821108_998562_5594">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698944966696_481023_106" annotatedElement="_19_0_4_12e503d9_1698944895059_523296_104">
+            <body>&lt;p>A &lt;code>WhileLoopActionUsage&lt;/code> must have at least two owned &lt;code>input&lt;/code> &lt;code>parameters&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698944895076_913524_105" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>inputParameters()->size() >= 2</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1624306886427_796867_5705" general="_19_0_4_12e503d9_1624203585458_610400_3524"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624203871924_371126_3842" name="whileArgument" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1624203871924_992943_3841">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624293585410_30911_4321" annotatedElement="_19_0_4_12e503d9_1624203871924_371126_3842">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> whose result, if true, determines that the &lt;code>bodyAction&lt;/code> should continue to be performed. It is the first owned &lt;code>parameter&lt;/code> of the &lt;code>WhileLoopActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624204281625_200796_3969" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624204281626_990742_3970" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624290717721_449719_4195" name="untilArgument" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1624290717707_879119_4194">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624293649481_562924_4322" annotatedElement="_19_0_4_12e503d9_1624290717721_449719_4195">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> whose result, if false, determines that the &lt;code>bodyAction&lt;/code> should continue to be performed. It is the (optional) third owned &lt;code>parameter&lt;/code> of the &lt;code>WhileLoopActionUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624290750006_306643_4231" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624290750007_336194_4232" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1640325378394_421584_3661" name="A_loopVariable_forLoopAction" visibility="public" memberEnd="_19_0_4_12e503d9_1640325378400_227367_3662 _19_0_4_12e503d9_1640325378408_924519_3663">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1640325378408_924519_3663" name="forLoopAction" visibility="public" type="_19_0_4_12e503d9_1624306893649_489444_5711" isDerived="true" association="_19_0_4_12e503d9_1640325378394_421584_3661">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1731090402146_305951_19" annotatedElement="_19_0_4_12e503d9_1640325378408_924519_3663">
+            <body>The &lt;code>ForLoopActionUsage&lt;/code> that has a certain &lt;code>ReferenceUsage&lt;/code> as its &lt;code>loopVariable&lt;/code>.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1640325419445_525041_3678" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1640325419446_442152_3679" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1642701018280_486257_4461" name="A_payloadParameter_owningAcceptActionUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1642701018287_478584_4462 _19_0_4_12e503d9_1642701018295_67865_4463">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1642701018295_67865_4463" name="owningAcceptActionUsage" visibility="public" type="_18_5_3_12e503d9_1565503089035_106795_33475" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591477541361_825733_934" association="_19_0_4_12e503d9_1642701018280_486257_4461">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1642710220152_532639_4938" annotatedElement="_19_0_4_12e503d9_1642701018295_67865_4463">
+            <body>&lt;p>The AcceptActionUsage that owns the &lt;code>payloadParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1642701301285_282360_4478" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1642701301286_424983_4479" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_19_0_4_12e503d9_1642701971867_321159_4844" name="TriggerKind" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1642704009212_517870_4930" annotatedElement="_19_0_4_12e503d9_1642701971867_321159_4844">
+          <body>&lt;p>&lt;code>TriggerKind&lt;/code> enumerates the kinds of triggers that can be represented by a &lt;code>TriggerInvocationExpression&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedLiteral xmi:id="_19_0_4_12e503d9_1642701987091_181503_4865" name="when" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1642704079421_508026_4931" annotatedElement="_19_0_4_12e503d9_1642701987091_181503_4865">
+            <body>&lt;p>Indicates a &lt;em>change trigger&lt;/em>, corresponding to the &lt;em>&lt;code>TriggerWhen&lt;/code>&lt;/em> &lt;code>Function&lt;/code> from the &lt;em>&lt;code>Triggers&lt;/code>&lt;/em> model in the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_19_0_4_12e503d9_1642701995255_930085_4867" name="at" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1642704141778_729127_4932" annotatedElement="_19_0_4_12e503d9_1642701995255_930085_4867">
+            <body>&lt;p>Indicates an &lt;em>absolute time trigger&lt;/em>, corresponding to the &lt;em>&lt;code>TriggerAt&lt;/code>&lt;/em> &lt;code>Function&lt;/code> from the &lt;em>&lt;code>Triggers&lt;/code>&lt;/em> model in the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_19_0_4_12e503d9_1642701999902_150850_4869" name="after" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1642704153886_538386_4933" annotatedElement="_19_0_4_12e503d9_1642701999902_150850_4869">
+            <body>&lt;p>Indicates a &lt;em>relative time trigger&lt;/em>, corresponding to the &lt;em>&lt;code>TriggerAfter&lt;/code>&lt;/em> &lt;code>Function&lt;/code> from the &lt;em>&lt;code>Triggers&lt;/code>&lt;/em> model in the &lt;code>Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1642710978426_592787_4947" name="A_payloadArgument_acceptingActionUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1642710978429_81558_4948 _19_0_4_12e503d9_1642710978439_455164_4949">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1642710978439_455164_4949" name="acceptingActionUsage" visibility="public" type="_18_5_3_12e503d9_1565503089035_106795_33475" isDerived="true" association="_19_0_4_12e503d9_1642710978426_592787_4947">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1642711145230_964678_4965" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1642711145235_614300_4966" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1643588492412_624345_274" name="TriggerInvocationExpression" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1644442899461_859035_1492" annotatedElement="_19_0_4_12e503d9_1643588492412_624345_274">
+          <body>&lt;p>A &lt;code>TriggerInvocationExpression&lt;/code> is an &lt;code>InvocationExpression&lt;/code> that invokes one of the trigger &lt;code>Functions&lt;/code> from the Kernel Semantic Library &lt;code>&lt;em>Triggers&lt;em>&lt;/code> package, as indicated by its &lt;code>kind&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698944534233_349365_95" name="validateTriggerInvocationExpressionAfterArgument" visibility="public" constrainedElement="_19_0_4_12e503d9_1643588492412_624345_274">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698944632117_872425_97" annotatedElement="_19_0_4_12e503d9_1698944534233_349365_95">
+            <body>&lt;p>If a &lt;code>TriggerInvocationExpression&lt;/code> has &lt;code>kind = after&lt;/code>, then it must have an argument &lt;code>Expression&lt;/code> with a &lt;code>result&lt;/code> that conforms to the type &lt;em>&lt;code>Quantities::ScalarQuantityValue&lt;/code>&lt;/em> and a &lt;code>feature&lt;/code> that directly or indirectly redefines &lt;em>&lt;code>Quantities::TensorQuantityValue::mRef&lt;/code>&lt;/em> and directly or indirectly specializes &lt;em>&lt;code>ISQBase::DurationUnit&lt;/code>&lt;/em>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698944534252_264142_96" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>kind = TriggerKind::after implies
+    argument->notEmpty() and
+    argument->at(1).result.specializesFromLibrary('Quantities::ScalarQuantityValue') and
+    let mRef : Element = 
+        resolveGlobal('Quantities::TensorQuantityValue::mRef').ownedMemberElement in
+    argument->at(1).result.feature->
+        select(ownedRedefinition.redefinedFeature->
+           closure(ownedRedefinition.redefinedFeature)->
+           includes(mRef))->
+        exists(specializesFromLibrary('ISQBase::DurationUnit'))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698944637632_542160_98" name="validateTriggerInvocationExpressionAtArgument" visibility="public" constrainedElement="_19_0_4_12e503d9_1643588492412_624345_274">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698944733964_589683_100" annotatedElement="_19_0_4_12e503d9_1698944637632_542160_98">
+            <body>&lt;p>If a &lt;code>TriggerInvocationExpression&lt;/code> has &lt;code>kind = at&lt;/code>, then it must have an argument &lt;code>Expression&lt;/code> with a &lt;code>result&lt;/code> that conforms to the type &lt;em>&lt;code>Time::TimeInstantValue&lt;/code>&lt;/em>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698944637651_929126_99" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>kind = TriggerKind::at implies
+    argument->notEmpty() and
+    argument->at(1).result.specializesFromLibrary('Time::TimeInstantValue')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698944757934_20286_101" name="validateTriggerInvocationExpressionWhenArgument" visibility="public" constrainedElement="_19_0_4_12e503d9_1643588492412_624345_274">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698944855700_421550_103" annotatedElement="_19_0_4_12e503d9_1698944757934_20286_101">
+            <body>&lt;p>If a &lt;code>TriggerInvocationExpression&lt;/code> has &lt;code>kind = when&lt;/code>, then it must have an &lt;code>argument&lt;/code> that is a &lt;code>FeatureReferenceExpression&lt;/code> whose &lt;code>referent&lt;/code> is an &lt;code>Expression&lt;/code> with a &lt;code>result&lt;/code> that conforms to the type &lt;em>&lt;code>ScalarValues::Boolean&lt;/code>&lt;/em>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698944757948_240729_102" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>kind = TriggerKind::when implies
+    argument->notEmpty() and
+    argument->at(1).oclIsKindOf(FeatureReferenceExpression) and
+    let referent : Feature = 
+        argument->at(1).oclAsType(FeatureReferenceExpression).referent in
+    referent.oclIsKindOf(Expression) and
+    referent.oclAsType(Expression).result.specializesFromLibrary('ScalarValues::Boolean')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1643588509984_923980_299">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557528671608_638869_111563"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1643588513495_774789_300" name="kind" visibility="public" type="_19_0_4_12e503d9_1642701971867_321159_4844">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1644443095939_40566_1493" annotatedElement="_19_0_4_12e503d9_1643588513495_774789_300">
+            <body>&lt;p>Indicates which of the &lt;code>Functions&lt;/code> from the &lt;code>&lt;em>Triggers&lt;/em>&lt;/code> model in the Kernel Semantic Library is to be invoked by this &lt;code>TriggerInvocationExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1740260799914_621750_418" name="instantiatedType" visibility="public" bodyCondition="_2022x_2_12e503d9_1740261394390_703160_804">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740261368892_259648_801" annotatedElement="_2022x_2_12e503d9_1740260799914_621750_418">
+            <body>&lt;p>Return one of the &lt;code>Functions&lt;/code> &lt;em>&lt;code>TriggerWhen&lt;/code>&lt;/em>, &lt;em>&lt;code>TriggerAt&lt;/code>&lt;/em> or &lt;em>&lt;code>TriggerAfter&lt;/code>&lt;/em>, from the Kernel Semantic Library &lt;em>&lt;code>Triggers&lt;/code>&lt;/em> package, depending on whether the &lt;code>kind&lt;/code> of this &lt;code>TriggerInvocationExpression&lt;/code> is &lt;code>when&lt;/code>, &lt;code>at&lt;/code> or &lt;code>after&lt;/code>, respectively.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1740261394390_703160_804" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740261394394_741687_805" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>resolveGlobal(
+    if kind = TriggerKind::when then
+        'Triggers::TriggerWhen'
+    else if kind = TriggerKind::at then
+        'Triggers::TriggerAt'
+    else
+        'Triggers::TriggerAfter'
+    endif endif
+).memberElement.oclAsType(Type)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1740260813181_469815_425" name="" visibility="public" direction="return">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_71301a1_1537895141427_270492_15579"/>
+          </ownedParameter>
+          <redefinedOperation href="KerML_only_xmi.uml#_2022x_2_12e503d9_1740179456959_241700_64"/>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1665504224524_746163_943" name="A_senderArgument_senderActionUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1665504224536_894018_944 _19_0_4_12e503d9_1665504224551_517457_945">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1665504224551_517457_945" name="senderActionUsage" visibility="public" type="_18_5_3_12e503d9_1565505727349_597544_34143" isDerived="true" association="_19_0_4_12e503d9_1665504224524_746163_943">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665505140850_327077_969" annotatedElement="_19_0_4_12e503d9_1665504224551_517457_945">
+            <body>&lt;p>The &lt;code>SendActionUsage&lt;/code> that has a certain &lt;code>Expression&lt;/code> as its &lt;code>senderArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665504259529_858059_958" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665504259531_602071_959" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_2022x_2_12e503d9_1724451571263_191875_31" name="TerminateActionUsage" visibility="public">
+        <ownedComment xmi:id="_2022x_2_12e503d9_1731090026135_611284_5" annotatedElement="_2022x_2_12e503d9_1724451571263_191875_31">
+          <body>&lt;p>A &lt;code>TerminateActionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that directly or indirectly specializes the &lt;code>ActionDefinition&lt;/code> &lt;em>&lt;code>TerminateAction&lt;/code>&lt;/em> from the Systems Model Library, which causes a given &lt;em>&lt;code>terminatedOccurrence&lt;/code>&lt;/em> to end during its performance. By default, the &lt;code>terminatedOccurrence&lt;/code> is the featuring instance (&lt;em>&lt;code>that&lt;/code>&lt;/em>) of the performance of the &lt;code>TerminateActionUsage&lt;/code>, generally the performance of its immediately containing &lt;code>ActionDefinition&lt;/code> or &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1731090507828_66862_21" name="checkTerminateActionUsageSpecialization" visibility="public" constrainedElement="_2022x_2_12e503d9_1724451571263_191875_31">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1731090635593_320002_23" annotatedElement="_2022x_2_12e503d9_1731090507828_66862_21">
+            <body>&lt;p>A &lt;code>TerminateActionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::terminateActions&lt;/code>&lt;/em> from the Systems Modeling Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1731090507829_811981_22" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::terminateActions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1731090793527_917303_27" name="deriveTerminateActionUsageTerminatedOccurrenceArgument" visibility="public" constrainedElement="_2022x_2_12e503d9_1724451571263_191875_31">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1731090861408_427771_29" annotatedElement="_2022x_2_12e503d9_1731090793527_917303_27">
+            <body>&lt;p>The &lt;code>terminatedOccurrenceArgument&lt;/code> of a &lt;code>TerminateActionUsage&lt;/code> is its first argument.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1731090793527_562273_28" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>terminatedOccurrenceArgument = argument(1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1731090657678_908544_24" name="checkTerminateActionUsageSubactionSpecialization" visibility="public" constrainedElement="_2022x_2_12e503d9_1724451571263_191875_31">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1731090727511_733117_26" annotatedElement="_2022x_2_12e503d9_1731090657678_908544_24">
+            <body>&lt;p>A composite &lt;code>TerminateActionUsage&lt;/code> that is a subaction must must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::terminateSubactions&lt;/code>&lt;/em> from the Systems Modeling Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1731090657679_922279_25" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSubactionUsage() implies
+    specializesFromLibrary('Actions::Action::terminateSubactions')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_2022x_2_12e503d9_1724451590372_974639_54" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1724451750939_948290_107" name="terminatedOccurrenceArgument" visibility="public" isDerived="true" association="_2022x_2_12e503d9_1724451750938_651931_106">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1731090182367_512846_6" annotatedElement="_2022x_2_12e503d9_1724451750939_948290_107">
+            <body>&lt;p>The &lt;code>Expression&lt;/code> that is the &lt;code>featureValue&lt;/code> of the &lt;em>&lt;code>terminateOccurrence&lt;/code>&lt;/em> &lt;code>parameter&lt;/code> of this &lt;code>TerminateActionUsage&lt;/code>.</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1724451821123_356995_117" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1724451821124_53038_118" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_2022x_2_12e503d9_1724451750938_651931_106" name="A_terminatedOccurrenceArgument_terminateActionUsage" visibility="public" memberEnd="_2022x_2_12e503d9_1724451750939_948290_107 _2022x_2_12e503d9_1724451750939_427813_108">
+        <ownedEnd xmi:id="_2022x_2_12e503d9_1724451750939_427813_108" name="terminateActionUsage" visibility="public" type="_2022x_2_12e503d9_1724451571263_191875_31" isDerived="true" association="_2022x_2_12e503d9_1724451750938_651931_106">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1731090496686_975610_20" annotatedElement="_2022x_2_12e503d9_1724451750939_427813_108">
+            <body>&lt;p>The &lt;code>TerminateActionUsage&lt;/code> that has a certain &lt;code>Expression&lt;/code> as its &lt;code>terminatedOccurrenceArgument&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1724452042870_838336_142" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1724452042871_462206_143" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1565471060138_413817_20367" name="DefinitionAndUsage" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565495064714_174745_26149" name="A_directedUsage_definitionWithDirectedUsage" visibility="public" memberEnd="_18_5_3_12e503d9_1565495064714_974634_26150 _18_5_3_12e503d9_1565495064715_753827_26151">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565495064715_753827_26151" name="definitionWithDirectedUsage" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" association="_18_5_3_12e503d9_1565495064714_174745_26149">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586298160362_334560_464" annotatedElement="_18_5_3_12e503d9_1565495064715_753827_26151">
+            <body>&lt;p>The Definitions that have a certain Usage as a &lt;code>flow&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565495134289_841915_26186" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565495134300_724738_26187" name="" visibility="public" value="*"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_18876_27787"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_4_12e503d9_1623952188842_831269_37170"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565498571495_243179_27785" name="A_usage_featuringDefinition" visibility="public" memberEnd="_18_5_3_12e503d9_1565498571495_48981_27786 _18_5_3_12e503d9_1565498571495_18876_27787">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565498571495_18876_27787" name="featuringDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" association="_18_5_3_12e503d9_1565498571495_243179_27785">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586298131525_900496_463" annotatedElement="_18_5_3_12e503d9_1565498571495_18876_27787">
+            <body>&lt;p>The Definitions that feature a certain Usage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565498617102_399735_27864" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565498617103_630951_27865" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674987_297074_43308"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565494459494_130172_26041" name="A_nestedPort_portOwningUsage" visibility="public" memberEnd="_18_5_3_12e503d9_1565494459494_859367_26042 _18_5_3_12e503d9_1565494459495_641560_26043">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565494459495_641560_26043" name="portOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1565472757327_504924_21260" association="_18_5_3_12e503d9_1565494459494_130172_26041">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586299638613_39241_519" annotatedElement="_18_5_3_12e503d9_1565494459495_641560_26043">
+            <body>&lt;p>The Usage in which the &lt;code>nestedPort&lt;/code> is nested (if any).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565494507394_766951_26130" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565494507394_643981_26131" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565479032244_336549_22524" name="Definition" visibility="public">
+        <ownedComment xmi:id="_18_5_3_12e503d9_1565480047383_504334_23900" annotatedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <body>&lt;p>A &lt;code>Definition&lt;/code> is a &lt;code>Classifier&lt;/code> of &lt;code>Usages&lt;/code>. The actual kinds of &lt;code>Definition&lt;/code> that may appear in a model are given by the subclasses of &lt;code>Definition&lt;/code> (possibly as extended with user-defined &lt;em>&lt;code>SemanticMetadata&lt;/code>&lt;/em>).&lt;/p>
+
+&lt;p>Normally, a &lt;code>Definition&lt;/code> has owned Usages that model &lt;code>features&lt;/code> of the thing being defined. A &lt;code>Definition&lt;/code> may also have other &lt;code>Definitions&lt;/code> nested in it, but this has no semantic significance, other than the nested scoping resulting from the &lt;code>Definition&lt;/code> being considered as a &lt;code>Namespace&lt;/code> for any nested &lt;code>Definitions&lt;/code>.&lt;/p>
+
+&lt;p>However, if a &lt;code>Definition&lt;/code> has &lt;code>isVariation&lt;/code> = &lt;code>true&lt;/code>, then it represents a &lt;em>variation point&lt;/em> &lt;code>Definition&lt;/code>. In this case, all of its &lt;code>members&lt;/code> must be &lt;code>variant&lt;/code> &lt;code>Usages&lt;/code>, related to the &lt;code>Definition&lt;/code> by &lt;code>VariantMembership&lt;/code> &lt;code>Relationships&lt;/code>. Rather than being &lt;code>features&lt;/code> of the &lt;code>Definition&lt;/code>, &lt;code>variant&lt;/code> &lt;code>Usages&lt;/code> model different concrete alternatives that can be chosen to fill in for an abstract &lt;code>Usage&lt;/code> of the variation point &lt;code>Definition&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614281024439_362213_1092" name="validateDefinitionVariationOwnedFeatureMembership" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672157190973_475874_6" annotatedElement="_19_0_4_12e503d9_1614281024439_362213_1092">
+            <body>&lt;p>If a &lt;code>Definition&lt;/code> is a variation, then all it must not have any &lt;code>ownedFeatureMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614281024439_681230_1093" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isVariation implies ownedFeatureMembership->isEmpty()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614281792714_115542_1112" name="deriveDefinitionVariant" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672157363410_270829_8" annotatedElement="_19_0_4_12e503d9_1614281792714_115542_1112">
+            <body>&lt;p>The &lt;code>variants&lt;/code> of a &lt;code>Definition&lt;/code> are the &lt;code>ownedVariantUsages&lt;/code> of its &lt;code>variantMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614281792714_612358_1113" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>variant = variantMembership.ownedVariantUsage</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614280936751_128102_1090" name="deriveDefinitionVariantMembership" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672157521498_323745_9" annotatedElement="_19_0_4_12e503d9_1614280936751_128102_1090">
+            <body>&lt;p>The &lt;code>variantMemberships&lt;/code> of a &lt;code>Definition&lt;/code> are those &lt;code>ownedMemberships&lt;/code> that are &lt;code>VariantMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614280936752_129238_1091" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>variantMembership = ownedMembership->selectByKind(VariantMembership)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672264813842_479666_49" name="validateDefinitionVariationSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672265000314_714540_51" annotatedElement="_19_0_4_12e503d9_1672264813842_479666_49">
+            <body>&lt;p>A variation &lt;code>Definition&lt;/code> may not specialize any other variation &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672264813872_795926_50" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isVariation implies
+    not ownedSpecialization.specific->exists(
+        oclIsKindOf(Definition) and
+        oclAsType(Definition).isVariation)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676630288841_860387_2" name="deriveDefinitionUsage" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676630366227_932065_4" annotatedElement="_19_0_4_12e503d9_1676630288841_860387_2">
+            <body>&lt;p>The &lt;code>usages&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>features&lt;/code> that are &lt;code>Usages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676630288873_702932_3" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>usage = feature->selectByKind(Usage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676630403241_782959_5" name="deriveDefinitionDirectedUsage" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676630507160_191888_7" annotatedElement="_19_0_4_12e503d9_1676630403241_782959_5">
+            <body>&lt;p>The &lt;code>directedUsages&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>directedFeatures&lt;/code> that are &lt;code>Usages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676630403248_561855_6" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>directedUsage = directedFeature->selectByKind(Usage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631413657_815938_8" name="deriveDefinitionOwnedUsage" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631516032_575399_10" annotatedElement="_19_0_4_12e503d9_1676631413657_815938_8">
+            <body>&lt;p>The &lt;code>ownedUsages&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedFeatures&lt;/code> that are &lt;code>Usages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631413686_250071_9" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedUsage = ownedFeature->selectByKind(Usage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631536802_610775_11" name="deriveDefinitionOwnedAttribute" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631536867_579475_13" annotatedElement="_19_0_4_12e503d9_1676631536802_610775_11">
+            <body>&lt;p>The &lt;code>ownedAttributes&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>AttributeUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631536857_635722_12" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedAttribute = ownedUsage->selectByKind(AttributeUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631683793_847276_20" name="deriveDefinitionOwnedReference" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631683844_332012_22" annotatedElement="_19_0_4_12e503d9_1676631683793_847276_20">
+            <body>&lt;p>The &lt;code>ownedReferences&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ReferenceUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631683833_992491_21" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedReference = ownedUsage->selectByKind(ReferenceUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631684659_614027_23" name="deriveDefinitionOwnedEnumeration" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631684676_769394_25" annotatedElement="_19_0_4_12e503d9_1676631684659_614027_23">
+            <body>&lt;p>The &lt;code>ownedEnumerations&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>EnumerationUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631684671_689985_24" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedEnumeration = ownedUsage->selectByKind(EnumerationUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631685171_678149_26" name="deriveDefinitionOwnedOccurrence" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631685195_640654_28" annotatedElement="_19_0_4_12e503d9_1676631685171_678149_26">
+            <body>&lt;p>The &lt;code>ownedOccurrences&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>OccurrenceUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631685191_915425_27" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedOccurrence = ownedUsage->selectByKind(OccurrenceUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631685663_465012_29" name="deriveDefinitionOwnedItem" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631685687_729990_31" annotatedElement="_19_0_4_12e503d9_1676631685663_465012_29">
+            <body>&lt;p>The &lt;code>ownedItems&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ItemUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631685684_529174_30" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedItem = ownedUsage->selectByKind(ItemUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631686188_386624_32" name="deriveDefinitionOwnedPart" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631686221_933502_34" annotatedElement="_19_0_4_12e503d9_1676631686188_386624_32">
+            <body>&lt;p>The &lt;code>ownedParts&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>PartUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631686209_145713_33" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedPart = ownedUsage->selectByKind(PartUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631686665_285652_35" name="deriveDefinitionOwnedPort" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631686682_102893_37" annotatedElement="_19_0_4_12e503d9_1676631686665_285652_35">
+            <body>&lt;p>The &lt;code>ownedPorts&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>PortUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631686679_700221_36" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedPort = ownedUsage->selectByKind(PortUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631687188_103379_38" name="deriveDefinitionOwnedConnection" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631687200_846422_40" annotatedElement="_19_0_4_12e503d9_1676631687188_103379_38">
+            <body>&lt;p>The &lt;code>ownedConnections&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ConnectorAsUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631687197_60923_39" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedConnection = ownedUsage->selectByKind(ConnectorAsUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631687738_877239_41" name="deriveDefinitionOwnedFlow" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631687767_646729_43" annotatedElement="_19_0_4_12e503d9_1676631687738_877239_41">
+            <body>&lt;p>The &lt;code>ownedFlows&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>FlowUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631687762_672531_42" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedFlow = ownedUsage->selectByKind(FlowUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631688293_582320_44" name="deriveDefinitionOwnedInterface" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631688304_927486_46" annotatedElement="_19_0_4_12e503d9_1676631688293_582320_44">
+            <body>&lt;p>The &lt;code>ownedInterfaces&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>InterfaceUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631688302_592171_45" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedInterface = ownedUsage->selectByKind(ReferenceUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631688814_626660_47" name="deriveDefinitionOwnedAllocation" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631688821_562043_49" annotatedElement="_19_0_4_12e503d9_1676631688814_626660_47">
+            <body>&lt;p>The &lt;code>ownedAllocations&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>AllocationUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631688820_598093_48" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedAllocation = ownedUsage->selectByKind(AllocationUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631689410_301811_50" name="deriveDefinitionOwnedAction" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631689441_779847_52" annotatedElement="_19_0_4_12e503d9_1676631689410_301811_50">
+            <body>&lt;p>The &lt;code>ownedActions&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ActionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631689437_318058_51" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedAction = ownedUsage->selectByKind(ActionUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631689966_346989_53" name="deriveDefinitionOwnedState" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631689991_112694_55" annotatedElement="_19_0_4_12e503d9_1676631689966_346989_53">
+            <body>&lt;p>The &lt;code>ownedStates&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>StateUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631689986_777824_54" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedState = ownedUsage->selectByKind(StateUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631690472_285446_56" name="deriveDefinitionOwnedTransition" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631690478_414101_58" annotatedElement="_19_0_4_12e503d9_1676631690472_285446_56">
+            <body>&lt;p>The &lt;code>ownedTransitions&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>TransitionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631690474_134288_57" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedTransition = ownedUsage->selectByKind(TransitionUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631690993_973207_59" name="deriveDefinitionOwnedCalculation" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631691019_672185_61" annotatedElement="_19_0_4_12e503d9_1676631690993_973207_59">
+            <body>&lt;p>The &lt;code>ownedCalculations&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>CalculationUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631691009_90550_60" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedCalculation = ownedUsage->selectByKind(CalculationUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631691485_110103_62" name="deriveDefinitionOwnedConstraint" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631691487_269574_64" annotatedElement="_19_0_4_12e503d9_1676631691485_110103_62">
+            <body>&lt;p>The &lt;code>ownedConstraints&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ConstraintUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631691486_33859_63" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedConstraint = ownedUsage->selectByKind(ConstraintUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631691959_407486_65" name="deriveDefinitionOwnedRequirement" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631691963_82573_67" annotatedElement="_19_0_4_12e503d9_1676631691959_407486_65">
+            <body>&lt;p>The &lt;code>ownedRequirements&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>RequirementUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631691962_968819_66" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedRequirement = ownedUsage->selectByKind(RequirementUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631692480_902038_68" name="deriveDefinitionOwnedConcern" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631692484_775115_70" annotatedElement="_19_0_4_12e503d9_1676631692480_902038_68">
+            <body>&lt;p>The &lt;code>ownedConcerns&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ConcernUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631692483_998526_69" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedConcern = ownedUsage->selectByKind(ConcernUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631693144_125794_71" name="deriveDefinitionOwnedCase" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631693153_359148_73" annotatedElement="_19_0_4_12e503d9_1676631693144_125794_71">
+            <body>&lt;p>The &lt;code>ownedCases&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>CaseUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631693149_330948_72" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedCase = ownedUsage->selectByKind(CaseUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631693836_673510_74" name="deriveDefinitionOwnedAnalysisCase" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631693868_449840_76" annotatedElement="_19_0_4_12e503d9_1676631693836_673510_74">
+            <body>&lt;p>The &lt;code>ownedAnalysisCases&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>AnalysisCaseUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631693860_436809_75" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedAnalysisCase = ownedUsage->selectByKind(AnalysisCaseUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631694290_193766_77" name="deriveDefinitionOwnedVerificationCase" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631694304_138297_79" annotatedElement="_19_0_4_12e503d9_1676631694290_193766_77">
+            <body>&lt;p>The &lt;code>ownedValidationCases&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ValidationCaseUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631694301_172624_78" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedVerificationCase = ownedUsage->selectByKind(VerificationCaseUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631694790_122983_80" name="deriveDefinitionOwnedUseCase" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631694795_392941_82" annotatedElement="_19_0_4_12e503d9_1676631694790_122983_80">
+            <body>&lt;p>The &lt;code>ownedUseCases&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>UseCaseUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631694794_7136_81" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedUseCase = ownedUsage->selectByKind(UseCaseUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631695297_94618_83" name="deriveDefinitionOwnedView" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631695318_849003_85" annotatedElement="_19_0_4_12e503d9_1676631695297_94618_83">
+            <body>&lt;p>The &lt;code>ownedViews&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ViewUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631695311_284120_84" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedView = ownedUsage->selectByKind(ViewUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631695783_11139_86" name="deriveDefinitionOwnedViewpoint" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631695791_579003_88" annotatedElement="_19_0_4_12e503d9_1676631695783_11139_86">
+            <body>&lt;p>The &lt;code>ownedViewpoints&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ViewpointUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631695789_36785_87" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedViewpoint = ownedUsage->selectByKind(ViewpointUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631696262_245559_89" name="deriveDefinitionOwnedRendering" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631696278_390169_91" annotatedElement="_19_0_4_12e503d9_1676631696262_245559_89">
+            <body>&lt;p>The &lt;code>ownedRenderings&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>RenderingUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631696274_790573_90" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedRendering = ownedUsage->selectByKind(RenderingUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676631696771_433028_92" name="deriveDefinitionOwnedMetadata" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676631696776_661463_94" annotatedElement="_19_0_4_12e503d9_1676631696771_433028_92">
+            <body>&lt;p>The &lt;code>ownedMetadata&lt;/code> of a &lt;code>Definition&lt;/code> are all its &lt;code>ownedMembers&lt;/code> that are &lt;code>MetadataUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676631696775_88110_93" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMetadata = ownedMember->selectByKind(MetadataUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1702247749612_847365_2" name="validateDefinitionVariationIsAbstract" visibility="public" constrainedElement="_18_5_3_12e503d9_1565479032244_336549_22524">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1702247806852_341682_4" annotatedElement="_19_0_4_12e503d9_1702247749612_847365_2">
+            <body>&lt;p>If a &lt;code>Definition&lt;/code> is a variation, then it must be abstract.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1702247749646_439716_3" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isVariation implies isAbstract</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565479043968_106429_22552">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651676_375105_42143"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1590978283180_265362_419" name="isVariation" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591031993419_431063_28" annotatedElement="_19_0_2_12e503d9_1590978283180_265362_419">
+            <body>&lt;p>Whether this &lt;code>Definition&lt;/code> is for a variation point or not. If true, then all the &lt;code>memberships&lt;/code> of the &lt;code>Definition&lt;/code> must be &lt;code>VariantMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1590979457191_746167_951" name="variant" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1590979457191_749355_950">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591028806009_400816_1043" annotatedElement="_19_0_2_12e503d9_1590979457191_746167_951">
+            <body>&lt;p>The &lt;code>Usages&lt;/code> which represent the variants of this &lt;code>Definition&lt;/code> as a variation point &lt;code>Definition&lt;/code>, if &lt;code>isVariation&lt;/code> = true. If &lt;code>isVariation = false&lt;/code>, the there must be no &lt;code>variants&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1590979523765_999152_967" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1590979523771_771492_968" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674979_259543_43268"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1590979005861_503124_894" name="variantMembership" visibility="public" type="_19_0_2_59601fc_1590331535985_437424_487" aggregation="composite" isDerived="true" association="_19_0_2_12e503d9_1590979005861_392013_893">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591029062211_413538_1045" annotatedElement="_19_0_2_12e503d9_1590979005861_503124_894">
+            <body>&lt;p>The &lt;code>ownedMemberships&lt;/code> of this &lt;code>Definition&lt;/code> that are &lt;code>VariantMemberships&lt;/code>. If &lt;code>isVariation&lt;/code> = true, then this must be all &lt;code>ownedMemberships&lt;/code> of the &lt;code>Definition&lt;/code>. If &lt;code>isVariation&lt;/code> = false, then &lt;code>variantMembership&lt;/code>must be empty.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1590979225923_563140_936" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1590979225924_652470_937" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674979_190614_43269"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565498571495_48981_27786" name="usage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isOrdered="true" isDerived="true" association="_18_5_3_12e503d9_1565498571495_243179_27785">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296209807_813521_418" annotatedElement="_18_5_3_12e503d9_1565498571495_48981_27786">
+            <body>&lt;p>The &lt;code>Usages&lt;/code> that are &lt;code>features&lt;/code> of this &lt;code>Definition&lt;/code> (not necessarily owned).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565498579370_856261_27818" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565498579370_464550_27819" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_326391_43166"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565495064714_974634_26150" name="directedUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isOrdered="true" isDerived="true" association="_18_5_3_12e503d9_1565495064714_174745_26149">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1567721650116_113716_17988" annotatedElement="_18_5_3_12e503d9_1565495064714_974634_26150">
+            <body>&lt;p>The &lt;code>usages&lt;/code> of this &lt;code>Definition&lt;/code> that are &lt;code>directedFeatures&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565495081250_213971_26172" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565495081250_193990_26173" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_4_12e503d9_1623952188842_882068_37169"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_48981_27786"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565479686637_967933_23236" name="ownedUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isOrdered="true" isDerived="true" association="_18_5_3_12e503d9_1565479686637_851044_23235">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296037868_230265_413" annotatedElement="_18_5_3_12e503d9_1565479686637_967933_23236">
+            <body>&lt;p>The &lt;code>Usages&lt;/code> that are &lt;code>ownedFeatures&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565479706561_122290_23278" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565479706561_788156_23279" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_226999_43167"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_48981_27786"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591477471991_39731_908" name="ownedReference" visibility="public" type="_19_0_2_12e503d9_1591477377905_618531_857" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686637_967933_23236" association="_19_0_2_12e503d9_1591477471991_678008_907">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591481721439_688710_2900" annotatedElement="_19_0_2_12e503d9_1591477471991_39731_908">
+            <body>&lt;p>The &lt;code>ReferenceUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591477492702_336967_918" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591477492702_696537_919" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591500614097_490259_4413" name="ownedAttribute" visibility="public" type="_18_5_3_12e503d9_1565471291545_950196_20762" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686637_967933_23236" association="_19_0_2_12e503d9_1591500614097_792385_4412">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591500779100_417418_4480" annotatedElement="_19_0_2_12e503d9_1591500614097_490259_4413">
+            <body>&lt;p>The &lt;code>AttributeUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591500646594_682951_4429" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591500646595_736097_4430" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1606946600508_763872_252" name="ownedEnumeration" visibility="public" type="_19_0_4_12e503d9_1606946489455_954016_180" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591500614097_490259_4413" association="_19_0_4_12e503d9_1606946600508_742209_251">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606948326250_382059_809" annotatedElement="_19_0_4_12e503d9_1606946600508_763872_252">
+            <body>&lt;p>The &lt;code>EnumerationUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606946668958_830300_275" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606946668960_263784_276" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1618943849505_989631_257" name="ownedOccurrence" visibility="public" type="_19_0_4_12e503d9_1618943737195_33207_138" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686637_967933_23236" association="_19_0_4_12e503d9_1618943849504_625746_256">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618946103977_428377_704" annotatedElement="_19_0_4_12e503d9_1618943849505_989631_257">
+            <body>&lt;p>The &lt;code>OccurrenceUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1618944299642_814039_424" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1618944299642_711867_425" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591482567975_649284_3005" name="ownedItem" visibility="public" type="_18_5_3_12e503d9_1565480460114_846184_24270" isOrdered="true" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943849505_989631_257" association="_19_0_2_12e503d9_1591482567975_432457_3004">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1592273672409_517824_9871" annotatedElement="_19_0_2_12e503d9_1591482567975_649284_3005">
+            <body>&lt;p>The &lt;code>ItemUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591482583847_9263_3015" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591482583847_515518_3016" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591496643392_630316_3279" name="ownedPart" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591482567975_649284_3005" association="_19_0_2_12e503d9_1591496643391_102309_3278">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591496760047_403257_3299" annotatedElement="_19_0_2_12e503d9_1591496643392_630316_3279">
+            <body>&lt;p>The &lt;code>PartUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591496720324_428037_3295" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591496720324_890590_3296" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565494319970_455996_25799" name="ownedPort" visibility="public" type="_18_5_3_12e503d9_1565492704639_896080_24992" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686637_967933_23236" association="_18_5_3_12e503d9_1565494319969_506347_25798">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296072869_649999_414" annotatedElement="_18_5_3_12e503d9_1565494319970_455996_25799">
+            <body>&lt;p>The &lt;code>PortUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565494388584_805962_25889" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565494388584_491629_25890" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591480607506_951212_2333" name="ownedConnection" visibility="public" type="_19_0_4_12e503d9_1624053320057_820842_471" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686637_967933_23236" association="_19_0_2_12e503d9_1591480607505_321093_2332">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591497159012_693697_3426" annotatedElement="_19_0_2_12e503d9_1591480607506_951212_2333">
+            <body>&lt;p>The &lt;code>ConnectorAsUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>. Note that this list includes &lt;code>BindingConnectorAsUsages&lt;/code>, &lt;code>SuccessionAsUsages&lt;/code>, and &lt;code>FlowUsages&lt;/code> because these are &lt;code>ConnectorAsUsages&lt;/code> even though they are not &lt;code>ConnectionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591480621544_686327_2363" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591480621544_203796_2364" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624055201422_104863_1697" name="ownedFlow" visibility="public" type="_19_0_4_12e503d9_1624054663096_771284_1274" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591480607506_951212_2333" association="_19_0_4_12e503d9_1624055201422_339748_1696">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624565021166_295337_8487" annotatedElement="_19_0_4_12e503d9_1624055201422_104863_1697">
+            <body>&lt;p>The &lt;code>FlowUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624055211666_546007_1721" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624055211667_479802_1722" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591498709150_220812_4128" name="ownedInterface" visibility="public" type="_18_5_3_12e503d9_1565498940266_617738_28508" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591480607506_951212_2333" association="_19_0_2_12e503d9_1591498709150_699835_4127">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591498883825_149107_4213" annotatedElement="_19_0_2_12e503d9_1591498709150_220812_4128">
+            <body>&lt;p>The &lt;code>InterfaceUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591498735331_35035_4158" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591498735331_240982_4159" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1611430819239_430196_1024" name="ownedAllocation" visibility="public" type="_19_0_4_12e503d9_1611430595314_523036_933" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591480607506_951212_2333" association="_19_0_4_12e503d9_1611430819239_130472_1023">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611591879191_546420_446" annotatedElement="_19_0_4_12e503d9_1611430819239_430196_1024">
+            <body>&lt;p>The &lt;code>AllocationUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1611430839631_957974_1034" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1611430839631_53498_1035" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591479011613_547927_1091" name="ownedAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isOrdered="true" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943849505_989631_257" association="_19_0_2_12e503d9_1591479011612_753775_1090">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591479151620_867937_1115" annotatedElement="_19_0_2_12e503d9_1591479011613_547927_1091">
+            <body>&lt;p>The &lt;code>ActionUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591479070816_854867_1107" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591479070816_697571_1108" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575587977045_745776_941" name="ownedState" visibility="public" type="_19_0_2_12e503d9_1575587557729_586912_651" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591479011613_547927_1091" association="_19_0_2_12e503d9_1575587977045_646521_940">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296236742_260087_420" annotatedElement="_19_0_2_12e503d9_1575587977045_745776_941">
+            <body>&lt;p>The &lt;code>StateUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575588109174_216509_1085" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575588109174_141978_1086" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1578598061680_350995_3923" name="ownedTransition" visibility="public" type="_19_0_2_12e503d9_1575672078353_626298_450" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686637_967933_23236" association="_19_0_2_12e503d9_1578598061680_861031_3922">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296259082_978426_422" annotatedElement="_19_0_2_12e503d9_1578598061680_350995_3923">
+            <body>&lt;p>The &lt;code>TransitionUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578598097137_643821_3933" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578598097137_434505_3934" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1588215335104_898924_667" name="ownedCalculation" visibility="public" type="_19_0_2_12e503d9_1588213258220_731107_146" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591479011613_547927_1091" association="_19_0_2_12e503d9_1588215335100_757908_665">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1588781879965_11243_3998" annotatedElement="_19_0_2_12e503d9_1588215335104_898924_667">
+            <body>&lt;p>The &lt;code>CalculationUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1588215419316_287838_676" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1588215419317_219390_677" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1578068081992_244000_1803" name="ownedConstraint" visibility="public" type="_19_0_2_12e503d9_1578067096274_745288_1478" isOrdered="true" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943849505_989631_257" association="_19_0_2_12e503d9_1578068081991_875860_1802">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296251039_604557_421" annotatedElement="_19_0_2_12e503d9_1578068081992_244000_1803">
+            <body>&lt;p>The &lt;code>ConstraintUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578068158773_718957_1821" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578068158774_216089_1822" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583000559760_444344_1273" name="ownedRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1578068081992_244000_1803" association="_19_0_2_12e503d9_1583000559759_903126_1272">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296272369_512368_423" annotatedElement="_19_0_2_12e503d9_1583000559760_444344_1273">
+            <body>&lt;p>The &lt;code>RequirementUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583000667109_826242_1285" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583000667109_982443_1286" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617051597354_928367_1357" name="ownedConcern" visibility="public" type="_19_0_4_12e503d9_1617051561652_163085_1288" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000559760_444344_1273" association="_19_0_4_12e503d9_1617051597354_65575_1356">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617054219212_458189_3157" annotatedElement="_19_0_4_12e503d9_1617051597354_928367_1357">
+            <body>&lt;p>The &lt;code>ConcernUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617051621634_944697_1397" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617051621640_959563_1398" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_59601fc_1590257108055_7496_483" name="ownedCase" visibility="public" type="_19_0_2_59601fc_1590256077623_424527_107" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1588215335104_898924_667" association="_19_0_2_59601fc_1590257108054_193596_482">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591415380790_832908_1662" annotatedElement="_19_0_2_59601fc_1590257108055_7496_483">
+            <body>&lt;p>The code>CaseUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591415312776_213930_1648" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591415312776_183307_1649" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591152747086_367030_3846" name="ownedAnalysisCase" visibility="public" type="_19_0_2_59601fc_1590260225615_617039_1090" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_59601fc_1590257108055_7496_483" association="_19_0_2_12e503d9_1591152747086_72134_3845">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591415739617_118253_1720" annotatedElement="_19_0_2_12e503d9_1591152747086_367030_3846">
+            <body>&lt;p>The &lt;code>AnalysisCaseUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591415697817_577994_1714" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591415697817_9799_1715" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596821523387_872104_10416" name="ownedVerificationCase" visibility="public" type="_19_0_2_12e503d9_1596821359347_71332_10236" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_59601fc_1590257108055_7496_483" association="_19_0_2_12e503d9_1596821523387_661403_10415">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1597204568062_792492_94138" annotatedElement="_19_0_2_12e503d9_1596821523387_872104_10416">
+            <body>&lt;p>The &lt;code>VerificationCaseUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596821540033_217723_10444" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596821540034_369073_10445" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621461106608_978605_945" name="ownedUseCase" visibility="public" type="_19_0_4_12e503d9_1621460902507_609356_850" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_59601fc_1590257108055_7496_483" association="_19_0_4_12e503d9_1621461106608_639383_944">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621545573009_822046_1835" annotatedElement="_19_0_4_12e503d9_1621461106608_978605_945">
+            <body>&lt;p>The &lt;code>UseCaseUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621461123666_908558_955" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621461123666_337761_956" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596644570381_840567_784" name="ownedView" visibility="public" type="_19_0_2_12e503d9_1596644366280_485907_701" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591496643392_630316_3279" association="_19_0_2_12e503d9_1596644570381_245644_783">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596746253476_75064_7059" annotatedElement="_19_0_2_12e503d9_1596644570381_840567_784">
+            <body>&lt;p>The &lt;code>ViewUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596644621398_356623_794" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596644621399_779247_795" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596649828408_673531_3683" name="ownedViewpoint" visibility="public" type="_19_0_2_59601fc_1583087291401_74297_590" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000559760_444344_1273" association="_19_0_2_12e503d9_1596649828408_543464_3682">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596747743983_820414_7078" annotatedElement="_19_0_2_12e503d9_1596649828408_673531_3683">
+            <body>&lt;p>The &lt;code>ViewpointUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596649847368_270855_3713" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596649847368_212118_3714" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596741437225_963350_6474" name="ownedRendering" visibility="public" type="_19_0_2_12e503d9_1596657138882_432286_4810" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591496643392_630316_3279" association="_19_0_2_12e503d9_1596741437224_790949_6473">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596748041517_915806_7087" annotatedElement="_19_0_2_12e503d9_1596741437225_963350_6474">
+            <body>&lt;p>The &lt;code>RenderingUsages&lt;/code> that are &lt;code>ownedUsages&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596741459192_894123_6508" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596741459193_87019_6509" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1661488358064_457109_2881" name="ownedMetadata" visibility="public" type="_19_0_4_12e503d9_1645121476406_921183_398" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591482567975_649284_3005" association="_19_0_4_12e503d9_1661488358056_692573_2880">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661488781266_145423_3105" annotatedElement="_19_0_4_12e503d9_1661488358064_457109_2881">
+            <body>&lt;p>The &lt;code>MetadataUsages&lt;/code> that are &lt;code>ownedMembers&lt;/code> of this &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661488449937_564812_2897" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661488449944_216982_2898" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565471361757_216899_20795" name="A_itemDefinition_definedItem" visibility="public" memberEnd="_18_5_3_12e503d9_1565471361757_649736_20796 _18_5_3_12e503d9_1565471361757_611715_20797">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565471361757_611715_20797" name="definedItem" visibility="public" type="_18_5_3_12e503d9_1565480460114_846184_24270" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943843466_481041_237" association="_18_5_3_12e503d9_1565471361757_216899_20795">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586298068692_793112_461" annotatedElement="_18_5_3_12e503d9_1565471361757_611715_20797">
+            <body>&lt;p>The ItemUsages being typed by a certain Structure.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565471705135_699012_20915" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565471705135_575626_20916" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565501745142_286049_31608" name="A_nestedAction_actionOwningUsage" visibility="public" memberEnd="_18_5_3_12e503d9_1565501745142_70952_31609 _18_5_3_12e503d9_1565501745143_149841_31610">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565501745143_149841_31610" name="actionOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943853976_291802_279" association="_18_5_3_12e503d9_1565501745142_286049_31608">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586293956564_349344_335" annotatedElement="_18_5_3_12e503d9_1565501745143_149841_31610">
+            <body>&lt;p>The Usage in which the &lt;code>nestedAction&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565502836140_331337_33210" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565502836140_439925_33211" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565494319969_506347_25798" name="A_ownedPort_portOwningDefinition" visibility="public" memberEnd="_18_5_3_12e503d9_1565494319970_455996_25799 _18_5_3_12e503d9_1565494319970_250243_25800">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565494319970_250243_25800" name="portOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686638_420576_23237" association="_18_5_3_12e503d9_1565494319969_506347_25798">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586299622580_716411_518" annotatedElement="_18_5_3_12e503d9_1565494319970_250243_25800">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedPort&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565494382354_464994_25875" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565494382354_732566_25876" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565479686637_851044_23235" name="A_ownedUsage_owningDefinition" visibility="public" memberEnd="_18_5_3_12e503d9_1565479686637_967933_23236 _18_5_3_12e503d9_1565479686638_420576_23237"/>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565472757326_116408_21258" name="A_nestedUsage_owningUsage" visibility="public" memberEnd="_18_5_3_12e503d9_1565472757327_162097_21259 _18_5_3_12e503d9_1565472757327_504924_21260"/>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565469997820_598571_19982" name="Usage" visibility="public">
+        <ownedComment xmi:id="_18_5_3_12e503d9_1565470067619_143399_20071" annotatedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <body>&lt;p>A &lt;code>Usage&lt;/code> is a usage of a &lt;code>Definition&lt;/code>.&lt;/p>
+
+&lt;p>A &lt;code>Usage&lt;/code> may have &lt;code>nestedUsages&lt;/code> that model &lt;code>features&lt;/code> that apply in the context of the &lt;code>owningUsage&lt;/code>. A &lt;code>Usage&lt;/code> may also have &lt;code>Definitions&lt;/code> nested in it, but this has no semantic significance, other than the nested scoping resulting from the &lt;code>Usage&lt;/code> being considered as a &lt;code>Namespace&lt;/code> for any nested &lt;code>Definitions&lt;/code>.&lt;/p>
+
+&lt;p>However, if a &lt;code>Usage&lt;/code> has &lt;code>isVariation = true&lt;/code>, then it represents a &lt;em>variation point&lt;/em> &lt;code>Usage&lt;/code>. In this case, all of its &lt;code>members&lt;/code> must be &lt;code>variant&lt;/code> &lt;code>Usages&lt;/code>, related to the &lt;code>Usage&lt;/code> by &lt;code>VariantMembership&lt;/code> &lt;code>Relationships&lt;/code>. Rather than being &lt;code>features&lt;/code> of the &lt;code>Usage&lt;/code>, &lt;code>variant&lt;/code> &lt;code>Usages&lt;/code> model different concrete alternatives that can be chosen to fill in for the variation point &lt;code>Usage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614281982661_494389_1114" name="deriveUsageVariant" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672158018138_704704_16" annotatedElement="_19_0_4_12e503d9_1614281982661_494389_1114">
+            <body>&lt;p>The &lt;code>variants&lt;/code> of a &lt;code>Usage&lt;/code> are the &lt;code>ownedVariantUsages&lt;/code> of its &lt;code>variantMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614281982661_166399_1115" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>variant = variantMembership.ownedVariantUsage</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614281405215_509589_1098" name="deriveUsageVariantMembership" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672158069557_535370_17" annotatedElement="_19_0_4_12e503d9_1614281405215_509589_1098">
+            <body>&lt;p>The &lt;code>variantMemberships&lt;/code> of a &lt;code>Usage&lt;/code> are those &lt;code>ownedMemberships&lt;/code> that are &lt;code>VariantMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614281405217_333374_1101" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>variantMembership = ownedMembership->selectByKind(VariantMembership)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1614281405207_9_1096" name="validateUsageVariationOwnedFeatureMembership" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672157919312_473438_14" annotatedElement="_19_0_4_12e503d9_1614281405207_9_1096">
+            <body>&lt;p>If a &lt;code>Usage&lt;/code> is a variation, then it must not have any &lt;code>ownedFeatureMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1614281405216_615590_1099" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isVariation implies ownedFeatureMembership->isEmpty()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1624035575839_854407_41522" name="deriveUsageIsReference" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672157880990_78898_13" annotatedElement="_19_0_4_12e503d9_1624035575839_854407_41522">
+            <body>&lt;p>A &lt;code>Usage&lt;/code> is referential if it is not composite.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1624035575848_222974_41523" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isReference = not isComposite</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672158588353_302912_40" name="checkUsageVariationUsageSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672158681297_204439_43" annotatedElement="_19_0_4_12e503d9_1672158588353_302912_40">
+            <body>&lt;p>If a &lt;code>Usage&lt;/code> has an &lt;code>owningVariationUsage&lt;/code>, then it must directly or indirectly specialize that &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672158588400_315633_41" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningVariationUsage &lt;> null implies
+    specializes(owningVariationUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672265020058_350669_52" name="validateUsageVariationSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672265020088_683014_54" annotatedElement="_19_0_4_12e503d9_1672265020058_350669_52">
+            <body>&lt;p>A variation &lt;code>Usage&lt;/code> may not specialize any variation &lt;code>Definition&lt;/code> or &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672265020082_988865_53" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isVariation implies
+    not ownedSpecialization.specific->exists(
+        oclIsKindOf(Definition) and
+        oclAsType(Definition).isVariation or
+        oclIsKindOf(Usage) and
+        oclAsType(Usage).isVariation)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672158143030_944320_18" name="checkUsageVariationDefinitionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672158662850_762360_42" annotatedElement="_19_0_4_12e503d9_1672158143030_944320_18">
+            <body>&lt;p>If a &lt;code>Usage&lt;/code> has an &lt;code>owningVariationDefinition&lt;/code>, then it must directly or indirectly specialize that &lt;code>Definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672158143048_896397_19" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningVariationDefinition &lt;> null implies
+    specializes(owningVariationDefinition)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578087_150548_217" name="deriveUsageDirectedUsage" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578135_116232_249" annotatedElement="_19_0_4_12e503d9_1676634578087_150548_217">
+            <body>&lt;p>The &lt;code>directedUsages&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>directedFeatures&lt;/code> that are &lt;code>Usages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578129_100272_248" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>directedUsage = directedFeature->selectByKind(Usage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578111_578681_218" name="deriveUsageNestedAction" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578142_210307_251" annotatedElement="_19_0_4_12e503d9_1676634578111_578681_218">
+            <body>&lt;p>The &lt;code>ownedActions&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ActionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578137_443245_250" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedAction = nestedUsage->selectByKind(ActionUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578111_475313_219" name="deriveUsageNestedAllocation" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578142_979946_253" annotatedElement="_19_0_4_12e503d9_1676634578111_475313_219">
+            <body>&lt;p>The &lt;code>ownedAllocations&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>AllocationUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578142_523570_252" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedAllocation = nestedUsage->selectByKind(AllocationUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578113_10712_220" name="deriveUsageNestedAnalysisCase" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578143_46835_255" annotatedElement="_19_0_4_12e503d9_1676634578113_10712_220">
+            <body>&lt;p>The &lt;code>ownedAnalysisCases&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>AnalysisCaseUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578143_474008_254" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedAnalysisCase = nestedUsage->selectByKind(AnalysisCaseUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578114_804237_221" name="deriveUsageNestedAttribute" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578143_366471_257" annotatedElement="_19_0_4_12e503d9_1676634578114_804237_221">
+            <body>&lt;p>The &lt;code>ownedAttributes&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>AttributeUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578143_795219_256" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedAttribute = nestedUsage->selectByKind(AttributeUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578115_651301_222" name="deriveUsageNestedCalculation" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578143_65294_259" annotatedElement="_19_0_4_12e503d9_1676634578115_651301_222">
+            <body>&lt;p>The &lt;code>ownedCalculations&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>CalculationUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578143_343487_258" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedCalculation = nestedUsage->selectByKind(CalculationUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578116_750044_223" name="deriveUsageNestedCase" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578143_390209_261" annotatedElement="_19_0_4_12e503d9_1676634578116_750044_223">
+            <body>&lt;p>The &lt;code>ownedCases&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>CaseUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578143_147949_260" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedCase = nestedUsage->selectByKind(CaseUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578116_143011_224" name="deriveUsageNestedConcern" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578144_265887_263" annotatedElement="_19_0_4_12e503d9_1676634578116_143011_224">
+            <body>&lt;p>The &lt;code>ownedConcerns&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ConcernUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578143_972906_262" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedConcern = nestedUsage->selectByKind(ConcernUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578116_921209_225" name="deriveUsageNestedConnection" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578144_359910_265" annotatedElement="_19_0_4_12e503d9_1676634578116_921209_225">
+            <body>&lt;p>The &lt;code>ownedConnections&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ConnectorAsUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578144_301914_264" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedConnection = nestedUsage->selectByKind(ConnectorAsUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578116_600053_226" name="deriveUsageNestedConstraint" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578144_48289_267" annotatedElement="_19_0_4_12e503d9_1676634578116_600053_226">
+            <body>&lt;p>The &lt;code>ownedConstraints&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ConstraintUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578144_979630_266" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedConstraint = nestedUsage->selectByKind(ConstraintUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578116_587613_227" name="deriveUsageNestedEnumeration" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578144_704184_269" annotatedElement="_19_0_4_12e503d9_1676634578116_587613_227">
+            <body>&lt;p>The &lt;code>ownedEnumerations&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>EnumerationUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578144_47234_268" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedNested = nestedUsage->selectByKind(EnumerationUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578117_912414_228" name="deriveUsageNestedFlow" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578145_704186_271" annotatedElement="_19_0_4_12e503d9_1676634578117_912414_228">
+            <body>&lt;p>The &lt;code>ownedFlows&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>FlowConnectionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578144_118083_270" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedFlow = nestedUsage->selectByKind(FlowUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578117_711176_229" name="deriveUsageNestedInterface" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578145_65783_273" annotatedElement="_19_0_4_12e503d9_1676634578117_711176_229">
+            <body>&lt;p>The &lt;code>ownedInterfaces&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>InterfaceUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578145_810849_272" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedInterface = nestedUsage->selectByKind(ReferenceUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578117_988558_230" name="deriveUsageNestedItem" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578146_756027_275" annotatedElement="_19_0_4_12e503d9_1676634578117_988558_230">
+            <body>&lt;p>The &lt;code>ownedItems&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ItemUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578145_464332_274" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedItem = nestedUsage->selectByKind(ItemUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578117_242831_231" name="deriveUsageNestedMetadata" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578146_207855_277" annotatedElement="_19_0_4_12e503d9_1676634578117_242831_231">
+            <body>&lt;p>The &lt;code>ownedMetadata&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedMembers&lt;/code> that are &lt;code>MetadataUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578146_356506_276" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedMetadata = nestedUsage->selectByKind(MetadataUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578117_456358_232" name="deriveUsageNestedOccurrence" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578146_162633_279" annotatedElement="_19_0_4_12e503d9_1676634578117_456358_232">
+            <body>&lt;p>The &lt;code>ownedOccurrences&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>OccurrenceUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578146_522936_278" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedOccurrence = nestedUsage->selectByKind(OccurrenceUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578117_65070_233" name="deriveUsageNestedPart" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578147_544337_281" annotatedElement="_19_0_4_12e503d9_1676634578117_65070_233">
+            <body>&lt;p>The &lt;code>ownedParts&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>PartUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578146_677852_280" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedPart = nestedUsage->selectByKind(PartUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578117_91616_234" name="deriveUsageNestedPort" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578165_34406_283" annotatedElement="_19_0_4_12e503d9_1676634578117_91616_234">
+            <body>&lt;p>The &lt;code>ownedPorts&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>PortUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578158_673959_282" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedPort = nestedUsage->selectByKind(PortUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578117_946918_235" name="deriveUsageNestedReference" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578167_431862_285" annotatedElement="_19_0_4_12e503d9_1676634578117_946918_235">
+            <body>&lt;p>The &lt;code>ownedReferences&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ReferenceUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578166_961983_284" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedReference = nestedUsage->selectByKind(ReferenceUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578118_30686_236" name="deriveUsageNestedRendering" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578167_779182_287" annotatedElement="_19_0_4_12e503d9_1676634578118_30686_236">
+            <body>&lt;p>The &lt;code>ownedRenderings&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>RenderingUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578167_23514_286" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedRendering = nestedUsage->selectByKind(RenderingUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578118_575429_237" name="deriveUsageNestedRequirement" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578168_841961_289" annotatedElement="_19_0_4_12e503d9_1676634578118_575429_237">
+            <body>&lt;p>The &lt;code>ownedRequirements&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>RequirementUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578168_224426_288" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedRequirement = nestedUsage->selectByKind(RequirementUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578118_168730_238" name="deriveUsageNestedState" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578168_534348_291" annotatedElement="_19_0_4_12e503d9_1676634578118_168730_238">
+            <body>&lt;p>The &lt;code>ownedStates&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>StateUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578168_772994_290" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedState = nestedUsage->selectByKind(StateUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578118_288259_239" name="deriveUsageNestedTransition" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578168_670077_293" annotatedElement="_19_0_4_12e503d9_1676634578118_288259_239">
+            <body>&lt;p>The &lt;code>ownedTransitions&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>TransitionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578168_846429_292" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedTransition = nestedUsage->selectByKind(TransitionUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578118_646770_240" name="deriveUsageNestedUsage" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578168_331673_295" annotatedElement="_19_0_4_12e503d9_1676634578118_646770_240">
+            <body>&lt;p>The &lt;code>ownedUsages&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedFeatures&lt;/code> that are &lt;code>Usages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578168_680133_294" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedUsage = ownedFeature->selectByKind(Usage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578118_911825_241" name="deriveUsageNestedUseCase" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578169_731836_297" annotatedElement="_19_0_4_12e503d9_1676634578118_911825_241">
+            <body>&lt;p>The &lt;code>ownedUseCases&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>UseCaseUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578168_781548_296" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedUseCase = nestedUsage->selectByKind(UseCaseUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578118_915613_242" name="deriveUsageNestedVerificationCase" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578169_688358_299" annotatedElement="_19_0_4_12e503d9_1676634578118_915613_242">
+            <body>&lt;p>The &lt;code>ownedValidationCases&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ValidationCaseUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578169_49305_298" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedVerificationCase = nestedUsage->selectByKind(VerificationCaseUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578118_918598_243" name="deriveUsageNestedView" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578184_447207_301" annotatedElement="_19_0_4_12e503d9_1676634578118_918598_243">
+            <body>&lt;p>The &lt;code>ownedViews&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ViewUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578169_640922_300" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedView = nestedUsage->selectByKind(ViewUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578126_37819_244" name="deriveUsageNestedViewpoint" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578187_221140_303" annotatedElement="_19_0_4_12e503d9_1676634578126_37819_244">
+            <body>&lt;p>The &lt;code>ownedViewpoints&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>ownedUsages&lt;/code> that are &lt;code>ViewpointUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578186_958984_302" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>nestedViewpoint = nestedUsage->selectByKind(ViewpointUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676634578127_467991_245" name="deriveUsageUsage" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676634578189_319642_305" annotatedElement="_19_0_4_12e503d9_1676634578127_467991_245">
+            <body>&lt;p>The &lt;code>usages&lt;/code> of a &lt;code>Usage&lt;/code> are all its &lt;code>features&lt;/code> that are &lt;code>Usages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676634578188_215232_304" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>usage = feature->selectByKind(Usage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698950778298_448024_151" name="validateUsageIsReferential" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698950853973_639682_153" annotatedElement="_19_0_4_12e503d9_1698950778298_448024_151">
+            <body>&lt;p>A &lt;code>Usage&lt;/code> that is directed, an end feature or has no &lt;code>featuringTypes&lt;/code> must be referential.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698950778330_369797_152" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>direction &lt;> null or isEnd or featuringType->isEmpty() implies
+    isReference</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1702247830285_191518_5" name="validateUsageVariationIsAbstract" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1702247890439_764648_7" annotatedElement="_19_0_4_12e503d9_1702247830285_191518_5">
+            <body>&lt;p>If a &lt;code>Usage&lt;/code> is a variation, then it must be abstract.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1702247830301_74408_6" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isVariation implies isAbstract</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739746258841_153678_107" name="deriveUsageMayTimeVary" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739746341814_263934_109" annotatedElement="_2022x_2_12e503d9_1739746258841_153678_107">
+            <body>&lt;p>A &lt;code>Usage&lt;/code> &lt;code>mayTimeVary&lt;/code> if and only if all of the following are true&lt;/p>
+&lt;ul>
+	&lt;li>It has an &lt;code>owningType&lt;/code> that specializes &lt;em>&lt;code>Occurrences::Occurrence&lt;/code>&lt;/em> (from the Kernel Semantic Library).&lt;/li>
+	&lt;li>It is not a portion.&lt;/li>
+	&lt;li>It does not specialize &lt;em>&lt;code>Links::SelfLink&lt;/code>&lt;/em>  or &lt;em>&lt;code>Occurrences::HappensLink&lt;/code>&lt;/em> (from the Kernel Semantic Library).&lt;/li>
+	&lt;li>If &lt;code>isComposite = true&lt;/code>, it does not specialize &lt;em>&lt;code>Actions::Action&lt;/code>&lt;/em> (from the Systems Model Library).
+&lt;/li>&lt;/ul></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739746258842_466653_108" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>mayTimeVary =
+    owningType &lt;> null and
+    owningType.specializesFromLibrary('Occurrences::Occurrence') and
+    not (
+        isPortion or
+        specializesFromLibrary('Links::SelfLink') or
+        specializesFromLibrary('Occurrences::HappensLink') or
+        isComposite and specializesFromLibrary('Actions::Action')
+    )</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1740253117228_903774_51" name="checkUsageVariationUsageTypeFeaturing" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469997820_598571_19982">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1740253177468_226131_53" annotatedElement="_2022x_2_12e503d9_1740253117228_903774_51">
+            <body>&lt;p>If a &lt;code>Usage&lt;/code> has an &lt;code>owningVariationUsage&lt;/code>, then it must have the same &lt;code>featuringTypes&lt;/code> as that &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1740253117229_253374_52" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningVariationUsage &lt;> null implies
+    featuringType->asSet() = owningVariationUsage.featuringType->asSet()</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565470043215_785559_20062">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+        </generalization>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1737227200362_771035_69" name="mayTimeVary" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1737227415507_328665_83" annotatedElement="_2022x_2_12e503d9_1737227200362_771035_69">
+            <body>&lt;p>Whether this &lt;code>Usage&lt;/code> may be time varying (that is, whether it is featured by the snapshots of its &lt;code>owningType&lt;/code>, rather than being featured by the &lt;code>owningType&lt;/code> itself). However, if &lt;code>isConstant&lt;/code> is also true, then the value of the &lt;code>Usage&lt;/code> is nevertheless constant over the entire duration of an instance of its &lt;code>owningType&lt;/code> (that is, it has the same value on all snapshots).&lt;/p>
+
+&lt;p>The property &lt;code>mayTimeVary&lt;/code> redefines the KerML property &lt;code>Feature::isVariable&lt;/code>, making it derived. The property &lt;code>isConstant&lt;/code> is inherited from &lt;code>Feature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_2022x_2_12e503d9_1725998273002_23711_212"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624035114787_488767_41423" name="isReference" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624035332885_579859_41485" annotatedElement="_19_0_4_12e503d9_1624035114787_488767_41423">
+            <body>&lt;p>Whether this &lt;code>Usage&lt;/code> is a referential &lt;code>Usage&lt;/code>, that is, it has &lt;code>isComposite = false&lt;/code>.&lt;p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1590979649160_380466_999" name="variant" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1590979649153_899215_998">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591028929478_204312_1044" annotatedElement="_19_0_2_12e503d9_1590979649160_380466_999">
+            <body>&lt;p>The &lt;code>Usages&lt;/code> which represent the variants of this &lt;code>Usage&lt;/code> as a variation point &lt;code>Usage&lt;/code>, if &lt;code>isVariation = true&lt;/code>. If &lt;code>isVariation = false&lt;/code>, then there must be no &lt;code>variants&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1590979687232_247785_1009" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1590979687232_258456_1010" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674979_259543_43268"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1590979136735_982171_914" name="variantMembership" visibility="public" type="_19_0_2_59601fc_1590331535985_437424_487" aggregation="composite" isDerived="true" association="_19_0_2_12e503d9_1590979136735_972734_913">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591029106636_443450_1046" annotatedElement="_19_0_2_12e503d9_1590979136735_982171_914">
+            <body>&lt;p>The &lt;code>ownedMemberships&lt;/code> of this &lt;code>Usage&lt;/code> that are &lt;code>VariantMemberships&lt;/code>. If &lt;code>isVariation = true&lt;/code>, then this must be all &lt;code>memberships&lt;/code> of the &lt;code>Usage&lt;/code>. If &lt;code>isVariation = false&lt;/code>, then &lt;code>variantMembership&lt;/code>must be empty.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1590979168044_723074_930" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1590979168045_101632_931" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674979_190614_43269"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565479686638_420576_23237" name="owningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" association="_18_5_3_12e503d9_1565479686637_851044_23235">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296461589_42540_428" annotatedElement="_18_5_3_12e503d9_1565479686638_420576_23237">
+            <body>&lt;p>The &lt;code>Definition&lt;/code> that owns this &lt;code>Usage&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565479757129_274216_23316" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565479757129_219935_23317" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_18876_27787"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565472757327_504924_21260" name="owningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_18_5_3_12e503d9_1565472757326_116408_21258">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296442665_492297_427" annotatedElement="_18_5_3_12e503d9_1565472757327_504924_21260">
+            <body>&lt;p>The &lt;code>Usage&lt;/code> in which this &lt;code>Usage&lt;/code> is nested (if any).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565472923109_343888_21295" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565472923109_658211_21296" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591477641252_179221_958" name="definition" visibility="public" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1591477641252_460789_957">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591478264932_899034_1002" annotatedElement="_19_0_2_12e503d9_1591477641252_179221_958">
+            <body>&lt;p>The &lt;code>Classifiers&lt;/code> that are the types of this &lt;code>Usage&lt;/code>. Nominally, these are &lt;code>Definitions&lt;/code>, but other kinds of Kernel &lt;code>Classifiers&lt;/code> are also allowed, to permit use of &lt;code>Classifiers&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651676_375105_42143"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591477788214_699190_983" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591477788214_445533_984" name="" visibility="public" value="*"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674969_376003_43216"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591217543254_26688_475" name="usage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1591217543246_373691_474">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591418565884_716862_2327" annotatedElement="_19_0_2_12e503d9_1591217543254_26688_475">
+            <body>&lt;p>The &lt;code>Usages&lt;/code> that are &lt;code>features&lt;/code> of this &lt;code>Usage&lt;/code> (not necessarily owned).&lt;/p></body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591218153242_169343_532">
+            <body></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591418568167_41211_2328" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591418568173_616535_2329" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_326391_43166"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591217699198_66279_508" name="directedUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1591217699198_172027_507">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591218191066_148091_534" annotatedElement="_19_0_2_12e503d9_1591217699198_66279_508">
+            <body>&lt;p>The &lt;code>usages&lt;/code> of this &lt;code>Usage&lt;/code> that are &lt;code>directedFeatures&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591418662939_383683_2344" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591418662942_467929_2345" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_4_12e503d9_1623952188842_882068_37169"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591217543254_26688_475"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565472757327_162097_21259" name="nestedUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isOrdered="true" isDerived="true" association="_18_5_3_12e503d9_1565472757326_116408_21258">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296394176_623985_426" annotatedElement="_18_5_3_12e503d9_1565472757327_162097_21259">
+            <body>&lt;p>The &lt;code>Usages&lt;/code> that are &lt;code>ownedFeatures&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565472809807_60899_21281" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565472809807_39288_21282" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_226999_43167"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591217543254_26688_475"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591477541360_47573_933" name="nestedReference" visibility="public" type="_19_0_2_12e503d9_1591477377905_618531_857" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_162097_21259" association="_19_0_2_12e503d9_1591477541360_347034_932">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1630352063270_483478_441" annotatedElement="_19_0_2_12e503d9_1591477541360_47573_933">
+            <body>&lt;p>The &lt;code>ReferenceUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591477626364_152439_949" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591477626364_987825_950" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591500785349_111324_4486" name="nestedAttribute" visibility="public" type="_18_5_3_12e503d9_1565471291545_950196_20762" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_162097_21259" association="_19_0_2_12e503d9_1591500785349_188308_4485">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591500880767_803376_4507" annotatedElement="_19_0_2_12e503d9_1591500785349_111324_4486">
+            <body>&lt;p>The code>AttributeUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591500851423_590287_4503" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591500851423_384822_4504" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1606946589000_158124_239" name="nestedEnumeration" visibility="public" type="_19_0_4_12e503d9_1606946489455_954016_180" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591500785349_111324_4486" association="_19_0_4_12e503d9_1606946589000_837456_238">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606948416542_790714_810" annotatedElement="_19_0_4_12e503d9_1606946589000_158124_239">
+            <body>&lt;p>The code>EnumerationUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606947420625_515568_545" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606947420626_705635_546" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1618943853976_48759_278" name="nestedOccurrence" visibility="public" type="_19_0_4_12e503d9_1618943737195_33207_138" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_162097_21259" association="_19_0_4_12e503d9_1618943853975_646579_277">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618946144115_877467_706" annotatedElement="_19_0_4_12e503d9_1618943853976_48759_278">
+            <body>&lt;p>The &lt;code>OccurrenceUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1618944329973_657887_454" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1618944329973_983_455" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591482421103_284620_2978" name="nestedItem" visibility="public" type="_18_5_3_12e503d9_1565480460114_846184_24270" isOrdered="true" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943853976_48759_278" association="_19_0_2_12e503d9_1591482421103_675608_2977">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591482533706_992991_2999" annotatedElement="_19_0_2_12e503d9_1591482421103_284620_2978">
+            <body>&lt;p>The &lt;code>ItemUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591482459023_385660_2994" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591482459024_441991_2995" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591496406876_479979_3188" name="nestedPart" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591482421103_284620_2978" association="_19_0_2_12e503d9_1591496406876_545820_3187">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591496596551_701392_3273" annotatedElement="_19_0_2_12e503d9_1591496406876_479979_3188">
+            <body>&lt;p>The &lt;code>PartUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591496452808_416954_3238" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591496452808_733951_3239" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565494459494_859367_26042" name="nestedPort" visibility="public" type="_18_5_3_12e503d9_1565492704639_896080_24992" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_162097_21259" association="_18_5_3_12e503d9_1565494459494_130172_26041">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296477406_281692_429" annotatedElement="_18_5_3_12e503d9_1565494459494_859367_26042">
+            <body>&lt;p>The &lt;code>PortUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565494487268_318386_26102" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565494487269_974479_26103" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591479754895_422988_1242" name="nestedConnection" visibility="public" type="_19_0_4_12e503d9_1624053320057_820842_471" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_162097_21259" association="_19_0_2_12e503d9_1591479754894_738711_1241">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591496994453_598649_3395" annotatedElement="_19_0_2_12e503d9_1591479754895_422988_1242">
+            <body>&lt;p>The &lt;code>ConnectorAsUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>. Note that this list includes &lt;code>BindingConnectorAsUsages&lt;/code>, &lt;code>SuccessionAsUsages&lt;/code>, and &lt;code>FlowUsages&lt;/code> because these are &lt;code>ConnectorAsUsages&lt;/code> even though they are not &lt;code>ConnectionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591479823064_400179_1258" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591479823064_907375_1259" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624054938718_124518_1464" name="nestedFlow" visibility="public" type="_19_0_4_12e503d9_1624054663096_771284_1274" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591479754895_422988_1242" association="_19_0_4_12e503d9_1624054938718_306944_1463">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624565201958_250225_8488" annotatedElement="_19_0_4_12e503d9_1624054938718_124518_1464">
+            <body>&lt;p>The code>FlowUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624054949397_551778_1474" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624054949398_1249_1475" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591498454569_383419_3839" name="nestedInterface" visibility="public" type="_18_5_3_12e503d9_1565498940266_617738_28508" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591479754895_422988_1242" association="_19_0_2_12e503d9_1591498454568_155125_3838">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591498523994_813293_3853" annotatedElement="_19_0_2_12e503d9_1591498454569_383419_3839">
+            <body>&lt;p>The &lt;code>InterfaceUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591498482539_152896_3849" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591498482540_535262_3850" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1611430983774_648557_1053" name="nestedAllocation" visibility="public" type="_19_0_4_12e503d9_1611430595314_523036_933" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591479754895_422988_1242" association="_19_0_4_12e503d9_1611430983773_757793_1052">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611591897234_255059_447" annotatedElement="_19_0_4_12e503d9_1611430983774_648557_1053">
+            <body>&lt;p>The &lt;code>AllocationUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1611431015178_841488_1063" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1611431015178_535602_1064" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565501745142_70952_31609" name="nestedAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isOrdered="true" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943853976_48759_278" association="_18_5_3_12e503d9_1565501745142_286049_31608">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296532240_795887_432" annotatedElement="_18_5_3_12e503d9_1565501745142_70952_31609">
+            <body>&lt;p>The &lt;code>ActionUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565502864684_407112_33234" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565502864684_197615_33235" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575587743891_973819_756" name="nestedState" visibility="public" type="_19_0_2_12e503d9_1575587557729_586912_651" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565501745142_70952_31609" association="_19_0_2_12e503d9_1575587743891_153996_755">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296538179_698632_433" annotatedElement="_19_0_2_12e503d9_1575587743891_973819_756">
+            <body>&lt;p>The &lt;code>StateUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575587845021_319752_842" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575587845021_257986_843" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1578597913303_768272_3894" name="nestedTransition" visibility="public" type="_19_0_2_12e503d9_1575672078353_626298_450" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_162097_21259" association="_19_0_2_12e503d9_1578597913303_376448_3893">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296555371_849678_435" annotatedElement="_19_0_2_12e503d9_1578597913303_768272_3894">
+            <body>&lt;p>The &lt;code>TransitionUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578597985716_245439_3904" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578597985717_302299_3905" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1588215112283_215964_632" name="nestedCalculation" visibility="public" type="_19_0_2_12e503d9_1588213258220_731107_146" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565501745142_70952_31609" association="_19_0_2_12e503d9_1588215112282_511532_630">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1588781900732_533111_3999" annotatedElement="_19_0_2_12e503d9_1588215112283_215964_632">
+            <body>&lt;p>The &lt;code>CalculationUsage&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1588215175761_20760_641" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1588215175762_308333_642" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1578067664051_434365_1774" name="nestedConstraint" visibility="public" type="_19_0_2_12e503d9_1578067096274_745288_1478" isOrdered="true" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943853976_48759_278" association="_19_0_2_12e503d9_1578067664051_864767_1773">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296545031_216314_434" annotatedElement="_19_0_2_12e503d9_1578067664051_434365_1774">
+            <body>&lt;p>The &lt;code>ConstraintUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578067913943_725852_1786" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578067913944_849366_1787" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583000447195_878123_1244" name="nestedRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1578067664051_434365_1774" association="_19_0_2_12e503d9_1583000447195_926306_1243">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586296621173_723827_436" annotatedElement="_19_0_2_12e503d9_1583000447195_878123_1244">
+            <body>&lt;p>The &lt;code>RequirementUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583000546433_216239_1262" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583000546433_761326_1263" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617051711833_106553_1460" name="nestedConcern" visibility="public" type="_19_0_4_12e503d9_1617051561652_163085_1288" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000447195_878123_1244" association="_19_0_4_12e503d9_1617051711833_91377_1459">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617058711069_275428_3204" annotatedElement="_19_0_4_12e503d9_1617051711833_106553_1460">
+            <body>&lt;p>The &lt;code>ConcernUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617051735715_46694_1496" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617051735716_84785_1497" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591135021853_494751_737" name="nestedCase" visibility="public" type="_19_0_2_59601fc_1590256077623_424527_107" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1588215112283_215964_632" association="_19_0_2_12e503d9_1591135021852_252283_735">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591415548318_541254_1692" annotatedElement="_19_0_2_12e503d9_1591135021853_494751_737">
+            <body>&lt;p>The &lt;code>CaseUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591482220069_620501_2949" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591482220070_544616_2950" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591152666850_226358_3749" name="nestedAnalysisCase" visibility="public" type="_19_0_2_59601fc_1590260225615_617039_1090" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591135021853_494751_737" association="_19_0_2_12e503d9_1591152666850_138654_3748">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591415910925_184794_1783" annotatedElement="_19_0_2_12e503d9_1591152666850_226358_3749">
+            <body>&lt;p>The &lt;code>AnalysisCaseUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591415824513_44772_1757" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591415824517_68604_1758" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596821592100_42801_10499" name="nestedVerificationCase" visibility="public" type="_19_0_2_12e503d9_1596821359347_71332_10236" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591135021853_494751_737" association="_19_0_2_12e503d9_1596821592100_512926_10498">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596822088241_574845_10761" annotatedElement="_19_0_2_12e503d9_1596821592100_42801_10499">
+            <body>&lt;p>The &lt;code>VerificationCaseUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596821600547_468104_10523" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596821600547_969943_10524" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621463992900_247262_1080" name="nestedUseCase" visibility="public" type="_19_0_4_12e503d9_1621460902507_609356_850" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591135021853_494751_737" association="_19_0_4_12e503d9_1621463992900_435759_1079">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621545676055_72679_1837" annotatedElement="_19_0_4_12e503d9_1621463992900_247262_1080">
+            <body>&lt;p>The &lt;code>UseCaseUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621464020442_814690_1116" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621464020445_906021_1117" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596644669126_858176_809" name="nestedView" visibility="public" type="_19_0_2_12e503d9_1596644366280_485907_701" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591496406876_479979_3188" association="_19_0_2_12e503d9_1596644669126_519561_808">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596746367471_377648_7063" annotatedElement="_19_0_2_12e503d9_1596644669126_858176_809">
+            <body>&lt;p>The &lt;code>ViewUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596644718386_827842_825" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596644718386_500266_826" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596649930212_443356_3818" name="nestedViewpoint" visibility="public" type="_19_0_2_59601fc_1583087291401_74297_590" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000447195_878123_1244" association="_19_0_2_12e503d9_1596649930212_263431_3817">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596747768398_439770_7079" annotatedElement="_19_0_2_12e503d9_1596649930212_443356_3818">
+            <body>&lt;p>The &lt;code>ViewpointUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596649945556_519292_3848" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596649945556_594600_3849" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596741501454_147708_6545" name="nestedRendering" visibility="public" type="_19_0_2_12e503d9_1596657138882_432286_4810" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591496406876_479979_3188" association="_19_0_2_12e503d9_1596741501454_644822_6544">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596748123393_281345_7090" annotatedElement="_19_0_2_12e503d9_1596741501454_147708_6545">
+            <body>&lt;p>The &lt;code>RenderingUsages&lt;/code> that are &lt;code>nestedUsages&lt;/code> of this &lt;code>Usage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596741521371_419979_6575" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596741521372_889190_6576" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1661488589862_120785_2970" name="nestedMetadata" visibility="public" type="_19_0_4_12e503d9_1645121476406_921183_398" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591482421103_284620_2978" association="_19_0_4_12e503d9_1661488589856_112722_2969">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661488860353_544025_3110" annotatedElement="_19_0_4_12e503d9_1661488589862_120785_2970">
+            <body>&lt;p>The &lt;code>MetadataUsages&lt;/code> that are &lt;code>ownedMembers&lt;/code> of this of this &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661488614125_113326_3006" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661488614145_60546_3007" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1590978312364_290951_421" name="isVariation" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591032014205_296490_29" annotatedElement="_19_0_2_12e503d9_1590978312364_290951_421">
+            <body>&lt;p>Whether this &lt;code>Usage&lt;/code> is for a variation point or not. If true, then all the &lt;code>memberships&lt;/code> of the &lt;code>Usage&lt;/code> must be &lt;code>VariantMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1617482356453_410307_26991" name="namingFeature" visibility="public" bodyCondition="_19_0_4_12e503d9_1617482998268_548525_27008">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617482839599_792050_27007" annotatedElement="_19_0_4_12e503d9_1617482356453_410307_26991">
+            <body>&lt;p>If this &lt;code>Usage&lt;/code> is a variant, then its naming &lt;code>Feature&lt;/code> is the &lt;code>referencedFeature&lt;/code> of its &lt;code>ownedReferenceSubsetting&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1617482998268_548525_27008" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1617482998270_21295_27009" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if not owningMembership.oclIsKindOf(VariantMembership) then
+    self.oclAsType(Feature).namingFeature()
+else if ownedReferenceSubsetting = null then null
+else ownedReferenceSubsetting.referencedFeature
+endif endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617482424397_200014_27004" name="" visibility="public" direction="return">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617482424398_846420_27005" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617482424399_371839_27006" name="" visibility="public" value="1"/>
+          </ownedParameter>
+          <redefinedOperation href="KerML_only_xmi.uml#_19_0_4_12e503d9_1617481077092_765416_26920"/>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1736982860062_429261_440" name="referencedFeatureTarget" visibility="public" bodyCondition="_2022x_2_12e503d9_1736982900893_338790_452">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736982938607_768027_458" annotatedElement="_2022x_2_12e503d9_1736982860062_429261_440">
+            <body>&lt;p>If &lt;code>ownedReferenceSubsetting&lt;/code> is not null, return the &lt;code>featureTarget&lt;/code> of the &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1736982900893_338790_452" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736982900893_616792_453" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if ownedReferenceSubsetting = null then null
+else ownedReferenceSubsetting.referencedFeature.featureTarget
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1736982879428_450471_445" name="" visibility="public" direction="return">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575587977045_646521_940" name="A_ownedState_stateOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1575587977045_745776_941 _19_0_2_12e503d9_1575587977054_272564_942">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1575587977054_272564_942" name="stateOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591479011613_883095_1092" association="_19_0_2_12e503d9_1575587977045_646521_940">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586383984142_665208_1012" annotatedElement="_19_0_2_12e503d9_1575587977054_272564_942">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedState&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575588046392_759105_1015" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575588046393_81395_1016" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575587743891_153996_755" name="A_nestedState_stateOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1575587743891_973819_756 _19_0_2_12e503d9_1575587743891_478973_757">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1575587743891_478973_757" name="stateOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1565501745143_149841_31610" association="_19_0_2_12e503d9_1575587743891_153996_755">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586383963633_328745_1011" annotatedElement="_19_0_2_12e503d9_1575587743891_478973_757">
+            <body>&lt;p>The Usage in which the &lt;code>nestedState&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575587784239_932163_788" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575587784241_711958_789" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1578067664051_864767_1773" name="A_nestedConstraint_constraintOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1578067664051_434365_1774 _19_0_2_12e503d9_1578067664052_609033_1775">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1578067664052_609033_1775" name="constraintOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943853976_291802_279" association="_19_0_2_12e503d9_1578067664051_864767_1773">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586295310932_99615_387" annotatedElement="_19_0_2_12e503d9_1578067664052_609033_1775">
+            <body>&lt;p>The Usage in which the &lt;code>nestedConstraint&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578067910727_502418_1782" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578067910727_268737_1783" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1578598061680_861031_3922" name="A_ownedTransition_transitionOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1578598061680_350995_3923 _19_0_2_12e503d9_1578598061681_273097_3924">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1578598061681_273097_3924" name="transitionOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686638_420576_23237" association="_19_0_2_12e503d9_1578598061680_861031_3922">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591500087507_844470_4326" annotatedElement="_19_0_2_12e503d9_1578598061681_273097_3924">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedTransition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578598142958_291640_3939" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578598142967_418761_3940" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1578068081991_875860_1802" name="A_ownedConstraint_constraintOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1578068081992_244000_1803 _19_0_2_12e503d9_1578068081992_386809_1804">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1578068081992_386809_1804" name="constraintOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943849505_862940_258" association="_19_0_2_12e503d9_1578068081991_875860_1802">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586295339912_578853_388" annotatedElement="_19_0_2_12e503d9_1578068081992_386809_1804">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedConstraint&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578068122530_479944_1813" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578068122537_793931_1814" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1578597913303_376448_3893" name="A_nestedTransition_transitionOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1578597913303_768272_3894 _19_0_2_12e503d9_1578597913303_653860_3895">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1578597913303_653860_3895" name="transitionOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_504924_21260" association="_19_0_2_12e503d9_1578597913303_376448_3893">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316262828_730231_826" annotatedElement="_19_0_2_12e503d9_1578597913303_653860_3895">
+            <body>&lt;p>The Usage in which the &lt;code>nestedTransition&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578598026174_745574_3910" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578598026174_724280_3911" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1583000559759_903126_1272" name="A_ownedRequirement_requirementOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1583000559760_444344_1273 _19_0_2_12e503d9_1583000559760_627975_1274">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1583000559760_627975_1274" name="requirementOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1578068081992_386809_1804" association="_19_0_2_12e503d9_1583000559759_903126_1272">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586302399640_978805_617" annotatedElement="_19_0_2_12e503d9_1583000559760_627975_1274">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedRequirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583000705257_708390_1293" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583000705257_857717_1294" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1583000447195_926306_1243" name="A_nestedRequirement_requirementOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1583000447195_878123_1244 _19_0_2_12e503d9_1583000447195_790733_1245">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1583000447195_790733_1245" name="requirementOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1578067664052_609033_1775" association="_19_0_2_12e503d9_1583000447195_926306_1243">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586302379341_561584_616" annotatedElement="_19_0_2_12e503d9_1583000447195_790733_1245">
+            <body>&lt;p>The Usage in which the &lt;code>nestedRequirement&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583000499717_157277_1254" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583000499717_221782_1255" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1591477377905_618531_857" name="ReferenceUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591477901865_956565_999" annotatedElement="_19_0_2_12e503d9_1591477377905_618531_857">
+          <body>&lt;p>A &lt;code>ReferenceUsage&lt;/code> is a &lt;code>Usage&lt;/code> that specifies a non-compositional (&lt;code>isComposite = false&lt;/code>) reference to something. The &lt;code>definition&lt;/code> of a &lt;code>ReferenceUsage&lt;/code> can be any kind of &lt;code>Classifier&lt;/code>, with the default being the top-level &lt;code>Classifier&lt;/code> &lt;code>&lt;em>Base::Anything&lt;/em>&lt;/code> from the Kernel Semantic Library. This allows the specification of a generic reference without distinguishing if the thing referenced is an attribute value, item, action, etc.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672157726426_590355_10" name="validateReferenceUsageIsReference" visibility="public" constrainedElement="_19_0_2_12e503d9_1591477377905_618531_857">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672157836380_153219_12" annotatedElement="_19_0_4_12e503d9_1672157726426_590355_10">
+            <body>&lt;p>A &lt;code>ReferenceUsage&lt;/code> is always referential.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672157726461_865487_11" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isReference</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1591477403277_550892_884" general="_18_5_3_12e503d9_1565469997820_598571_19982"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624035133434_200283_41434" name="isReference" visibility="public" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1624035114787_488767_41423">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624050648533_232994_26" annotatedElement="_19_0_4_12e503d9_1624035133434_200283_41434">
+            <body>&lt;p>Always &lt;code>true&lt;/code> for a &lt;code>ReferenceUsage&lt;/code>.&lt;/code></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralString" xmi:id="_19_0_4_12e503d9_1624035142403_45879_41438" name="" visibility="public" value="true"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1675362703021_649342_714" name="namingFeature" visibility="public" bodyCondition="_19_0_4_12e503d9_1675362703057_667907_715" redefinedOperation="_19_0_4_12e503d9_1617482356453_410307_26991">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675362703062_508724_717" annotatedElement="_19_0_4_12e503d9_1675362703021_649342_714">
+            <body>&lt;p>If this &lt;code>ReferenceUsage&lt;/code> is the &lt;em>&lt;code>payload&lt;/code>&lt;/em> &lt;code>parameter&lt;/code> of a &lt;code>TransitionUsage&lt;/code>, then its naming &lt;code>Feature&lt;/code> is the &lt;code>payloadParameter&lt;/code> of the &lt;code>triggerAction&lt;/code> of that &lt;code>TransitionUsage&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1675362703057_667907_715" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675362703064_938678_718" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if owningType &lt;> null and owningType.oclIsKindOf(TransitionUsage) and
+    owningType.oclAsType(TransitionUsage).inputParameter(2) = self then
+    owningType.oclAsType(TransitionUsage).triggerPayloadParameter()
+else self.oclAsType(Usage).namingFeature()
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1675362703059_290623_716" name="" visibility="public" direction="return">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1675362703071_62606_720" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1675362703069_3780_719" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1590979136735_972734_913" name="A_variantMembership_owningVariationUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1590979136735_982171_914 _19_0_2_12e503d9_1590979136742_640547_915">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1590979136742_640547_915" name="owningVariationUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1590979136735_972734_913">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591028332845_432303_1039" annotatedElement="_19_0_2_12e503d9_1590979136742_640547_915">
+            <body>&lt;p>The owning Definition of this VariantMembership, which must have &lt;code>isVariation&lt;/code> = true.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1590979156833_302111_924" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1590979156836_953471_925" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_193857_43197"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591482567975_432457_3004" name="A_ownedItem_itemOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1591482567975_649284_3005 _19_0_2_12e503d9_1591482567975_591411_3006">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591482567975_591411_3006" name="itemOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943849505_862940_258" association="_19_0_2_12e503d9_1591482567975_432457_3004">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1592273525069_386410_9854" annotatedElement="_19_0_2_12e503d9_1591482567975_591411_3006">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedItem&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591482618684_771970_3021" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591482618684_818232_3022" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591498454568_155125_3838" name="A_nestedInterface_interfaceOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1591498454569_383419_3839 _19_0_2_12e503d9_1591498454569_466298_3840">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591498454569_466298_3840" name="interfaceOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591479754895_542970_1243" association="_19_0_2_12e503d9_1591498454568_155125_3838">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591498585285_307949_3860" annotatedElement="_19_0_2_12e503d9_1591498454569_466298_3840">
+            <body>&lt;p>The Usage in which the &lt;code>nestedInterface&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591498551229_26194_3856" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591498551229_692348_3857" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591477541360_347034_932" name="A_nestedReference_referenceOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1591477541360_47573_933 _19_0_2_12e503d9_1591477541361_825733_934">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591477541361_825733_934" name="referenceOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_504924_21260" association="_19_0_2_12e503d9_1591477541360_347034_932">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591481778410_430613_2901" annotatedElement="_19_0_2_12e503d9_1591477541361_825733_934">
+            <body>&lt;p>The Usage that owns the &lt;code>nestedReference&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591477584819_156439_943" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591477584819_925821_944" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591152747086_72134_3845" name="A_analysisCaseOwningDefinition_ownedAnalysisCase" visibility="public" memberEnd="_19_0_2_12e503d9_1591152747087_455217_3847 _19_0_2_12e503d9_1591152747086_367030_3846">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591152747087_455217_3847" name="analysisCaseOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_59601fc_1590257108056_85484_484" association="_19_0_2_12e503d9_1591152747086_72134_3845">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591415663115_347963_1711" annotatedElement="_19_0_2_12e503d9_1591152747087_455217_3847">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedAnalysisCase&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591415620215_69876_1705" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591415620215_492744_1706" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591217543246_373691_474" name="A_featuringUsage_usage" visibility="public" memberEnd="_19_0_2_12e503d9_1591217543255_292723_476 _19_0_2_12e503d9_1591217543254_26688_475">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591217543255_292723_476" name="featuringUsage" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1591217543246_373691_474">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591218167491_769486_533" annotatedElement="_19_0_2_12e503d9_1591217543255_292723_476">
+            <body>&lt;p>The Usages that feature a certain Usage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591418621574_361807_2336" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591418621574_899347_2337" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674987_297074_43308"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591496643391_102309_3278" name="A_ownedPart_partOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1591496643392_630316_3279 _19_0_2_12e503d9_1591496643392_535546_3280">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591496643392_535546_3280" name="partOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591482567975_591411_3006" association="_19_0_2_12e503d9_1591496643391_102309_3278">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591496904838_720010_3392" annotatedElement="_19_0_2_12e503d9_1591496643392_535546_3280">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedPart&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591496714159_234995_3291" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591496714160_79714_3292" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591217699198_172027_507" name="A_directedUsage_usageWithDirectedUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1591217699198_66279_508 _19_0_2_12e503d9_1591217699205_439156_509">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591217699205_439156_509" name="usageWithDirectedUsage" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1591217699198_172027_507">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591418807709_746894_2362" annotatedElement="_19_0_2_12e503d9_1591217699205_439156_509">
+            <body>&lt;p>The Usages that have a certain Usage as a &lt;code>flow&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591218261633_49283_535">
+            <body></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591418756281_685073_2354" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591418756284_768620_2355" name="" visibility="public" value="*"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591217543255_292723_476"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_4_12e503d9_1623952188842_831269_37170"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591152666850_138654_3748" name="A_analysisCaseOwningUsage_nestedAnalysisCase" visibility="public" memberEnd="_19_0_2_12e503d9_1591152666851_415343_3750 _19_0_2_12e503d9_1591152666850_226358_3749">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591152666851_415343_3750" name="analysisCaseOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591152666851_415343_3750" association="_19_0_2_12e503d9_1591152666850_138654_3748">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591415932991_31999_1786" annotatedElement="_19_0_2_12e503d9_1591152666851_415343_3750">
+            <body>&lt;p>The Usage in which the &lt;code>nestedAnalysisCase&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591415846761_459937_1763" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591415846762_906623_1764" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591498709150_699835_4127" name="A_ownedInterface_interfaceOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1591498709150_220812_4128 _19_0_2_12e503d9_1591498709150_625235_4129">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591498709150_625235_4129" name="interfaceOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591480607506_817896_2334" association="_19_0_2_12e503d9_1591498709150_699835_4127">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591498840172_894881_4210" annotatedElement="_19_0_2_12e503d9_1591498709150_625235_4129">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedInterface&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591498787733_377003_4192" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591498787733_844157_4193" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1590979457191_749355_950" name="A_variant_owningVariationDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1590979457191_746167_951 _19_0_2_12e503d9_1590979457198_529180_952">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1590979457198_529180_952" name="owningVariationDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" association="_19_0_2_12e503d9_1590979457191_749355_950">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591029733629_876265_1049" annotatedElement="_19_0_2_12e503d9_1590979457198_529180_952">
+            <body>&lt;p>The variation point Definition that for which this Usage represents a variant, derived as the &lt;code>owningVariationDefinition&lt;/code> of the &lt;code>owningVariantMembership&lt;/code> of the Usage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1590979492107_380111_961" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1590979492107_997641_962" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674986_474739_43306"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591477471991_678008_907" name="A_ownedReference_referenceOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1591477471991_39731_908 _19_0_2_12e503d9_1591477471991_359426_909">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591477471991_359426_909" name="referenceOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686638_420576_23237" association="_19_0_2_12e503d9_1591477471991_678008_907">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591481693149_793302_2899" annotatedElement="_19_0_2_12e503d9_1591477471991_359426_909">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedReference&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591477526175_550608_924" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591477526175_81102_925" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591482421103_675608_2977" name="A_nestedItem_itemOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1591482421103_284620_2978 _19_0_2_12e503d9_1591482421103_503614_2979">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591482421103_503614_2979" name="itemOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943853976_291802_279" association="_19_0_2_12e503d9_1591482421103_675608_2977">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591482494264_536644_2998" annotatedElement="_19_0_2_12e503d9_1591482421103_503614_2979">
+            <body>&lt;p>The Usage in which the &lt;code>nestedItem&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591482456257_305948_2990" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591482456258_488486_2991" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591479011612_753775_1090" name="A_ownedAction_actionOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1591479011613_547927_1091 _19_0_2_12e503d9_1591479011613_883095_1092">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591479011613_883095_1092" name="actionOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943849505_862940_258" association="_19_0_2_12e503d9_1591479011612_753775_1090">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591479176507_332789_1116" annotatedElement="_19_0_2_12e503d9_1591479011613_883095_1092">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedAction&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591479053966_96753_1101" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591479053966_78564_1102" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591496406876_545820_3187" name="A_nestedPart_partOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1591496406876_479979_3188 _19_0_2_12e503d9_1591496406877_994044_3189">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591496406877_994044_3189" name="partOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591482421103_503614_2979" association="_19_0_2_12e503d9_1591496406876_545820_3187">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591496515830_922109_3260" annotatedElement="_19_0_2_12e503d9_1591496406877_994044_3189">
+            <body>&lt;p>The Usage in which the &lt;code>nestedPart&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591496434278_324793_3218" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591496434278_741246_3219" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591479754894_738711_1241" name="A_nestedConnection_connectionOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1591479754895_422988_1242 _19_0_2_12e503d9_1591479754895_542970_1243">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591479754895_542970_1243" name="connectionOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591496406877_994044_3189" association="_19_0_2_12e503d9_1591479754894_738711_1241">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591497023272_322674_3396" annotatedElement="_19_0_2_12e503d9_1591479754895_542970_1243">
+            <body>&lt;p>The Usage in which the &lt;code>nestedUsage&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591479803001_419043_1252" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591479803001_35512_1253" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1590979649153_899215_998" name="A_variant_owningVariationUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1590979649160_380466_999 _19_0_2_12e503d9_1590979649160_288132_1000">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1590979649160_288132_1000" name="owningVariationUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1590979649153_899215_998">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591028775063_659396_1042" annotatedElement="_19_0_2_12e503d9_1590979649160_288132_1000">
+            <body>&lt;p>The variation point Usage that for which this Usage represents a variant, derived as the &lt;code>owningVariationUsage&lt;/code> of the &lt;code>owningVariantMembership&lt;/code> of the Usage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1590979718406_639863_1015" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1590979718406_785942_1016" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674986_474739_43306"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591500785349_188308_4485" name="A_nestedAttribute_attributeOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1591500785349_111324_4486 _19_0_2_12e503d9_1591500785350_975154_4487">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591500785350_975154_4487" name="attributeOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_504924_21260" association="_19_0_2_12e503d9_1591500785349_188308_4485">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591500837123_49241_4500" annotatedElement="_19_0_2_12e503d9_1591500785350_975154_4487">
+            <body>&lt;p>The Usage in which the &lt;code>nestedAttribute&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591500805630_157917_4496" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591500805631_983479_4497" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591500614097_792385_4412" name="A_ownedAttribute_attributeOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1591500614097_490259_4413 _19_0_2_12e503d9_1591500614097_88285_4414">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591500614097_88285_4414" name="attributeOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686638_420576_23237" association="_19_0_2_12e503d9_1591500614097_792385_4412">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591500689740_525704_4433" annotatedElement="_19_0_2_12e503d9_1591500614097_88285_4414">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedAttribute&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591500633156_586168_4423" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591500633156_413959_4424" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591477641252_460789_957" name="A_definition_definedUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1591477641252_179221_958 _19_0_2_12e503d9_1591477641253_520897_959">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591477641253_520897_959" name="definedUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1591477641252_460789_957">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591478363260_204823_1003" annotatedElement="_19_0_2_12e503d9_1591477641253_520897_959">
+            <body>&lt;p>The Usages that have a certain Classifier as a &lt;code>definition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591477815211_16842_991" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591477815212_391442_992" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674973_102139_43242"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591480607505_321093_2332" name="A_ownedConnection_connectionOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1591480607506_951212_2333 _19_0_2_12e503d9_1591480607506_817896_2334">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591480607506_817896_2334" name="connectionOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591496643392_535546_3280" association="_19_0_2_12e503d9_1591480607505_321093_2332">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591497131875_802846_3425" annotatedElement="_19_0_2_12e503d9_1591480607506_817896_2334">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedConnection&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591480648404_937538_2383" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591480648405_723868_2384" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_59601fc_1590257108054_193596_482" name="A_caseOwningDefinition_ownedCase" visibility="public" memberEnd="_19_0_2_59601fc_1590257108056_85484_484 _19_0_2_59601fc_1590257108055_7496_483">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591415276681_957187_1639" annotatedElement="_19_0_2_59601fc_1590257108054_193596_482">
+          <body>&lt;p>The Definition that owns this CaseUsage (if any).&lt;/p></body>
+        </ownedComment>
+        <ownedEnd xmi:id="_19_0_2_59601fc_1590257108056_85484_484" name="caseOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1588215335103_850314_666" association="_19_0_2_59601fc_1590257108054_193596_482">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591482147464_476660_2916" annotatedElement="_19_0_2_59601fc_1590257108056_85484_484">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedCase&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591415301979_466617_1642" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591415301985_501162_1643" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_59601fc_1590331535985_437424_487" name="VariantMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591025096649_764174_1033" annotatedElement="_19_0_2_59601fc_1590331535985_437424_487">
+          <body>&lt;p>A &lt;code>VariantMembership&lt;/code> is a &lt;code>Membership&lt;/code> between a variation point &lt;code>Definition&lt;/code> or &lt;code>Usage&lt;/code> and a &lt;code>Usage&lt;/code> that represents a variant in the context of that variation. The &lt;code>membershipOwningNamespace&lt;/code> for the &lt;code>VariantMembership&lt;/code> must be either a Definition or a &lt;code>Usage&lt;/code> with &lt;code>isVariation = true&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676636603851_765641_466" name="validateVariantMembershipOwningNamespace" visibility="public" constrainedElement="_19_0_2_59601fc_1590331535985_437424_487">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676636759249_743170_470" annotatedElement="_19_0_4_12e503d9_1676636603851_765641_466">
+            <body>&lt;p>The &lt;code>membershipOwningNamespace&lt;/code> of a &lt;code>VariantMembership&lt;/code> must be a variation-point &lt;code>Definition&lt;/code> or &lt;code>Usage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676636603874_246282_467" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>membershipOwningNamespace.oclIsKindOf(Definition) and
+    membershipOwningNamespace.oclAsType(Definition).isVariation or
+membershipOwningNamespace.oclIsKindOf(Usage) and
+    membershipOwningNamespace.oclAsType(Usage).isVariation
+</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1590978431197_974078_477">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_12e503d9_1648180804650_933390_31"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1590978683452_645414_775" name="ownedVariantUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" aggregation="composite" isDerived="true" association="_19_0_2_12e503d9_1590978683451_485149_774">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591028476317_984342_1040" annotatedElement="_19_0_2_12e503d9_1590978683452_645414_775">
+            <body>&lt;p>The &lt;code>Usage&lt;/code> that represents a variant in the context of the &lt;code>owningVariationDefinition&lt;/code> or &lt;code>owningVariationUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1590978726524_26426_787" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1590978726535_343844_788" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_501750_43196"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1590978683451_485149_774" name="A_ownedVariantUsage_owningVariantMembership" visibility="public" memberEnd="_19_0_2_12e503d9_1590978683452_645414_775 _19_0_2_12e503d9_1590978683453_307739_776">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1590978683453_307739_776" name="owningVariantMembership" visibility="public" type="_19_0_2_59601fc_1590331535985_437424_487" isDerived="true" association="_19_0_2_12e503d9_1590978683451_485149_774">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591030702255_840600_1054" annotatedElement="_19_0_2_12e503d9_1590978683453_307739_776">
+            <body>&lt;p>The VariantMembership that owns this Usage, if the Usage represents a variant in the context of some variation point Definition or Usage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1590978735634_178073_793" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1590978735634_789441_794" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674972_622493_43236"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1590979005861_392013_893" name="A_variantMembership_owningVariationDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1590979005861_503124_894 _19_0_2_12e503d9_1590979005862_743940_895">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1590979005862_743940_895" name="owningVariationDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" association="_19_0_2_12e503d9_1590979005861_392013_893">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591028053509_974739_1038" annotatedElement="_19_0_2_12e503d9_1590979005862_743940_895">
+            <body>&lt;p>The owning Definition of this VariantMembership, which must have &lt;code>isVariation&lt;/code> = true.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1590979065249_959957_904" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1590979065252_300602_905" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_193857_43197"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596821592100_512926_10498" name="A_nestedVerificationCase_verificationCaseOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1596821592100_42801_10499 _19_0_2_12e503d9_1596821592101_525737_10500">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596821592101_525737_10500" name="verificationCaseOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591135021852_369550_736" association="_19_0_2_12e503d9_1596821592100_512926_10498">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596822149478_929051_10763" annotatedElement="_19_0_2_12e503d9_1596821592101_525737_10500">
+            <body>&lt;p>The Usage that owns a certain &lt;code>nestedVerificationCase&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596821623753_199330_10537" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596821623783_627332_10538" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596649930212_263431_3817" name="A_nestedViewpoint_viewpointOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1596649930212_443356_3818 _19_0_2_12e503d9_1596649930213_42653_3819">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596649930213_42653_3819" name="viewpointOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000447195_790733_1245" association="_19_0_2_12e503d9_1596649930212_263431_3817">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596747816485_656600_7080" annotatedElement="_19_0_2_12e503d9_1596649930213_42653_3819">
+            <body>&lt;p>The Usage that owns a certain &lt;code>nestedViewpoint&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596649999237_562184_3898" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596649999237_854284_3899" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596644570381_245644_783" name="A_ownedView_viewOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1596644570381_840567_784 _19_0_2_12e503d9_1596644570381_727814_785">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596644570381_727814_785" name="viewOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591496643392_535546_3280" association="_19_0_2_12e503d9_1596644570381_245644_783">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596746312051_813143_7061" annotatedElement="_19_0_2_12e503d9_1596644570381_727814_785">
+            <body>&lt;p>The Definition that owns a certain &lt;code>ownedView&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596644660670_29668_800" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596644660670_744639_801" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596741437224_790949_6473" name="A_ownedRendering_redenderingOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1596741437225_963350_6474 _19_0_2_12e503d9_1596741437225_905773_6475">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596741437225_905773_6475" name="redenderingOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591496643392_535546_3280" association="_19_0_2_12e503d9_1596741437224_790949_6473">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596748075614_527824_7088" annotatedElement="_19_0_2_12e503d9_1596741437225_905773_6475">
+            <body>&lt;p>The Definition that owns a certain &lt;code>ownedRendering&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596741489541_131861_6526" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596741489541_644212_6527" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596649828408_543464_3682" name="A_ownedViewpoint_viewpointOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1596649828408_673531_3683 _19_0_2_12e503d9_1596649828409_760756_3684">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596649828409_760756_3684" name="viewpointOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000559760_627975_1274" association="_19_0_2_12e503d9_1596649828408_543464_3682">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596747731877_656595_7077" annotatedElement="_19_0_2_12e503d9_1596649828409_760756_3684">
+            <body>&lt;p>The Definition that owns a certain &lt;code>ownedViewpoint&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596649883450_352061_3755" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596649883450_827677_3756" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596741501454_644822_6544" name="A_nestedRendering_renderingOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1596741501454_147708_6545 _19_0_2_12e503d9_1596741501455_451430_6546">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596741501455_451430_6546" name="renderingOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591496406877_994044_3189" association="_19_0_2_12e503d9_1596741501454_644822_6544">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596748098177_361828_7089" annotatedElement="_19_0_2_12e503d9_1596741501455_451430_6546">
+            <body>&lt;p>The Usage that owns a certain &lt;code>nestedRendering&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596741540819_290467_6593" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596741540819_56314_6594" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596821523387_661403_10415" name="A_ownedVerificationCase_verificationCaseOwningDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1596821523387_872104_10416 _19_0_2_12e503d9_1596821523387_448351_10417">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596821523387_448351_10417" name="verificationCaseOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_59601fc_1590257108056_85484_484" association="_19_0_2_12e503d9_1596821523387_661403_10415">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596822120830_278168_10762" annotatedElement="_19_0_2_12e503d9_1596821523387_448351_10417">
+            <body>&lt;p>The Definition that owns a certain &lt;code>ownedVerificationCase&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596821576722_884864_10472" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596821576723_844118_10473" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596644669126_519561_808" name="A_nestedView_viewOwningUsage" visibility="public" memberEnd="_19_0_2_12e503d9_1596644669126_858176_809 _19_0_2_12e503d9_1596644669127_979804_810">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596644669127_979804_810" name="viewOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591496406877_994044_3189" association="_19_0_2_12e503d9_1596644669126_519561_808">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596746319985_893736_7062" annotatedElement="_19_0_2_12e503d9_1596644669127_979804_810">
+            <body>&lt;p>The Usage that owns a certain &lt;code>nestedView&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596644700546_413064_819" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596644700547_114282_820" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1606946600508_742209_251" name="A_ownedEnumeration_enumerationOwningDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1606946600508_763872_252 _19_0_4_12e503d9_1606946600508_251485_253">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1606946600508_251485_253" name="enumerationOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591500614097_88285_4414" association="_19_0_4_12e503d9_1606946600508_742209_251">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606948290166_316744_808" annotatedElement="_19_0_4_12e503d9_1606946600508_251485_253">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedEnumeration&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606947346810_216295_485" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606947346810_668898_486" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1606946589000_837456_238" name="A_nestedEnumeration_enumerationOwningUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1606946589000_158124_239 _19_0_4_12e503d9_1606946589002_952461_240">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1606946589002_952461_240" name="enumerationOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591500785350_975154_4487" association="_19_0_4_12e503d9_1606946589000_837456_238">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606948447390_61833_811" annotatedElement="_19_0_4_12e503d9_1606946589002_952461_240">
+            <body>&lt;p>The Usage that owns the &lt;code>nestedEnumeration&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606947415877_432316_541" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606947415877_519718_542" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1611430819239_130472_1023" name="A_ownedAllocation_allocationOwningDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1611430819239_430196_1024 _19_0_4_12e503d9_1611430819239_347088_1025">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1611430819239_347088_1025" name="allocationOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" subsettedProperty="_19_0_2_12e503d9_1591480607506_817896_2334" association="_19_0_4_12e503d9_1611430819239_130472_1023">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611629810159_673790_452" annotatedElement="_19_0_4_12e503d9_1611430819239_347088_1025">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedAllocation&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1611430868120_499765_1040" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1611430868126_969632_1041" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1611430983773_757793_1052" name="A_nestedAllocation_allocationOwningUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1611430983774_648557_1053 _19_0_4_12e503d9_1611430983774_211403_1054">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1611430983774_211403_1054" name="allocationOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591479754895_542970_1243" association="_19_0_4_12e503d9_1611430983773_757793_1052">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611629824964_116853_453" annotatedElement="_19_0_4_12e503d9_1611430983774_211403_1054">
+            <body>&lt;p>The Usage that owns the &lt;code>nestedAllocation&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1611431039585_493947_1069" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1611431039591_903481_1070" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617051711833_91377_1459" name="A_nestedConcern_concernOwningUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1617051711833_106553_1460 _19_0_4_12e503d9_1617051711834_250531_1461">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617051711834_250531_1461" name="concernOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000447195_790733_1245" association="_19_0_4_12e503d9_1617051711833_91377_1459">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617058743541_815782_3205" annotatedElement="_19_0_4_12e503d9_1617051711834_250531_1461">
+            <body>&lt;p>The Usage that owns the &lt;code>nestedConcern&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617051772789_301403_1532" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617051772790_576806_1533" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617051597354_65575_1356" name="A_ownedConcern_concernOwningDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1617051597354_928367_1357 _19_0_4_12e503d9_1617051597355_220907_1358">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617051597355_220907_1358" name="concernOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000559760_627975_1274" association="_19_0_4_12e503d9_1617051597354_65575_1356">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617054155260_291637_3156" annotatedElement="_19_0_4_12e503d9_1617051597355_220907_1358">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedConcern&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617051688623_431572_1431" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617051688624_755516_1432" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1618943849504_625746_256" name="A_ownedOccurrence_occurrenceOwningDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1618943849505_989631_257 _19_0_4_12e503d9_1618943849505_862940_258">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1618943849505_862940_258" name="occurrenceOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686638_420576_23237" association="_19_0_4_12e503d9_1618943849504_625746_256">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618946124799_987224_705" annotatedElement="_19_0_4_12e503d9_1618943849505_862940_258">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedOccurrence&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1618944384806_737372_504" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1618944384806_186703_505" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1618943853975_646579_277" name="A_nestedOccurrence_occurrenceOwningUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1618943853976_48759_278 _19_0_4_12e503d9_1618943853976_291802_279">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1618943853976_291802_279" name="occurrenceOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_504924_21260" association="_19_0_4_12e503d9_1618943853975_646579_277">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618946172499_384015_707" annotatedElement="_19_0_4_12e503d9_1618943853976_291802_279">
+            <body>&lt;p>The Usage in which the &lt;code>nestedOccurrence&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1618944333877_380603_458" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1618944333877_512144_459" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624054938718_306944_1463" name="A_nestedFlow_flowOwningUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1624054938718_124518_1464 _19_0_4_12e503d9_1624054938719_335170_1465">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624054938719_335170_1465" name="flowOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591479754895_542970_1243" association="_19_0_4_12e503d9_1624054938718_306944_1463">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624565261315_704586_8491" annotatedElement="_19_0_4_12e503d9_1624054938719_335170_1465">
+            <body>&lt;p>The &lt;code>Usage&lt;/code> that owns the &lt;code>nestedFlow&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624055109230_113959_1598" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624055109231_589905_1599" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621463992900_435759_1079" name="A_nestedUseCase_useCaseOwningUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1621463992900_247262_1080 _19_0_4_12e503d9_1621463992900_754204_1081">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621463992900_754204_1081" name="useCaseOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591135021852_369550_736" association="_19_0_4_12e503d9_1621463992900_435759_1079">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621545707128_874115_1838" annotatedElement="_19_0_4_12e503d9_1621463992900_754204_1081">
+            <body>&lt;p>The Usage in which the &lt;code>nestedUseCase&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621464040709_800953_1136" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621464040710_488931_1137" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624055201422_339748_1696" name="A_ownedFlow_flowOwningDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1624055201422_104863_1697 _19_0_4_12e503d9_1624055201422_100581_1698">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624055201422_100581_1698" name="flowOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591480607506_817896_2334" association="_19_0_4_12e503d9_1624055201422_339748_1696">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624565208213_543051_8489" annotatedElement="_19_0_4_12e503d9_1624055201422_100581_1698">
+            <body>&lt;p>The &lt;code>Definition&lt;/code> that owns the &lt;code>ownedFlow&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624055261254_581671_1755" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624055261255_979881_1756" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621461106608_639383_944" name="A_ownedUseCase_useCaseOwningDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1621461106608_978605_945 _19_0_4_12e503d9_1621461106609_756767_946">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621461106609_756767_946" name="useCaseOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_59601fc_1590257108056_85484_484" association="_19_0_4_12e503d9_1621461106608_639383_944">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621545645786_272656_1836" annotatedElement="_19_0_4_12e503d9_1621461106609_756767_946">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedUseCase&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621463953939_951750_1059" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621463953951_78030_1060" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1661488589856_112722_2969" name="A_nestedMetadata_metadataOwningUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1661488589862_120785_2970 _19_0_4_12e503d9_1661488589873_575490_2971">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1661488589873_575490_2971" name="metadataOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591482421103_503614_2979" association="_19_0_4_12e503d9_1661488589856_112722_2969">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661488836803_662449_3109" annotatedElement="_19_0_4_12e503d9_1661488589873_575490_2971">
+            <body>&lt;p>The Usage in which the &lt;code>nestedMetadata&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661488639667_847215_3024" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661488639685_625704_3025" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1661488358056_692573_2880" name="A_ownedMetadata_metadataOwningDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1661488358064_457109_2881 _19_0_4_12e503d9_1661488358074_815063_2882">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1661488358074_815063_2882" name="metadataOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591482567975_591411_3006" association="_19_0_4_12e503d9_1661488358056_692573_2880">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661488790708_606104_3106" annotatedElement="_19_0_4_12e503d9_1661488358074_815063_2882">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedMetadata&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661488422474_956064_2891" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661488422496_695947_2892" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1565469611055_32565_19814" name="Parts" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565469626440_455154_19856" name="PartDefinition" visibility="public">
+        <ownedComment xmi:id="_18_5_3_12e503d9_1565469989823_120173_19980" annotatedElement="_18_5_3_12e503d9_1565469626440_455154_19856">
+          <body>&lt;p>A &lt;code>PartDefinition&lt;/code> is an &lt;code>ItemDefinition&lt;/code> of a &lt;code>Class&lt;/code> of systems or parts of systems. Note that all parts may be considered items for certain purposes, but not all items are parts that can perform actions within a system.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672605624341_18481_373" name="checkPartDefinitionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565469626440_455154_19856">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676644328979_920559_504" annotatedElement="_19_0_4_12e503d9_1672605624341_18481_373">
+            <body>&lt;/p>A &lt;code>PartDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>PartDefinition&lt;/code> &lt;em>&lt;code>Parts::Part&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672605624363_67979_374" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Parts::Part')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565479794676_465414_23372" general="_19_0_2_12e503d9_1591216581238_805702_84"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565471239590_312157_20701" name="PartUsage" visibility="public">
+        <ownedComment xmi:id="_18_5_3_12e503d9_1565472041345_730568_21023" annotatedElement="_18_5_3_12e503d9_1565471239590_312157_20701">
+          <body>&lt;p>A &lt;code>PartUsage&lt;/code> is a usage of a &lt;code>PartDefinition&lt;/code> to represent a system or a part of a system. At least one of the &lt;code>itemDefinitions&lt;/code> of the &lt;code>PartUsage&lt;/code> must be a &lt;code>PartDefinition&lt;/code>.&lt;/p>
+
+&lt;p>A &lt;code>PartUsage&lt;/code> must subset, directly or indirectly, the base &lt;code>PartUsage&lt;/code> &lt;em>&lt;code>parts&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672605782996_164378_375" name="derivePartUsagePartDefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1565471239590_312157_20701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672605867510_658050_377" annotatedElement="_19_0_4_12e503d9_1672605782996_164378_375">
+            <body>&lt;p>The &lt;code>partDefinitions&lt;/code> of an &lt;code>PartUsage&lt;/code> are those &lt;code>itemDefinitions&lt;/code> that are &lt;code>PartDefinitions&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672605783007_283213_376" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>itemDefinition->selectByKind(PartDefinition)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672605876297_33555_378" name="validatePartUsagePartDefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1565471239590_312157_20701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672605962952_915820_380" annotatedElement="_19_0_4_12e503d9_1672605876297_33555_378">
+            <body>&lt;p>At least one of the &lt;code>itemDefinitions&lt;/code> of a &lt;code>PartUsage&lt;/code> must be a &lt;code>PartDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672605876303_273212_379" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>partDefinition->notEmpty()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672605977033_130454_381" name="checkPartUsageSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565471239590_312157_20701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672606055072_515729_383" annotatedElement="_19_0_4_12e503d9_1672605977033_130454_381">
+            <body>&lt;p>A &lt;code>PartUsage&lt;/code> must directly or indirectly specialize the &lt;code>PartUsage&lt;/code> &lt;em>&lt;code>Parts::parts&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672605977041_480237_382" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Parts::parts')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672606059199_164034_384" name="checkPartUsageSubpartSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565471239590_312157_20701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676644414389_440953_505" annotatedElement="_19_0_4_12e503d9_1672606059199_164034_384">
+            <body>&lt;p>A composite &lt;code>PartUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>ItemDefinition&lt;/code> or &lt;code>ItemUsage&lt;/code> must directly or indirectly specialize the  &lt;code>PartUsage&lt;/code> &lt;em>&lt;code>Items::Item::subparts&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672606059203_291285_385" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(ItemDefinition) or
+ owningType.oclIsKindOf(ItemUsage)) implies
+    specializesFromLibrary('Items::Item::subparts')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676733301934_322638_834" name="checkPartUsageActorSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565471239590_312157_20701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676733682358_637329_836" annotatedElement="_19_0_4_12e503d9_1676733301934_322638_834">
+            <body>&lt;p>If a &lt;code>PartUsage&lt;/code> is owned via an &lt;code>ActorMembership&lt;/code>, then it must directly or indirectly specialize either &lt;code>&lt;em>Requirements::RequirementCheck::actors&lt;/em>&lt;/code> (if its &lt;code>owningType&lt;/code> is a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code> or &lt;code>&lt;em>Cases::Case::actors&lt;/em>&lt;/code> (otherwise).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676733301938_933652_835" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningFeatureMembership &lt;> null and
+owningFeatureMembership.oclIsKindOf(ActorMembership) implies
+    if owningType.oclIsKindOf(RequirementDefinition) or 
+       owningType.oclIsKindOf(RequirementUsage)
+    then specializesFromLibrary('Requirements::RequirementCheck::actors')
+    else specializesFromLibrary('Cases::Case::actors')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676733686890_118453_837" name="checkPartUsageStakeholderSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565471239590_312157_20701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676733724126_99385_839" annotatedElement="_19_0_4_12e503d9_1676733686890_118453_837">
+            <body>&lt;p>If a &lt;code>PartUsage&lt;/code> is owned via a &lt;code>StakeholderMembership&lt;/code>, then it must directly or indirectly specialize &lt;code>&lt;em>Requirements::RequirementCheck::stakeholders&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676733686900_890635_838" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningFeatureMembership &lt;> null and
+owningFeatureMembership.oclIsKindOf(StakeholderMembership) implies
+    specializesFromLibrary('Requirements::RequirementCheck::stakeholders')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565471250133_154794_20729" general="_18_5_3_12e503d9_1565480460114_846184_24270"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591475180488_929065_121" name="partDefinition" visibility="public" type="_18_5_3_12e503d9_1565469626440_455154_19856" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565471361757_649736_20796" association="_19_0_2_12e503d9_1591475180487_926646_120">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591475377792_330897_147" annotatedElement="_19_0_2_12e503d9_1591475180488_929065_121">
+            <body>&lt;p>The &lt;code>itemDefinitions&lt;/code> of this PartUsage that are PartDefinitions.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591475193380_499478_131" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591475193381_792021_132" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591475180487_926646_120" name="A_partDefinition_definedPart" visibility="public" memberEnd="_19_0_2_12e503d9_1591475180488_929065_121 _19_0_2_12e503d9_1591475180488_240858_122">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591475180488_240858_122" name="definedPart" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565471361757_611715_20797" association="_19_0_2_12e503d9_1591475180487_926646_120">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591476227103_582947_676" annotatedElement="_19_0_2_12e503d9_1591475180488_240858_122">
+            <body>&lt;p>The PartUsages typed by a certain PartDefinition.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591475206596_620898_137" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591475206596_597077_138" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_18_5_3_12e503d9_1565495814752_934068_26285" name="Interfaces" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565496234915_213431_26663" name="A_interfaceEnd_interfaceDefinitionWithEnd" visibility="public" memberEnd="_18_5_3_12e503d9_1565496234915_779221_26664 _18_5_3_12e503d9_1565496234915_937829_26665">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565496234915_937829_26665" name="interfaceDefinitionWithEnd" visibility="public" type="_18_5_3_12e503d9_1565496029896_966800_26573" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591476421095_594435_683" association="_18_5_3_12e503d9_1565496234915_213431_26663">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586298452736_214311_481" annotatedElement="_18_5_3_12e503d9_1565496234915_937829_26665">
+            <body>&lt;p>The InterfaceDefinitions that have a certain PortUsage as an &lt;code>interfaceEnd&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565496618907_278606_27100" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565496618908_305361_27101" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565498940266_617738_28508" name="InterfaceUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567722611286_500745_17992" annotatedElement="_18_5_3_12e503d9_1565498940266_617738_28508">
+          <body>&lt;p>An &lt;code>InterfaceUsage&lt;/code> is a Usage of an &lt;code>InterfaceDefinition&lt;/code> to represent an interface connecting parts of a system through specific ports.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673035984225_429679_550" name="checkInterfaceUsageBinarySpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565498940266_617738_28508">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673036252623_4131_559" annotatedElement="_19_0_4_12e503d9_1673035984225_429679_550">
+            <body>&lt;p>A binary &lt;code>InterfaceUsage&lt;/code> must directly or indirectly specialize the &lt;code>InterfaceUsage&lt;/code> &lt;em>&lt;code>Interfaces::binaryInterfaces&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673035984271_151476_551" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedEndFeature->size() = 2 implies
+    specializesFromLibrary('Interfaces::binaryInterfaces')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673036089181_205708_555" name="checkInterfaceUsageSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565498940266_617738_28508">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673036089206_256067_557" annotatedElement="_19_0_4_12e503d9_1673036089181_205708_555">
+            <body>&lt;p>An &lt;code>InterfaceUsage&lt;/code> must directly or indirectly specialize the &lt;code>InterfaceUsage&lt;/code> &lt;em>&lt;code>Interfaces::interfaces&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673036089200_952885_556" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Interfaces::interfaces')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1565824131787_326032_2026" general="_19_0_2_12e503d9_1565824079403_302443_1935"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565499418349_431355_28798" name="interfaceDefinition" visibility="public" type="_18_5_3_12e503d9_1565496029896_966800_26573" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1594853499656_139435_802" association="_18_5_3_12e503d9_1565499418349_244860_28797">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586298390214_721462_478" annotatedElement="_18_5_3_12e503d9_1565499418349_431355_28798">
+            <body>&lt;p>The &lt;code>InterfaceDefinitions&lt;/code> that type this &lt;code>InterfaceUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565499724582_208399_29130" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565499724582_2190_29131" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_18_5_3_12e503d9_1565499418349_244860_28797" name="A_interfaceDefinition_definedInterface" visibility="public" memberEnd="_18_5_3_12e503d9_1565499418349_431355_28798 _18_5_3_12e503d9_1565499418350_939140_28799">
+        <ownedEnd xmi:id="_18_5_3_12e503d9_1565499418350_939140_28799" name="definedInterface" visibility="public" type="_18_5_3_12e503d9_1565498940266_617738_28508" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1594853499657_181098_803" association="_18_5_3_12e503d9_1565499418349_244860_28797">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586298398415_731541_479" annotatedElement="_18_5_3_12e503d9_1565499418350_939140_28799">
+            <body>&lt;p>The InterfaceUsages typed by a certain InterfaceDefinition.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565499731564_119007_29142" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565499731564_951525_29143" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565496029896_966800_26573" name="InterfaceDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567722215670_907138_17990" annotatedElement="_18_5_3_12e503d9_1565496029896_966800_26573">
+          <body>&lt;p>An &lt;code>InterfaceDefinition&lt;/code> is a &lt;code>ConnectionDefinition&lt;/code> all of whose ends are &lt;code>PortUsages&lt;/code>, defining an interface between elements that interact through such ports.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673035834897_272010_547" name="checkInterfaceDefinitionSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565496029896_966800_26573">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673035956173_126590_549" annotatedElement="_19_0_4_12e503d9_1673035834897_272010_547">
+            <body>&lt;p>An &lt;code>InterfaceDefinition&lt;/code> must directly or indirectly specialize the &lt;code>InterfaceDefinition&lt;/code> &lt;em>&lt;code>Interfaces::Interface&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673035834922_960262_548" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Interfaces::Interface')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673036008805_269849_552" name="checkInterfaceDefinitionBinarySpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565496029896_966800_26573">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673036008838_326316_554" annotatedElement="_19_0_4_12e503d9_1673036008805_269849_552">
+            <body>&lt;p>A binary &lt;code>InterfaceDefinition&lt;/code> must directly or indirectly specialize the &lt;code>InterfaceDefinition&lt;/code> &lt;em>&lt;code>Interfaces::BinaryInterface&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673036008824_243546_553" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedEndFeature->size() = 2 implies
+    specializesFromLibrary('Interfaces::BinaryInterface')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565496064782_117400_26604" general="_19_0_2_12e503d9_1565813525877_81950_622"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565496234915_779221_26664" name="interfaceEnd" visibility="public" type="_18_5_3_12e503d9_1565492704639_896080_24992" isOrdered="true" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1591476421094_685440_682" association="_18_5_3_12e503d9_1565496234915_213431_26663">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586298304183_132751_477" annotatedElement="_18_5_3_12e503d9_1565496234915_779221_26664">
+            <body>&lt;p>The &lt;code>PortUsages&lt;/code> that are the &lt;code>connectionEnds&lt;/code> of this &lt;code>InterfaceDefinition&lt;/code>.
+
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565496290230_527575_26788" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565496290230_419366_26789" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1575587457004_850414_384" name="States" visibility="public" URI="">
+      <ownedComment xmi:id="_19_0_2_12e503d9_1578439832808_314201_239" annotatedElement="_19_0_2_12e503d9_1575587457004_850414_384">
+        <body>
+
+</body>
+      </ownedComment>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1575587557729_586912_651" name="StateUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578598325243_416734_3947" annotatedElement="_19_0_2_12e503d9_1575587557729_586912_651">
+          <body>&lt;p>A &lt;code>StateUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that is nominally the &lt;code>Usage&lt;/code> of a &lt;code>StateDefinition&lt;/code>. However, other kinds of kernel &lt;code>Behaviors&lt;/code> are also allowed as &lt;code>types&lt;/code>, to permit use of &lt;code>Behaviors&lt;/code from the Kernel Model Libraries.&lt;/p>
+
+&lt;p>A &lt;code>StateUsage&lt;/code> may be related to up to three of its &lt;code>ownedFeatures&lt;/code> by &lt;code>StateSubactionMembership&lt;/code> &lt;code>Relationships&lt;/code>, all of different &lt;code>kinds&lt;/code>, corresponding to the entry, do and exit actions of the &lt;code>StateUsage&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675366902902_201575_85" name="deriveStateUsageDoAction" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587557729_586912_651">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675366902946_954831_95" annotatedElement="_19_0_4_12e503d9_1675366902902_201575_85">
+            <body>&lt;p>The &lt;code>doAction&lt;/code> of a &lt;code>StateUsage&lt;/code> is the &lt;code>action&lt;/code> of the owned &lt;code>StateSubactionMembership&lt;/code> with &lt;code>kind = do&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675366902943_172956_94" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>doAction =
+    let doMemberships : Sequence(StateSubactionMembership) =
+        ownedMembership->
+            selectByKind(StateSubactionMembership)->
+            select(kind = StateSubactionKind::do) in
+    if doMemberships->isEmpty() then null
+    else doMemberships->at(1)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675366902905_453986_86" name="deriveStateUsageEntryAction" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587557729_586912_651">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675366902947_849145_97" annotatedElement="_19_0_4_12e503d9_1675366902905_453986_86">
+            <body>&lt;p>The &lt;code>entryAction&lt;/code> of a &lt;code>StateUsage&lt;/code> is the &lt;code>action&lt;/code> of the owned &lt;code>StateSubactionMembership&lt;/code> with &lt;code>kind = entry&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675366902946_571178_96" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>entryAction =
+    let entryMemberships : Sequence(StateSubactionMembership) =
+        ownedMembership->
+            selectByKind(StateSubactionMembership)->
+            select(kind = StateSubactionKind::entry) in
+    if entryMemberships->isEmpty() then null
+    else entryMemberships->at(1)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675366902920_466759_90" name="validateStateUsageParallelSubactions" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587557729_586912_651">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675366902949_449229_105" annotatedElement="_19_0_4_12e503d9_1675366902920_466759_90">
+            <body>&lt;p>If a &lt;code>StateUsage&lt;/code> is parallel, then its &lt;code>nestedActions&lt;/code> (which includes &lt;code>nestedStates&lt;/code>) must not have any &lt;code>incomingTransitions&lt;/code> or &lt;code>outgoingTransitions&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675366902949_930787_104" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isParallel implies
+    nestedAction.incomingTransition->isEmpty() and
+    nestedAction.outgoingTransition->isEmpty()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675368222109_56975_256" name="checkStateUsageExclusiveStateSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587557729_586912_651">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675368222143_533369_258" annotatedElement="_19_0_4_12e503d9_1675368222109_56975_256">
+            <body>&lt;p>A &lt;code>StateUsage&lt;/code> that is a substate usage with a non-parallel owning &lt;code>StateDefinition&lt;/code> or &lt;code>StateUsage&lt;/code> must directly or indirectly specialize the &lt;code>StateUsage&lt;/code> &lt;em>&lt;code>States::StateAction::exclusiveStates&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675368222135_401608_257" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSubstateUsage(false) implies
+    specializesFromLibrary('States::StateAction::exclusiveStates')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675366902907_148253_87" name="deriveStateUsageExitAction" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587557729_586912_651">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675366902948_737299_99" annotatedElement="_19_0_4_12e503d9_1675366902907_148253_87">
+            <body>&lt;p>The &lt;code>exitAction&lt;/code> of a &lt;code>StateUsage&lt;/code> is the &lt;code>action&lt;/code> of the owned &lt;code>StateSubactionMembership&lt;/code> with &lt;code>kind = exit
+&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675366902947_421450_98" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>exitAction =
+    let exitMemberships : Sequence(StateSubactionMembership) =
+        ownedMembership->
+            selectByKind(StateSubactionMembership)->
+            select(kind = StateSubactionKind::exit) in
+    if exitMemberships->isEmpty() then null
+    else exitMemberships->at(1)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675366902875_532871_84" name="checkStateUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587557729_586912_651">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675366902935_319248_93" annotatedElement="_19_0_4_12e503d9_1675366902875_532871_84">
+            <body>&lt;p>A &lt;code>StateUsage&lt;/code> must directly or indirectly specialize the &lt;code>StateUsage&lt;/code> &lt;em>&lt;code>States::stateActions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675366902928_742183_92" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('States::stateActions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675366902926_925159_91" name="validateStateUsageStateSubactionKind" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675366902951_582926_107" annotatedElement="_19_0_4_12e503d9_1675366902926_925159_91">
+            <body>&lt;p>A &lt;code>StateUsage&lt;/code> must not have more than one owned &lt;code>StateSubactionMembership&lt;/code> of each &lt;code>kind&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675366902949_624947_106" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMembership->
+    selectByKind(StateSubactionMembership)->
+    isUnique(kind)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676652313104_728469_664" name="checkStateUsageSubstateSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587557729_586912_651">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676652313145_100660_666" annotatedElement="_19_0_4_12e503d9_1676652313104_728469_664">
+            <body>&lt;p>A &lt;code>StateUsage&lt;/code> that is a substate usage with a owning &lt;code>StateDefinition&lt;/code> or &lt;code>StateUsage&lt;/code> that is parallel must directly or indirectly specialize the &lt;code>StateUsage&lt;/code> &lt;em>&lt;code>States::StateAction::substates&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676652313132_478860_665" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSubstateUsage(true) implies
+    specializesFromLibrary('States::StateAction::substates')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1736984297591_930288_537" name="checkStateUsageOwnedStateSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587557729_586912_651">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736984350716_226257_539" annotatedElement="_2022x_2_12e503d9_1736984297591_930288_537">
+            <body>&lt;p>A composite &lt;code>StateUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>PartDefinition&lt;/code> or &lt;code>PartUsage&lt;/code> must directly or indirectly specialize the &lt;code>StateUsage&lt;/code> &lt;em>&lt;code>Parts::Part::ownedStates&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736984297592_148538_538" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(PartDefinition) or
+ owningType.oclIsKindOf(PartUsage)) implies
+    specializesFromLibrary('Parts::Part::ownedStates')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1575587636354_152763_710" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575588456737_49200_1438" name="stateDefinition" visibility="public" isOrdered="true" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1565500905804_589845_30779" association="_19_0_2_12e503d9_1575588456736_131561_1437">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586384026483_559650_1013" annotatedElement="_19_0_2_12e503d9_1575588456737_49200_1438">
+            <body>&lt;p>The &lt;code>Behaviors&lt;/code> that are the &lt;code>types&lt;/code> of this &lt;code>StateUsage&lt;/code>. Nominally, these would be &lt;code>StateDefinitions&lt;/code>, but kernel &lt;code>Behaviors&lt;/code> are also allowed, to permit use of &lt;code>Behaviors&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651709_376789_42207"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575588493435_273756_1468" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575588493436_846445_1469" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1582976239200_979652_605" name="entryAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_2_12e503d9_1582976239199_397775_604">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1582985479950_936267_772" annotatedElement="_19_0_2_12e503d9_1582976239200_979652_605">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateUsage&lt;/code> to be performed on entry to the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateUsage&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = entry&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582976251279_704976_629" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582976251280_611567_630" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1582976255473_203238_644" name="doAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_2_12e503d9_1582976255472_347038_643">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1582985692338_900411_783" annotatedElement="_19_0_2_12e503d9_1582976255473_203238_644">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateUsage&lt;/code> to be performed while in the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateUsage&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = do&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582976269496_220394_670" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582976269503_19199_671" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1582976283940_998741_691" name="exitAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_2_12e503d9_1582976283940_517953_690">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1582985700925_884830_784" annotatedElement="_19_0_2_12e503d9_1582976283940_998741_691">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateUsage&lt;/code> to be performed on exit to the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateUsage&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = exit&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582976296101_653728_717" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582976296108_288271_718" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624025713025_548712_37708" name="isParallel" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624027941496_611186_37730" annotatedElement="_19_0_4_12e503d9_1624025713025_548712_37708">
+            <body>&lt;p>Whether the &lt;code>nestedStates&lt;/code> of this &lt;code>StateUsage&lt;/code> are to all be performed in parallel. If true, none of the &lt;code>nestedActions&lt;/code> (which include &lt;code>nestedStates&lt;/code>) may have any incoming or outgoing &lt;code>Transitions&lt;/code>. If false, only one &lt;code>nestedState&lt;/code> may be performed at a time.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1624026104886_753999_37713" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1675367686748_489016_239" name="isSubstateUsage" visibility="public" bodyCondition="_19_0_4_12e503d9_1675368413626_291106_268">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675367855874_385757_245" annotatedElement="_19_0_4_12e503d9_1675367686748_489016_239">
+            <body>&lt;p>Check if this &lt;code>StateUsage&lt;/code> is composite and has an &lt;code>owningType&lt;/code> that is a &lt;code>StateDefinition&lt;/code> or &lt;code>StateUsage&lt;/code> with the given value of &lt;code>isParallel&lt;/code>, but is &lt;em>not&lt;/em> an &lt;code>entryAction&lt;/code>, &lt;code>doAction&lt;/code>, or &lt;code>exitAction&lt;/code>. If so, then it represents a &lt;code>&lt;em>StateAction&lt;/em>&lt;/code> that is a &lt;code>&lt;em>substate&lt;/em>&lt;/code> or &lt;code>&lt;em>exclusiveState&lt;/em>&lt;/code> (for &lt;code>isParallel = false&lt;/code>) of another &lt;code>&lt;em>StateAction&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1675368413626_291106_268" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675368413650_701789_269" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(StateDefinition) and
+    owningType.oclAsType(StateDefinition).isParallel = isParallel or
+ owningType.oclIsKindOf(StateUsage) and
+    owningType.oclAsType(StateUsage).isParallel = isParallel) and
+not owningFeatureMembership.oclIsKindOf(StateSubactionMembership)</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1675367840267_631019_242" name="isParallel" visibility="public">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1675368285852_364696_267" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575588190693_303009_1155" name="A_state_featuringStateDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1575588190693_949879_1156 _19_0_2_12e503d9_1575588190695_702401_1157">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1575588190695_702401_1157" name="featuringStateDefinition" visibility="public" type="_19_0_2_12e503d9_1575587534200_898246_600" isDerived="true" association="_19_0_2_12e503d9_1575588190693_303009_1155">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314919242_630981_796" annotatedElement="_19_0_2_12e503d9_1575588190695_702401_1157">
+            <body>&lt;p>The StateDefinitions featuring a certain StateUsage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575588393705_23489_1406" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575588393706_807980_1407" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_b9102da_1536346067213_746991_17344"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_19_0_2_12e503d9_1575671829228_418282_268" name="StateSubactionKind" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578701145325_273396_42685" annotatedElement="_19_0_2_12e503d9_1575671829228_418282_268">
+          <body>&lt;p>A &lt;code>StateSubactionKind&lt;/code> indicates whether the &lt;code>action&lt;/code> of a StateSubactionMembership is an entry, do or exit action.&lt;/p></body>
+        </ownedComment>
+        <ownedLiteral xmi:id="_19_0_2_12e503d9_1575671842860_742456_299" name="entry" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316826008_755857_833" annotatedElement="_19_0_2_12e503d9_1575671842860_742456_299">
+            <body>&lt;p>Indicates that the &lt;code>action&lt;/code> of a &lt;code>StateSubactionMembership&lt;/code> is an &lt;code>entryAction&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_19_0_2_12e503d9_1575671850153_344119_305" name="do" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316831812_117633_834" annotatedElement="_19_0_2_12e503d9_1575671850153_344119_305">
+            <body>&lt;p>Indicates that the &lt;code>action&lt;/code> of a &lt;code>StateSubactionMembership&lt;/code> is a &lt;code>doAction&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_19_0_2_12e503d9_1575671854032_765194_311" name="exit" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316839373_314003_835" annotatedElement="_19_0_2_12e503d9_1575671854032_765194_311">
+            <body>&lt;p>Indicates that the &lt;code>action&lt;/code> of a &lt;code>StateSubactionMembership&lt;/code> is an &lt;code>exitAction&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1575671792204_632048_203" name="StateSubactionMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1575671918220_649286_338" annotatedElement="_19_0_2_12e503d9_1575671792204_632048_203">
+          <body>&lt;p>A &lt;code>StateSubactionMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> for an entry, do or exit &lt;code>ActionUsage&lt;code> of a &lt;code>StateDefinition&lt;/code> or &lt;code>StateUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675382273431_176325_555" name="validateStateSubactionMembershipOwningType" visibility="public" constrainedElement="_19_0_2_12e503d9_1575671792204_632048_203">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675382753666_478487_560" annotatedElement="_19_0_4_12e503d9_1675382273431_176325_555">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>StateSubactionMembership&lt;/code> must be a &lt;code>StateDefinition&lt;/code> or a &lt;code>StateUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675382273446_668485_556" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsKindOf(StateDefinition) or
+owningType.oclIsKindOf(StateUsage)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1575671813716_434571_256">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651715_740575_42237"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575671861308_70894_325" name="kind" visibility="public" type="_19_0_2_12e503d9_1575671829228_418282_268">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1578440112918_494733_241" annotatedElement="_19_0_2_12e503d9_1575671861308_70894_325">
+            <body>&lt;p>Whether this &lt;code>StateSubactionMembership&lt;/code> is for an &lt;code>entry&lt;code>, &lt;code>do&lt;/code> or &lt;code>exit&lt;/code> &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1582974847979_606181_96" name="action" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" aggregation="composite" isDerived="true" association="_19_0_2_12e503d9_1582974847979_801200_95">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1582974898518_122076_110" annotatedElement="_19_0_2_12e503d9_1582974847979_606181_96">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> that is the &lt;code>ownedMemberFeature&lt;/code> of this &lt;code>StateSubactionMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582974866539_128175_106" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582974866541_445968_107" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674993_898044_43344"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1575587534200_898246_600" name="StateDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578439911706_568074_240" annotatedElement="_19_0_2_12e503d9_1575587534200_898246_600">
+          <body>&lt;p>A &lt;code>StateDefinition&lt;/code> is the &lt;code>Definition&lt;/code> of the &lt;/code>Behavior&lt;/code> of a system or part of a system in a certain state condition.&lt;/p>
+
+&lt;p>A &lt;code>StateDefinition&lt;/code> may be related to up to three of its &lt;code>ownedFeatures&lt;/code> by &lt;code>StateBehaviorMembership&lt;/code> &lt;code>Relationships&lt;/code>, all of different &lt;code>kinds&lt;/code>, corresponding to the entry, do and exit actions of the &lt;code>StateDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675366026495_916084_68" name="checkStateDefinitionSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587534200_898246_600">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675366120541_75401_70" annotatedElement="_19_0_4_12e503d9_1675366026495_916084_68">
+            <body>&lt;p>A &lt;code>StateDefinition&lt;/code> must directly or indirectly specialize the &lt;code>StateDefinition&lt;/code> &lt;em>&lt;code>States::StateAction&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675366026512_334203_69" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('States::StateAction')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675365637636_339767_63" name="validateStateDefinitionStateSubactionKind" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587534200_898246_600">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675365994416_672859_65" annotatedElement="_19_0_4_12e503d9_1675365637636_339767_63">
+            <body>&lt;p>A &lt;code>StateDefinition&lt;/code> must not have more than one owned &lt;code>StateSubactionMembership&lt;/code> of each &lt;code>kind&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675365637648_128709_64" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMembership->
+    selectByKind(StateSubactionMembership)->
+    isUnique(kind)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675365085390_844818_33" name="deriveStateDefinitionState" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587534200_898246_600">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675365220279_333555_35" annotatedElement="_19_0_4_12e503d9_1675365085390_844818_33">
+            <body>&lt;p>The &lt;code>states&lt;/code> of a &lt;code>StateDefinition&lt;/code> are those of its &lt;code>actions&lt;/code> that are &lt;code>StateUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675365085410_726225_34" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>state = action->selectByKind(StateUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675365503844_475569_39" name="deriveStateDefinitionDoAction" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587534200_898246_600">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675365503903_936994_41" annotatedElement="_19_0_4_12e503d9_1675365503844_475569_39">
+            <body>&lt;p>The &lt;code>doAction&lt;/code> of a &lt;code>StateDefinition&lt;/code> is the &lt;code>action&lt;/code> of the owned &lt;code>StateSubactionMembership&lt;/code> with &lt;code>kind = do&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675365503891_485759_40" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>doAction =
+    let doMemberships : Sequence(StateSubactionMembership) =
+        ownedMembership->
+            selectByKind(StateSubactionMembership)->
+            select(kind = StateSubactionKind::do) in
+    if doMemberships->isEmpty() then null
+    else doMemberships->at(1)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675365295637_889115_36" name="deriveStateDefinitionEntryAction" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587534200_898246_600">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675365451962_500699_38" annotatedElement="_19_0_4_12e503d9_1675365295637_889115_36">
+            <body>&lt;p>The &lt;code>entryAction&lt;/code> of a &lt;code>StateDefinition&lt;/code> is the &lt;code>action&lt;/code> of the owned &lt;code>StateSubactionMembership&lt;/code> with &lt;code>kind = entry&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675365295657_317802_37" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>entryAction =
+    let entryMemberships : Sequence(StateSubactionMembership) =
+        ownedMembership->
+            selectByKind(StateSubactionMembership)->
+            select(kind = StateSubactionKind::entry) in
+    if entryMemberships->isEmpty() then null
+    else entryMemberships->at(1)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675366604027_41223_71" name="validateStateDefinitionParallelSubactions" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587534200_898246_600">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675366833967_882902_83" annotatedElement="_19_0_4_12e503d9_1675366604027_41223_71">
+            <body>&lt;p>If a &lt;code>StateDefinition&lt;/code> is parallel, then its &lt;code>ownedActions&lt;/code> (which includes its &lt;code>ownedStates&lt;/code>) must not have any &lt;code>incomingTransitions&lt;/code> or &lt;code>outgoingTransitions&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675366604054_608929_72" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isParallel implies
+    ownedAction.incomingTransition->isEmpty() and
+    ownedAction.outgoingTransition->isEmpty()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675365565778_46208_52" name="deriveStateDefinitionExitAction" visibility="public" constrainedElement="_19_0_2_12e503d9_1575587534200_898246_600">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675365565807_905679_54" annotatedElement="_19_0_4_12e503d9_1675365565778_46208_52">
+            <body>&lt;p>The &lt;code>exitAction&lt;/code> of a &lt;code>StateDefinition&lt;/code> is the &lt;code>action&lt;/code> of the owned &lt;code>StateSubactionMembership&lt;/code> with &lt;code>kind = exit
+&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675365565802_994125_53" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>exitAction = 
+    let exitMemberships : Sequence(StateSubactionMembership) =
+        ownedMembership->
+            selectByKind(StateSubactionMembership)->
+            select(kind = StateSubactionKind::exit) in
+    if exitMemberships->isEmpty() then null
+    else exitMemberships->at(1)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1583704603816_675823_754" general="_18_5_3_12e503d9_1565500542970_17430_30342"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575588190693_949879_1156" name="state" visibility="public" type="_19_0_2_12e503d9_1575587557729_586912_651" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565500809065_170841_30688" association="_19_0_2_12e503d9_1575588190693_303009_1155">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314252731_24596_788" annotatedElement="_19_0_2_12e503d9_1575588190693_949879_1156">
+            <body>&lt;p>The &lt;code>StateUsages&lt;/code>, which are &lt;code>actions&lt;/code> in the &lt;code>StateDefinition&lt;/code>, that specify the discrete states in the behavior defined by the &lt;code>StateDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575588206405_670249_1180" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575588206407_191370_1181" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1582975902339_513804_312" name="entryAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_2_12e503d9_1582975902339_934472_311">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1582985446165_477074_771" annotatedElement="_19_0_2_12e503d9_1582975902339_513804_312">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateDefinition&lt;/code> to be performed on entry to the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateDefinition&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = entry&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582975965171_120751_362" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582975965171_272315_363" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1582975916386_388324_339" name="doAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_2_12e503d9_1582975916386_236056_338">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1582985641580_244827_779" annotatedElement="_19_0_2_12e503d9_1582975916386_388324_339">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateDefinition&lt;/code> to be performed while in the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateDefinition&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = do&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582975975466_536719_368" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582975975466_659048_369" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1582975927011_696894_352" name="exitAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_2_12e503d9_1582975927010_291183_351">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1582985666181_61205_780" annotatedElement="_19_0_2_12e503d9_1582975927011_696894_352">
+            <body>&lt;p>The &lt;code>ActionUsage&lt;/code> of this &lt;code>StateDefinition&lt;/code> to be performed on exit to the state defined by the &lt;code>StateDefinition&lt;/code>. It is the owned &lt;code>ActionUsage&lt;/code> related to the &lt;code>StateDefinition&lt;/code> by a &lt;code>StateSubactionMembership&lt;/code>  with &lt;code>kind = exit&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582975996318_761644_374" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582975996318_9345_375" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624025670323_266174_37704" name="isParallel" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624027201672_129039_37729" annotatedElement="_19_0_4_12e503d9_1624025670323_266174_37704">
+            <body>&lt;p>Whether the &lt;code>ownedStates&lt;/code> of this &lt;code>StateDefinition&lt;/code> are to all be performed in parallel. If true, none of the &lt;code>ownedActions&lt;/code> (which includes &lt;code>ownedStates&lt;/code>) may have any incoming or outgoing &lt;code>Transitions&lt;/code>. If false, only one &lt;code>ownedState&lt;/code> may be performed at a time.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1624025682614_331003_37707" name="" visibility="public"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1575588456736_131561_1437" name="A_stateDefinition_definedState" visibility="public" memberEnd="_19_0_2_12e503d9_1575588456737_49200_1438 _19_0_2_12e503d9_1575588456738_85446_1439">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1575588456738_85446_1439" name="definedState" visibility="public" type="_19_0_2_12e503d9_1575587557729_586912_651" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565500905804_571076_30780" association="_19_0_2_12e503d9_1575588456736_131561_1437">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314979286_16633_797" annotatedElement="_19_0_2_12e503d9_1575588456738_85446_1439">
+            <body>&lt;p>The Behaviors that are the types of this StateUsage. Nominally, these would be StateDefinition, but non-StateDefinition Behaviors are also allowed, to permit use of Behaviors from the Kernel Library.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1575588555412_611635_1498" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1575588555412_366860_1499" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1575672078353_626298_450" name="TransitionUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578598845675_381015_3958" annotatedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <body>&lt;p>A &lt;code>TransitionUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> representing a triggered transition between &lt;code>ActionUsages&lt;/code> or &lt;code>StateUsages&lt;/code>. When triggered by a &lt;code>triggerAction&lt;/code>, when its &lt;code>guardExpression&lt;/code> is true, the &lt;code>TransitionUsage&lt;/code> asserts that its &lt;code>source&lt;/code> is exited, then its &lt;code>effectAction&lt;/code> (if any) is performed, and then its &lt;code>target&lt;/code> is entered.&lt;/p>
+
+&lt;p>A &lt;code>TransitionUsage&lt;/code> can be related to some of its &lt;code>ownedFeatures&lt;/code> using &lt;code>TransitionFeatureMembership&lt;/code> &lt;code>Relationships&lt;/code>, corresponding to the &lt;code>triggerAction&lt;/code>, &lt;code>guardExpression&lt;/code> and &lt;code>effectAction&lt;/code> of the &lt;code>TransitionUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673297200957_67949_906" name="checkTransitionUsageActionSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673297546945_10140_908" annotatedElement="_19_0_4_12e503d9_1673297200957_67949_906">
+            <body>&lt;p>A composite &lt;code>TransitionUsage&lt;/code> whose &lt;code>owningType&lt;/code> is an &lt;code>ActionDefinition&lt;/code> or &lt;code>ActionUsage&lt;/code> and whose &lt;code>source&lt;/code> is &lt;em>not&lt;/em> a &lt;code>StateUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::Action::decisionTransitions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673297200997_869932_907" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(ActionDefinition) or
+ owningType.oclIsKindOf(ActionUsage)) and
+source &lt;> null and not source.oclIsKindOf(StateUsage) implies
+    specializesFromLibrary('Actions::Action::decisionTransitions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673297704211_311981_912" name="checkTransitionUsageStateSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673297939000_748301_914" annotatedElement="_19_0_4_12e503d9_1673297704211_311981_912">
+            <body>&lt;p>A composite &lt;code>TransitionUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>StateDefinition&lt;/code> or &lt;code>StateUsage&lt;/code> and whose &lt;code>source&lt;/code> is a &lt;code>StateUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>States::StateAction::stateTransitions&lt;/code>&lt;/em> from the Systems Model Library&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673297704221_628913_913" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(StateDefinition) or
+ owningType.oclIsKindOf(StateUsage)) and
+source &lt;> null and source.oclIsKindOf(StateUsage) implies
+    specializesFromLibrary('States::StateAction::stateTransitions')
+</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673297564753_389498_909" name="checkTransitionUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673297700381_796678_911" annotatedElement="_19_0_4_12e503d9_1673297564753_389498_909">
+            <body>&lt;p>A &lt;code>TransitionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::transitionActions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673297564764_735843_910" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Actions::transitionActions')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675376496866_702419_297" name="deriveTransitionUsageSource" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675376784794_558708_299" annotatedElement="_19_0_4_12e503d9_1675376496866_702419_297">
+            <body>&lt;p>The &lt;code>source&lt;/code> of a &lt;code>TransitionUsage&lt;/code> is &lt;code>featureTarget&lt;/code> of the result of &lt;code>sourceFeature()&lt;/code>, which must be an &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675376496888_312727_298" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>source =
+    let sourceFeature : Feature = sourceFeature() in
+    if sourceFeature = null then null
+    else sourceFeature.featureTarget.oclAsType(ActionUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675377161675_656427_386" name="deriveTransitionUsageTarget" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675377577226_335143_460" annotatedElement="_19_0_4_12e503d9_1675377161675_656427_386">
+            <body>&lt;p>The &lt;code>target&lt;/code> of a &lt;code>TransitionUsage&lt;/code> is given by the &lt;code>featureTarget&lt;/code> of the &lt;code>targetFeature&lt;/code> of its &lt;code>succession&lt;/code>, which must be an &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675377161693_572874_387" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>target =
+    if succession.targetFeature->isEmpty() then null
+    else
+        let targetFeature : Feature =
+            succession.targetFeature->first().featureTarget in
+        if not targetFeature.oclIsKindOf(ActionUsage) then null
+        else targetFeature.oclAsType(ActionUsage)
+        endif
+    endif
+</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675377520608_87867_454" name="deriveTransitionUsageTriggerAction" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675377749390_482900_461" annotatedElement="_19_0_4_12e503d9_1675377520608_87867_454">
+            <body>&lt;p>The &lt;code>triggerActions&lt;/code> of a &lt;code>TransitionUsage&lt;/code> are the &lt;code>transitionFeatures&lt;/code> of the &lt;code>ownedFeatureMemberships&lt;/code> of the &lt;code>TransitionUsage&lt;/code> with &lt;code>kind = trigger&lt;/code>, which must all be &lt;code>AcceptActionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675377520630_930317_455" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>triggerAction = ownedFeatureMembership->
+    selectByKind(TransitionFeatureMembership)->
+    select(kind = TransitionFeatureKind::trigger).transitionFeature->
+    selectByKind(AcceptActionUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675378631793_445064_515" name="validateTransitionUsageSuccession" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675378855089_631060_517" annotatedElement="_19_0_4_12e503d9_1675378631793_445064_515">
+            <body>&lt;p>A &lt;code>TransitionUsage&lt;/code> must have an &lt;code>ownedMember&lt;/code> that is a &lt;code>Succession&lt;/code> with an &lt;code>ActionUsage&lt;/code> as the &lt;code>featureTarget&lt;/code> of its &lt;code>targetFeature&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675378631817_361424_516" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>let successions : Sequence(Successions) = 
+    ownedMember->selectByKind(Succession) in
+successions->notEmpty() and
+successions->at(1).targetFeature.featureTarget->
+    forAll(oclIsKindOf(ActionUsage))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675377775057_229432_472" name="deriveTransitionUsageGuardExpression" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675377775089_163740_474" annotatedElement="_19_0_4_12e503d9_1675377775057_229432_472">
+            <body>&lt;p>The &lt;code>triggerActions&lt;/code> of a &lt;code>TransitionUsage&lt;/code> are the &lt;code>transitionFeatures&lt;/code> of the &lt;code>ownedFeatureMemberships&lt;/code> of the &lt;code>TransitionUsage&lt;/code> with &lt;code>kind = trigger&lt;/code>, which must all be &lt;code>Expressions&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675377775081_962443_473" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>guardExpression = ownedFeatureMembership->
+    selectByKind(TransitionFeatureMembership)->
+    select(kind = TransitionFeatureKind::trigger).transitionFeature->
+    selectByKind(Expression)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675381892471_652231_548" name="checkTransitionUsageTransitionFeatureSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675382233824_122297_550" annotatedElement="_19_0_4_12e503d9_1675381892471_652231_548">
+            <body>&lt;p>The &lt;code>triggerActions&lt;/code>, &lt;code>guardExpressions&lt;/code>, and &lt;code>effectActions&lt;/code> of a &lt;code>TransitionUsage&lt;/code> must specialize, respectively, the &lt;em>&lt;code>accepter&lt;/code>&lt;/em>, &lt;em>&lt;code>guard&lt;/code>&lt;/em>, and &lt;em>&lt;code>effect&lt;/code>&lt;/em> &lt;code>features&lt;/code> of the &lt;code>ActionUsage&lt;/code> &lt;em>&lt;code>Actions::TransitionActions&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675381892496_163432_549" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>triggerAction->forAll(specializesFromLibrary('Actions::TransitionAction::accepter') and
+guardExpression->forAll(specializesFromLibrary('Actions::TransitionAction::guard') and
+effectAction->forAll(specializesFromLibrary('Actions::TransitionAction::effect'))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675378104912_303830_485" name="deriveTransitionUsageEffectAction" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675378104959_332883_487" annotatedElement="_19_0_4_12e503d9_1675378104912_303830_485">
+            <body>&lt;p>The &lt;code>effectActions&lt;/code> of a &lt;code>TransitionUsage&lt;/code> are the &lt;code>transitionFeatures&lt;/code> of the &lt;code>ownedFeatureMemberships&lt;/code> of the &lt;code>TransitionUsage&lt;/code> with &lt;code>kind = effect&lt;/code>, which must all be &lt;code>ActionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675378104951_559461_486" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>triggerAction = ownedFeatureMembership->
+    selectByKind(TransitionFeatureMembership)->
+    select(kind = TransitionFeatureKind::trigger).transitionFeatures->
+    selectByKind(AcceptActionUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675379486685_624040_524" name="checkTransitionUsageSuccessionSourceSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675379704296_409178_526" annotatedElement="_19_0_4_12e503d9_1675379486685_624040_524">
+            <body>&lt;p>The &lt;code>sourceFeature&lt;/code> of the &lt;code>succession&lt;/code> of a &lt;code>TransitionUsage&lt;/code> must be the &lt;code>source&lt;/code> of the &lt;code>TransitionUsage&lt;/code> (i.e., the first &lt;code>connectorEnd&lt;/code> of the &lt;code>succession&lt;/code> must have a &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationship&lt;/code> with the &lt;code>source&lt;/code>).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675379486715_824729_525" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>succession.sourceFeature = source</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675380136497_65720_530" name="checkTransitionUsageSourceBindingConnector" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675380347013_427283_534" annotatedElement="_19_0_4_12e503d9_1675380136497_65720_530">
+            <body>&lt;p>A &lt;code>TransitionUsage&lt;/code> must have an &lt;code>ownedMember&lt;/code> that is a &lt;code>BindingConnector&lt;/code> between its &lt;code>source&lt;/code> and its first input &lt;code>parameter&lt;/code> (which redefines &lt;code>&lt;em>Actions::TransitionAction::transitionLinkSource&lt;/em>&lt;/code>).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675380136515_912226_531" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMember->selectByKind(BindingConnector)->exists(b |
+    b.relatedFeatures->includes(source) and
+    b.relatedFeatures->includes(inputParameter(1)))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675379117297_912114_522" name="checkTransitionUsagePayloadSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676651729694_552693_663" annotatedElement="_19_0_4_12e503d9_1675379117297_912114_522">
+            <body>&lt;p>If a &lt;code>TransitionUsage&lt;/code> has a &lt;code>triggerAction&lt;/code>, then the &lt;em>&lt;code>payload&lt;/code>&lt;/em> &lt;code>parameter&lt;/code> of the &lt;code>TransitionUsage&lt;/code> subsets the &lt;code>Feature&lt;/code> chain of the &lt;code>triggerAction&lt;/code> and its &lt;code>payloadParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675379117313_877451_523" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>triggerAction->notEmpty() implies
+    let payloadParameter : Feature = inputParameter(2) in
+    payloadParameter &lt;> null and
+    payloadParameter.subsetsChain(triggerAction->at(1), triggerPayloadParameter())</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675379717079_82469_527" name="checkTransitionUsageSuccessionBindingConnector" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675380132884_161710_529" annotatedElement="_19_0_4_12e503d9_1675379717079_82469_527">
+            <body>&lt;p>A &lt;code>TransitionUsage&lt;/code> must have an &lt;code>ownedMember&lt;/code> that is a &lt;code>BindingConnector&lt;/code> between its &lt;code>succession&lt;/code> and the inherited &lt;code>Feature&lt;/code> &lt;code>&lt;em>TransitionPerformances::TransitionPerformance::transitionLink&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675379717093_550552_528" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMember->selectByKind(BindingConnector)->exists(b |
+    b.relatedFeatures->includes(succession) and
+    b.relatedFeatures->includes(resolveGlobal(
+        'TransitionPerformances::TransitionPerformance::transitionLink')))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675380406940_412346_537" name="validateTransitionUsageParameters" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675380578184_98078_539" annotatedElement="_19_0_4_12e503d9_1675380406940_412346_537">
+            <body>&lt;p>A &lt;code>TransitionUsage&lt;/code> must have at least one owned input &lt;code>parameter&lt;/code> and, if it has a &lt;code>triggerAction&lt;/code>, it must have at least two.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675380406962_636052_538" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if triggerAction->isEmpty() then
+    inputParameters()->size() >= 1
+else
+    inputParameters()->size() >= 2
+endif
+    </body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675378402350_670905_512" name="deriveTransitionUsageSuccession" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675378551955_82680_514" annotatedElement="_19_0_4_12e503d9_1675378402350_670905_512">
+            <body>&lt;p>The &lt;code>succession&lt;/code> of a &lt;code>TransitionUsage&lt;/code> is its first &lt;code>ownedMember&lt;/code> that is a &lt;code>Succession&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675378402360_204998_513" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>succession = ownedMember->selectByKind(Succession)->at(1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1736982532191_828579_413" name="validateTransitionUsageTriggerActions" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672078353_626298_450">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736982562471_27424_415" annotatedElement="_2022x_2_12e503d9_1736982532191_828579_413">
+            <body>&lt;p>If the &lt;code>source&lt;/code> of a &lt;code>TransitionUsage&lt;/code> is &lt;em>not&lt;/em> a &lt;code>StateUsage&lt;/code>, then the &lt;code>TransitionUsage&lt;/code> must not have any &lt;code>triggerActions&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736982532193_449291_414" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>source &lt;> null and not source.oclIsKindOf(StateUsage) implies
+    triggerAction->isEmpty()</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1583705498329_285253_1447" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1581029439311_947395_6114" name="source" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_2_12e503d9_1581029439310_886075_6113">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1581030450367_553535_6328" annotatedElement="_19_0_2_12e503d9_1581029439311_947395_6114">
+            <body>&lt;p>The source &lt;code>ActionUsage&lt;/code> of this &lt;code>TransitionUsage&lt;/code>, which becomes the &lt;code>source&lt;/code> of the &lt;code>succession&lt;/code> for the &lt;code>TransitionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1581029451778_938591_6124" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1581029451779_640330_6125" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1581029493366_130491_6153" name="target" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_2_12e503d9_1581029493366_136034_6152">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1581030617014_907094_6379" annotatedElement="_19_0_2_12e503d9_1581029493366_130491_6153">
+            <body>&lt;p>The target &lt;code>ActionUsage&lt;/code> of this &lt;code>TransitionUsage&lt;code>, which is the &lt;code>targetFeature&lt;/code> of the &lt;code>succession&lt;/code> for the &lt;code>TransitionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1581029503130_251445_6163" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1581029503130_223849_6164" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1581029662256_985457_6209" name="triggerAction" visibility="public" type="_18_5_3_12e503d9_1565503089035_106795_33475" isDerived="true" association="_19_0_2_12e503d9_1581029662255_938680_6208">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1581030015820_922595_6323" annotatedElement="_19_0_2_12e503d9_1581029662256_985457_6209">
+            <body>&lt;p>The &lt;code>AcceptActionUsages&lt;/code> that define the triggers of this &lt;code>TransitionUsage&lt;/code>, which are the &lt;code>ownedFeatures&lt;/code> of the &lt;code>TransitionUsage&lt;/code> related to it by &lt;code>TransitionFeatureMemberships&lt;/code> with &lt;code>kind = trigger&lt;/code>, which must all be &lt;code>AcceptActionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1581029674339_952442_6219" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1581029674339_350036_6220" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_226999_43167"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1581029720824_747691_6254" name="guardExpression" visibility="public" isDerived="true" association="_19_0_2_12e503d9_1581029720824_149051_6253">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1581030298579_126851_6326" annotatedElement="_19_0_2_12e503d9_1581029720824_747691_6254">
+            <body>&lt;p>The &lt;code>Expressions&lt;/code> that define the guards of this &lt;code>TransitionUsage&lt;/code>, which are the &lt;code>ownedFeatures&lt;/code> of the &lt;code>TransitionUsage&lt;/code> related to it by &lt;code>TransitionFeatureMemberships&lt;/code> with &lt;code>kind = guard&lt;/code>, which must all be &lt;code>Expressions&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1581029739364_665212_6264" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1581029739364_830541_6265" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_226999_43167"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1581029782522_542070_6299" name="effectAction" visibility="public" type="_18_5_3_12e503d9_1565500580749_954926_30405" isDerived="true" association="_19_0_2_12e503d9_1581029782522_117628_6298">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1581030338176_416376_6327" annotatedElement="_19_0_2_12e503d9_1581029782522_542070_6299">
+            <body>&lt;p>The &lt;code>ActionUsages&lt;/code> that define the effects of this &lt;code>TransitionUsage&lt;/code>, which are the &lt;code>ownedFeatures&lt;/code> of the &lt;code>TransitionUsage&lt;/code> related to it by &lt;code>TransitionFeatureMemberships&lt;/code> with &lt;code>kind = effect&lt;/code>, which must all be &lt;code>ActionUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1581029802794_948402_6309" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1581029802794_537835_6310" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_326391_43166"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1581030490131_304332_6364" name="succession" visibility="public" isDerived="true" association="_19_0_2_12e503d9_1581030490131_396465_6363">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1581030572944_474446_6378" annotatedElement="_19_0_2_12e503d9_1581030490131_304332_6364">
+            <body>&lt;p>The &lt;code>Succession&lt;/code> that is the &lt;code>ownedFeature&lt;/code> of this &lt;code>TransitionUsage&lt;/code>, which, if the &lt;code>TransitionUsage&lt;/code> is triggered, asserts the temporal ordering of the &lt;code>source&lt;/code> and &lt;code>target&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_71301a1_1536100248189_622183_16479"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1581030527525_778931_6374" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1581030527526_436680_6375" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674979_259543_43268"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1675361994379_725277_691" name="triggerPayloadParameter" visibility="public" bodyCondition="_19_0_4_12e503d9_1675362169310_453895_697">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676651460903_86082_662" annotatedElement="_19_0_4_12e503d9_1675361994379_725277_691">
+            <body>&lt;p>Return the &lt;code>payloadParameter&lt;/code> of the &lt;code>triggerAction&lt;/code> of this &lt;code>TransitionUsage&lt;/code>, if it has one.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1675362169310_453895_697" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675362169333_283457_698" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if triggerAction->isEmpty() then null
+else triggerAction->first().payloadParameter
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1675362060440_516944_693" name="" visibility="public" type="_19_0_2_12e503d9_1591477377905_618531_857" direction="return">
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1675362060446_549837_694" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1675362060452_823094_695" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_2022x_2_12e503d9_1732207444826_112532_892" name="sourceFeature" visibility="public" bodyCondition="_2022x_2_12e503d9_1732207493586_797117_893">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1732207622305_287946_897" annotatedElement="_2022x_2_12e503d9_1732207444826_112532_892">
+            <body>&lt;p>Return the &lt;code>Feature&lt;/code> to be used as the &lt;code>source&lt;/code> of the &lt;code>succession&lt;/code> of this &lt;code>TransitionUsage&lt;/code>, which is the first &lt;code>member&lt;/code> of the &lt;code>TransitionUsage&lt;/code> that is a &lt;code>Feature&lt;/code>, that is owned by the &lt;code>TransitionUsage&lt;/code> via a &lt;code>Membership&lt;/code> that is &lt;em>not&lt;/em> a &lt;code>FeatureMembership&lt;/code>, and whose &lt;code>featureTarget&lt;/code> is an &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_2022x_2_12e503d9_1732207493586_797117_893" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1732207493586_20181_894" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let features : Sequence(Feature) = ownedMembership->
+    reject(oclIsKindOf(FeatureMembership)).memberElement->
+    selectByKind(Feature)->
+    select(featureTarget.oclIsKindOf(ActionUsage)) in
+if features->isEmpty() then null
+else features->first()
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_2022x_2_12e503d9_1733344677842_637798_7" name="" visibility="public" direction="return">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1733344692653_905813_11" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1733344692654_915533_12" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1575672033669_188530_395" name="TransitionFeatureMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578599110644_307395_3959" annotatedElement="_19_0_2_12e503d9_1575672033669_188530_395">
+          <body>&lt;p>A &lt;code>TransitionFeatureMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> for a trigger, guard or effect of a &lt;code>TransitionUsage&lt;/code>, whose &lt;code>transitionFeature&lt;/code> is a &lt;code>AcceptActionUsage&lt;/code>, &lt;em>&lt;code>Boolean&lt;/code>&lt;/em>-valued &lt;code>Expression&lt;/code> or &lt;code>ActionUsage&lt;/code>, depending on its &lt;code>kind&lt;/code>. &lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675382768317_922619_561" name="validateTransitionFeatureMembershipTriggerAction" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672033669_188530_395">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675382903587_630608_563" annotatedElement="_19_0_4_12e503d9_1675382768317_922619_561">
+            <body>&lt;p>If the &lt;code>kind&lt;/code> of a &lt;code>TransitionUsage&lt;/code> is &lt;code>trigger&lt;/code>, then its &lt;code>transitionFeature&lt;/code> must be a kind of &lt;code>AcceptActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675382768326_411628_562" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>kind = TransitionFeatureKind::trigger implies
+    transitionFeature.oclIsKindOf(AcceptActionUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675382574345_448955_557" name="validateTransitionFeatureMembershipOwningType" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672033669_188530_395">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675382708533_885681_559" annotatedElement="_19_0_4_12e503d9_1675382574345_448955_557">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>TransitionFeatureMembership&lt;/code> must be a &lt;code>TransitionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675382574363_381541_558" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsKindOf(TransitionUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675382915025_411046_564" name="validateTransitionFeatureMembershipGuardExpression" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672033669_188530_395">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675382915055_417935_566" annotatedElement="_19_0_4_12e503d9_1675382915025_411046_564">
+            <body>&lt;p>If the &lt;code>kind&lt;/code> of a &lt;code>TransitionUsage&lt;/code> is &lt;code>guard&lt;/code>, then its &lt;code>transitionFeature&lt;/code> must be a kind of &lt;code>Expression&lt;/code> whose result is a &lt;em>&lt;code>Boolean&lt;/code>&lt;/em> value.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675382915051_198388_565" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>kind = TransitionFeatureKind::guard implies
+    transitionFeature.oclIsKindOf(Expression) and
+    let guard : Expression = transitionFeature.oclIsKindOf(Expression) in
+    guard.result.specializesFromLibrary('ScalarValues::Boolean') and
+    guard.result.multiplicity &lt;> null and
+    guard.result.multiplicity.hasBounds(1,1)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675382994628_889928_585" name="validateTransitionFeatureMembershipEffectAction" visibility="public" constrainedElement="_19_0_2_12e503d9_1575672033669_188530_395">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675382994655_334011_587" annotatedElement="_19_0_4_12e503d9_1675382994628_889928_585">
+            <body>&lt;p>If the &lt;code>kind&lt;/code> of a &lt;code>TransitionUsage&lt;/code> is &lt;code>effect&lt;/code>, then its &lt;code>transitionFeature&lt;/code> must be a kind of &lt;code>ActionUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675382994647_664595_586" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>kind = TransitionFeatureKind::effect implies
+    transitionFeature.oclIsKindOf(ActionUsage)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1575672060522_941290_422">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651715_740575_42237"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1575672142396_129864_506" name="kind" visibility="public" type="_19_0_2_12e503d9_1575672102123_272443_479">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586315534784_530592_811" annotatedElement="_19_0_2_12e503d9_1575672142396_129864_506">
+            <body>&lt;p>Whether this &lt;code>TransitionFeatureMembership &lt;/code> is for a &lt;code>trigger&lt;/code>, &lt;code>guard&lt;/code> or &lt;code>effect&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1582975046568_736161_148" name="transitionFeature" visibility="public" aggregation="composite" isDerived="true" association="_19_0_2_12e503d9_1582975046568_823274_147">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1582975252328_105491_172" annotatedElement="_19_0_2_12e503d9_1582975046568_736161_148">
+            <body>&lt;p>The &lt;code>Step&lt;/code> that is the &lt;code>ownedMemberFeature&lt;/code> of this &lt;code>TransitionFeatureMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_b9102da_1536345916995_711141_17306"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582975079861_3858_158" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582975079861_4642_159" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674993_898044_43344"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1577070975739_684062_203" name="ExhibitStateUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578440502662_864832_256" annotatedElement="_19_0_2_12e503d9_1577070975739_684062_203">
+          <body>&lt;p>An &lt;code>ExhibitStateUsage&lt;/code> is a &lt;code>StateUsage&lt;/code> that represents the exhibiting of a &lt;code>StateUsage&lt;/code>. Unless it is the &lt;code>StateUsage&lt;/code> itself, the &lt;code>StateUsage&lt;/code> to be exhibited is related to the &lt;code>ExhibitStateUsage&lt;/code> by a &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationship&lt;/code>. An &lt;code>ExhibitStateUsage&lt;/code> is also a &lt;code>PerformActionUsage&lt;/code>, with its &lt;code>exhibitedState&lt;/code> as the &lt;code>performedAction&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676650756429_693700_629" name="checkExhibitStateUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1577070975739_684062_203">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676650756473_995246_631" annotatedElement="_19_0_4_12e503d9_1676650756429_693700_629">
+            <body>&lt;p>If an &lt;code>ExhibitStateUsage&lt;/code> has an &lt;code>owningType&lt;/code> that is a &lt;code>PartDefinition&lt;/code> or &lt;code>PartUsage&lt;/code>, then it must directly or indirectly specialize the &lt;code>StateUsage&lt;/code> &lt;code>&lt;em>Parts::Part::exhibitedStates&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676650756462_622885_630" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(PartDefinition) or
+ owningType.oclIsKindOf(PartUsage)) implies
+    specializesFromLibrary('Parts::Part::exhibitedStates')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698944985561_398800_107" name="validateExhibitStateUsageReference" visibility="public" constrainedElement="_19_0_2_12e503d9_1577070975739_684062_203">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698945109165_655945_109" annotatedElement="_19_0_4_12e503d9_1698944985561_398800_107">
+            <body>&lt;p>If an &lt;code>ExhibitStateUsage&lt;/code> has an &lt;code>ownedReferenceSubsetting&lt;/code>, then the &lt;code>featureTarget&lt;/code> of the &lt;code>referencedFeature&lt;/code> must be a &lt;code>StateUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698944985577_472958_108" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referencedFeatureTarget() &lt;> null implies
+    referencedFeatureTarget().oclIsKindOf(StateUsage)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1577070989838_484612_246" general="_19_0_2_12e503d9_1575587557729_586912_651"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1621540623211_189796_1657" general="_18_5_3_12e503d9_1565503273042_472885_33822"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1577070999039_688794_260" name="exhibitedState" visibility="public" type="_19_0_2_12e503d9_1575587557729_586912_651" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1567740791820_867719_18017" association="_19_0_2_12e503d9_1577070999039_574431_259">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1581046721392_573516_9604" annotatedElement="_19_0_2_12e503d9_1577070999039_688794_260">
+            <body>&lt;p>The &lt;code>StateUsage&lt;/code> to be exhibited by the &lt;code>ExhibitStateUsage&lt;/code>. It is the &lt;code>performedAction&lt;/code> of the &lt;code>ExhibitStateUsage&lt;/code> considered as a &lt;code>PerformActionUsage&lt;/code>, which must be a &lt;code>StateUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1577071015405_111415_292" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1577071015406_233247_293" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_19_0_2_12e503d9_1575672102123_272443_479" name="TransitionFeatureKind" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578599163970_22074_3960" annotatedElement="_19_0_2_12e503d9_1575672102123_272443_479">
+          <body>&lt;p>A &lt;code>TransitionActionKind&lt;/code> indicates whether the &lt;code>transitionFeature&lt;/code> of a &lt;code>TransitionFeatureMembership&lt;/code> is a trigger, guard or effect.&lt;/p></body>
+        </ownedComment>
+        <ownedLiteral xmi:id="_19_0_2_12e503d9_1575672122376_92971_500" name="trigger" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586315623892_756930_812" annotatedElement="_19_0_2_12e503d9_1575672122376_92971_500">
+            <body>&lt;p>Indicates that the &lt;code>transitionFeature&lt;/code> of a &lt;code>TransitionFeatureMembership&lt;/code> is a &lt;code>triggerAction&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_19_0_2_12e503d9_1575672129172_37300_502" name="guard" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586315697317_465604_813" annotatedElement="_19_0_2_12e503d9_1575672129172_37300_502">
+            <body>&lt;p>Indicates that the &lt;code>transitionFeature&lt;/code> of a &lt;code>TransitionFeatureMembership&lt;/code> is a &lt;code>guardExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_19_0_2_12e503d9_1575672135615_421029_504" name="effect" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586315713219_561690_814" annotatedElement="_19_0_2_12e503d9_1575672135615_421029_504">
+            <body>&lt;p>Indicates that the &lt;code>transitionFeature&lt;/code> of a &lt;code>TransitionFeatureMembership&lt;/code> is an &lt;code>effectAction&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1577070999039_574431_259" name="A_exhibitedState_exhibitingState" visibility="public" memberEnd="_19_0_2_12e503d9_1577070999039_688794_260 _19_0_2_12e503d9_1577070999040_977153_261">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1577070999040_977153_261" name="exhibitingState" visibility="public" type="_19_0_2_12e503d9_1577070975739_684062_203" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1567740791820_137197_18018" association="_19_0_2_12e503d9_1577070999039_574431_259">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314177230_934465_777" annotatedElement="_19_0_2_12e503d9_1577070999040_977153_261">
+            <body>&lt;p>The ExhibitStateUsages that have a certain StateUsage as their &lt;tt>exhibitedState&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1577071023378_293489_306" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1577071023378_359886_307" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1581030490131_396465_6363" name="A_succession_linkedTransition" visibility="public" memberEnd="_19_0_2_12e503d9_1581030490131_304332_6364 _19_0_2_12e503d9_1581030490131_732210_6365">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1581030490131_732210_6365" name="linkedTransition" visibility="public" type="_19_0_2_12e503d9_1575672078353_626298_450" isDerived="true" association="_19_0_2_12e503d9_1581030490131_396465_6363">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316560589_874458_829" annotatedElement="_19_0_2_12e503d9_1581030490131_732210_6365">
+            <body>&lt;p>The Transition that owns a certain Succession.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583705756070_11745_1695" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583705756070_743704_1696" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674986_474739_43306"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1581029782522_117628_6298" name="A_effectAction_activeTransition" visibility="public" memberEnd="_19_0_2_12e503d9_1581029782522_542070_6299 _19_0_2_12e503d9_1581029782523_217610_6300">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1581029782523_217610_6300" name="activeTransition" visibility="public" type="_19_0_2_12e503d9_1575672078353_626298_450" isDerived="true" association="_19_0_2_12e503d9_1581029782522_117628_6298">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316633727_954512_830" annotatedElement="_19_0_2_12e503d9_1581029782523_217610_6300">
+            <body>&lt;p>The TransitionUsage that has a certain &lt;tt>effectAction&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583705919841_342984_1703" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583705919842_108070_1704" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1581029493366_136034_6152" name="A_target_incomingTransition" visibility="public" memberEnd="_19_0_2_12e503d9_1581029493366_130491_6153 _19_0_2_12e503d9_1581029493367_962648_6154">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1581029493367_962648_6154" name="incomingTransition" visibility="public" type="_19_0_2_12e503d9_1575672078353_626298_450" isDerived="true" association="_19_0_2_12e503d9_1581029493366_136034_6152">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316665217_99220_831" annotatedElement="_19_0_2_12e503d9_1581029493367_962648_6154">
+            <body>&lt;p>The TransitionUsage incoming to a certain target &lt;tt>ActionUsage&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583705994452_608541_1713" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583705994453_81213_1714" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1581029662255_938680_6208" name="A_triggerAction_triggeredTransition" visibility="public" memberEnd="_19_0_2_12e503d9_1581029662256_985457_6209 _19_0_2_12e503d9_1581029662256_279869_6210">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1581029662256_279869_6210" name="triggeredTransition" visibility="public" type="_19_0_2_12e503d9_1575672078353_626298_450" isDerived="true" association="_19_0_2_12e503d9_1581029662255_938680_6208">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316507789_323596_827" annotatedElement="_19_0_2_12e503d9_1581029662256_279869_6210">
+            <body>&lt;p>The TransitionUsage that is triggered by a certain AcceptActionUsage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583705702352_834299_1655" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583705702353_631150_1656" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1581029720824_149051_6253" name="A_guardExpression_guardedTransition" visibility="public" memberEnd="_19_0_2_12e503d9_1581029720824_747691_6254 _19_0_2_12e503d9_1581029720825_258946_6255">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1581029720825_258946_6255" name="guardedTransition" visibility="public" type="_19_0_2_12e503d9_1575672078353_626298_450" isDerived="true" association="_19_0_2_12e503d9_1581029720824_149051_6253">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591500125707_236510_4327" annotatedElement="_19_0_2_12e503d9_1581029720825_258946_6255">
+            <body>&lt;p>The TransitionUsage that is guarded by a certain Expression.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583705721088_416641_1675" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583705721088_983806_1676" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1581029439310_886075_6113" name="A_source_outgoingTransition" visibility="public" memberEnd="_19_0_2_12e503d9_1581029439311_947395_6114 _19_0_2_12e503d9_1581029439311_641133_6115">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1581029439311_641133_6115" name="outgoingTransition" visibility="public" type="_19_0_2_12e503d9_1575672078353_626298_450" isDerived="true" association="_19_0_2_12e503d9_1581029439310_886075_6113">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586316686257_820200_832" annotatedElement="_19_0_2_12e503d9_1581029439311_641133_6115">
+            <body>&lt;p>The TransitionUsage outgoing from a certain source &lt;tt>ActionUsage&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583705991136_879971_1709" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583705991136_152404_1710" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1582975927010_291183_351" name="A_exitAction_exitedStateDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1582975927011_696894_352 _19_0_2_12e503d9_1582975927012_877974_353">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1582975927012_877974_353" name="exitedStateDefinition" visibility="public" type="_19_0_2_12e503d9_1575587534200_898246_600" isDerived="true" association="_19_0_2_12e503d9_1582975927010_291183_351">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314862726_764179_792" annotatedElement="_19_0_2_12e503d9_1582975927012_877974_353">
+            <body>&lt;p>The StateDefinitions with a certain &lt;tt>exitAction&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582976233207_433635_590" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582976233207_861967_591" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1582975916386_236056_338" name="A_doAction_activeStateDefintion" visibility="public" memberEnd="_19_0_2_12e503d9_1582975916386_388324_339 _19_0_2_12e503d9_1582975916387_231969_340">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1582975916387_231969_340" name="activeStateDefintion" visibility="public" type="_19_0_2_12e503d9_1575587534200_898246_600" isDerived="true" association="_19_0_2_12e503d9_1582975916386_236056_338">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314831883_636564_791" annotatedElement="_19_0_2_12e503d9_1582975916387_231969_340">
+            <body>&lt;p>The StateDefinitions with a certain &lt;tt>doAction&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582976222269_134144_576" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582976222269_504058_577" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1582976239199_397775_604" name="A_entryAction_enteredState" visibility="public" memberEnd="_19_0_2_12e503d9_1582976239200_979652_605 _19_0_2_12e503d9_1582976239206_699877_606">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1582976239206_699877_606" name="enteredState" visibility="public" type="_19_0_2_12e503d9_1575587557729_586912_651" isDerived="true" association="_19_0_2_12e503d9_1582976239199_397775_604">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314898575_874925_795" annotatedElement="_19_0_2_12e503d9_1582976239206_699877_606">
+            <body>&lt;p>The StateUsages with a certain &lt;tt>entryAction&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582976311736_72536_731" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582976311736_218473_732" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1582975902339_934472_311" name="A_entryAction_enteredStateDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1582975902339_513804_312 _19_0_2_12e503d9_1582975902340_252529_313">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1582975902340_252529_313" name="enteredStateDefinition" visibility="public" type="_19_0_2_12e503d9_1575587534200_898246_600" isDerived="true" association="_19_0_2_12e503d9_1582975902339_934472_311">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314822264_429141_790" annotatedElement="_19_0_2_12e503d9_1582975902340_252529_313">
+            <body>&lt;p>The StateDefinitions with a certain &lt;tt>entryAction&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582976182018_768256_544" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582976182018_128220_545" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1582975046568_823274_147" name="A_transitionFeature_transitionFeatureMembership" visibility="public" memberEnd="_19_0_2_12e503d9_1582975046568_736161_148 _19_0_2_12e503d9_1582975046569_663761_149">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1582975046569_663761_149" name="transitionFeatureMembership" visibility="public" type="_19_0_2_12e503d9_1575672033669_188530_395" isDerived="true" association="_19_0_2_12e503d9_1582975046568_823274_147">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586315768232_590667_815" annotatedElement="_19_0_2_12e503d9_1582975046569_663761_149">
+            <body>&lt;p>The TransitionFeatureMembership that owns a certain Step (if any).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583707131247_787881_2189" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583707131248_919715_2190" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674970_68441_43223"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1582976283940_517953_690" name="A_exitAction_exitedState" visibility="public" memberEnd="_19_0_2_12e503d9_1582976283940_998741_691 _19_0_2_12e503d9_1582976283941_243838_692">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1582976283941_243838_692" name="exitedState" visibility="public" type="_19_0_2_12e503d9_1575587557729_586912_651" isDerived="true" association="_19_0_2_12e503d9_1582976283940_517953_690">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314876850_727021_793" annotatedElement="_19_0_2_12e503d9_1582976283941_243838_692">
+            <body>&lt;p>The StateUsages with a certain &lt;tt>exitAction&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582976331146_427550_757" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582976331146_890577_758" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1582976255472_347038_643" name="A_doAction_activeState" visibility="public" memberEnd="_19_0_2_12e503d9_1582976255473_203238_644 _19_0_2_12e503d9_1582976255473_424029_645">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1582976255473_424029_645" name="activeState" visibility="public" type="_19_0_2_12e503d9_1575587557729_586912_651" isDerived="true" association="_19_0_2_12e503d9_1582976255472_347038_643">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314885210_224644_794" annotatedElement="_19_0_2_12e503d9_1582976255473_424029_645">
+            <body>&lt;p>The StateUsages with a certain &lt;tt>doAction&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1582976315529_978805_737" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1582976315536_236109_738" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1582974847979_801200_95" name="A_action_stateSubactionMembership" visibility="public" memberEnd="_19_0_2_12e503d9_1582974847979_606181_96 _19_0_2_12e503d9_1582974847980_492162_97">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1582974847980_492162_97" name="stateSubactionMembership" visibility="public" type="_19_0_2_12e503d9_1575671792204_632048_203" isDerived="true" association="_19_0_2_12e503d9_1582974847979_801200_95">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586315397020_268025_810" annotatedElement="_19_0_2_12e503d9_1582974847980_492162_97">
+            <body>&lt;p>The StateSubactionMembership that is the owner of a certain ActionUsage (if any).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583707123191_110411_2177" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583707123192_519975_2178" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674970_68441_43223"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1578066877077_760426_1020" name="Constraints" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1578067096274_745288_1478" name="ConstraintUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1578069171660_147754_1832" annotatedElement="_19_0_2_12e503d9_1578067096274_745288_1478">
+          <body>&lt;p>A &lt;code>ConstraintUsage&lt;/code> is an &lt;code>OccurrenceUsage&lt;/code> that is also a &lt;code>BooleanExpression&lt;/code>, and, so, is typed by a &lt;code>Predicate&lt;/code>. Nominally, if the type is a &lt;code>ConstraintDefinition&lt;/code>, a &lt;code>ConstraintUsage&lt;/code> is a &lt;code>Usage&lt;/code> of that &lt;code>ConstraintDefinition&lt;/code>. However, other kinds of kernel &lt;code>Predicates&lt;/code> are also allowed, to permit use of &lt;code>Predicates&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675461118332_474776_854" name="checkConstraintUsageRequirementConstraintSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1578067096274_745288_1478">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676653244381_16796_718" annotatedElement="_19_0_4_12e503d9_1675461118332_474776_854">
+            <body>&lt;p>A composite &lt;code>ConstraintUsage&lt;/code> whose &lt;code>owningFeatureMembership&lt;/code> is a &lt;code>RequirementConstraintMembership&lt;/code> must directly or indirectly specialize on the &lt;code>ConstraintUsages&lt;/code> &lt;code>&lt;em>assumptions&lt;/em>&lt;/code> or &lt;code>&lt;em>constraints&lt;/em>&lt;/code> from the &lt;code>ConstraintDefinition&lt;/code> &lt;code>&lt;em>Requirements::RequirementCheck&lt;/em>&lt;/code> in the Systems Model Library, depending on whether the &lt;code>kind&lt;/code> of the &lt;code>RequirementConstraintMembership&lt;/code> is &lt;code>assumption&lt;/code> or &lt;code>requirement&lt;/code>, respectively.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675461118352_463963_855" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and
+owningFeatureMembership &lt;> null and
+owningFeatureMembership.oclIsKindOf(RequirementConstraintMembership) implies
+    if owningFeatureMembership.oclAsType(RequirementConstraintMembership).kind = 
+        RequirementConstraintKind::assumption then
+        specializesFromLibrary('Requirements::RequirementCheck::assumptions')
+    else
+        specializesFromLibrary('Requirements::RequirementCheck::constraints')
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675460148933_851295_836" name="checkConstraintUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1578067096274_745288_1478">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675460253850_344678_838" annotatedElement="_19_0_4_12e503d9_1675460148933_851295_836">
+            <body>&lt;p>A &lt;code>ConstraintUsage&lt;/code> must directly or indirectly specialize the base &lt;code>ConstraintUsage&lt;/code> &lt;em>&lt;code>Constraints::constraintChecks&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675460148954_54507_837" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Constraints::constraintChecks')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675460257311_689432_839" name="checkConstraintUsageCheckedConstraintSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1578067096274_745288_1478">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675461009136_736661_843" annotatedElement="_19_0_4_12e503d9_1675460257311_689432_839">
+            <body>&lt;p>A &lt;code>ConstraintUsage&lt;/code> whose &lt;code>owningType&lt;/code> is an &lt;code>ItemDefinition&lt;/code> or &lt;code>ItemUsage&lt;/code> must directly or indirectly specialize the &lt;code>ConstraintUsage&lt;/code> &lt;em>&lt;code>Items::Item::checkedConstraints&lt;/code>&lt;/em>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675460257324_902326_840" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(ItemDefinition) or
+ owningType.oclIsKindOf(ItemUsage)) implies
+    specializesFromLibrary('Items::Item::checkedConstraints')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1578067303586_613232_1589">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_2_12e503d9_1578511256733_336334_354"/>
+        </generalization>
+        <generalization xmi:id="_19_0_2_12e503d9_1578067122159_87006_1505" general="_19_0_4_12e503d9_1618943737195_33207_138"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1578067546711_751168_1745" name="constraintDefinition" visibility="public" isDerived="true" association="_19_0_2_12e503d9_1578067546711_623195_1744">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586295267033_166833_386" annotatedElement="_19_0_2_12e503d9_1578067546711_751168_1745">
+            <body>&lt;p>The (single) &lt;code>Predicate&lt;/code> that is the type of this &lt;code>ConstraintUsage&lt;/code>. Nominally, this will be a &lt;code>ConstraintDefinition&lt;/code>, but other kinds of &lt;code>Predicates&lt;/code> are also allowed, to permit use of &lt;code>Predicates&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651691_194569_42171"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1667403295991_249678_26" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1667403295999_346884_27" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1578025035149_386_969"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1617483628003_824933_27118" name="namingFeature" visibility="public" bodyCondition="_19_0_4_12e503d9_1675460008487_78797_834" redefinedOperation="_19_0_4_12e503d9_1617482356453_410307_26991">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617483872609_626988_27199" annotatedElement="_19_0_4_12e503d9_1617483628003_824933_27118">
+            <body>&lt;p>The naming &lt;code>Feature&lt;/code> of a &lt;code>ConstraintUsage&lt;/code> that is owned by a &lt;code>RequirementConstraintMembership&lt;/code> and has an &lt;code>ownedReferenceSubsetting&lt;/code> is the &lt;code>featureTarget&lt;/code> of the &lt;code>referencedFeature&lt;/code> of that &lt;code>ownedReferenceSubsetting&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1675460008487_78797_834" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675460008503_859288_835" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>if owningFeatureMembership &lt;> null and
+owningFeatureMembership.oclIsKindOf(RequirementConstraintMembership) and
+ownedReferenceSubsetting &lt;> null then
+    ownedReferenceSubsetting.referencedFeature.featureTarget
+else
+    self.oclAsType(OccurrenceUsage).namingFeature()
+endif</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1617483687662_700184_27138" name="" visibility="public" direction="return">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617483687664_7584_27139" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617483687665_885350_27140" name="" visibility="public" value="1"/>
+          </ownedParameter>
+        </ownedOperation>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665528956981_401422_2553" name="modelLevelEvaluable" visibility="public" bodyCondition="_19_0_4_12e503d9_1665528956998_654178_2554">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665528957004_870522_2555" annotatedElement="_19_0_4_12e503d9_1665528956981_401422_2553">
+            <body>&lt;p>A &lt;code>ConstraintUsage&lt;/code> is not model-level evaluable.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665528956998_654178_2554" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665528957006_261265_2556" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>false</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665614568893_284677_2712" name="visited" visibility="public">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665614568903_990001_2713" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665614568904_822938_2714" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665615698494_305206_2734" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <redefinedOperation href="KerML_only_xmi.uml#_19_0_4_12e503d9_1665516752162_909455_1465"/>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1578067054125_439104_1452" name="ConstraintDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1582974438644_380580_34" annotatedElement="_19_0_2_12e503d9_1578067054125_439104_1452">
+          <body>&lt;p>A &lt;code>ConstraintDefinition&lt;/code> is an &lt;code>OccurrenceDefinition&lt;/code> that is also a &lt;code>Predicate&lt;/code> that defines a constraint that may be asserted to hold on a system or part of a system.&lt;/p>
+
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675459143632_174430_831" name="checkConstraintDefinitionSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1578067054125_439104_1452">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675459256908_296125_833" annotatedElement="_19_0_4_12e503d9_1675459143632_174430_831">
+            <body>&lt;p>A &lt;code>ConstraintDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>ConstraintDefinition&lt;/code> &lt;em>&lt;code>Constraints::ConstraintCheck&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675459143652_222981_832" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Constraints::ConstraintCheck')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1578067127999_923325_1508" general="_19_0_4_12e503d9_1618943693347_790503_111"/>
+        <generalization xmi:id="_19_0_2_12e503d9_1578067307271_331602_1592">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651691_194569_42171"/>
+        </generalization>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1578067546711_623195_1744" name="A_constraintDefinition_definedConstraint" visibility="public" memberEnd="_19_0_2_12e503d9_1578067546711_751168_1745 _19_0_2_12e503d9_1578067546711_808430_1746">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1578067546711_808430_1746" name="definedConstraint" visibility="public" type="_19_0_2_12e503d9_1578067096274_745288_1478" isDerived="true" association="_19_0_2_12e503d9_1578067546711_623195_1744">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586298092129_319444_462" annotatedElement="_19_0_2_12e503d9_1578067546711_808430_1746">
+            <body>&lt;p>The ConstraintUsages typed by a certain Predicate.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1578067635718_189896_1763" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1578067635718_687755_1764" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1578025035149_512008_970"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1581045158665_865397_9457" name="A_assertedConstraint_constraintAssertion" visibility="public" memberEnd="_19_0_2_12e503d9_1581045158665_239617_9458 _19_0_2_12e503d9_1581045158672_291459_9459">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1581045158672_291459_9459" name="constraintAssertion" visibility="public" type="_19_0_2_12e503d9_1581045078368_47459_9326" isDerived="true" association="_19_0_2_12e503d9_1581045158665_865397_9457">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313509795_793899_675" annotatedElement="_19_0_2_12e503d9_1581045158672_291459_9459">
+            <body>&lt;p>The AssertConstraintUsages that have a certain ConstraintUsage as their &lt;tt>assertedConstraint&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583185331971_42658_2551" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583185331971_790494_2552" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1581045078368_47459_9326" name="AssertConstraintUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1581045547351_683200_9507" annotatedElement="_19_0_2_12e503d9_1581045078368_47459_9326">
+          <body>&lt;p>An &lt;code>AssertConstraintUsage&lt;/code> is a &lt;code>ConstraintUsage&lt;/code> that is also an &lt;code>Invariant&lt;/code> and, so, is asserted to be true (by default). Unless it is the &lt;code>AssertConstraintUsage&lt;/code> itself, the asserted &lt;code>ConstraintUsage&lt;/code> is related to the &lt;code>AssertConstraintUsage&lt;/code> by a ReferenceSubsetting &lt;code>Relationship&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1661877851412_92770_358" name="deriveAssertConstraintUsageAssertedConstraint" visibility="public" constrainedElement="_19_0_2_12e503d9_1581045078368_47459_9326">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661878029843_229827_360" annotatedElement="_19_0_4_12e503d9_1661877851412_92770_358">
+            <body>&lt;p>If an &lt;code>AssertConstraintUsage&lt;/code> has no &lt;code>ownedReferenceSubsetting&lt;/code>, then its &lt;code>assertedConstraint&lt;/code> is the &lt;code>AssertConstraintUsage&lt;/code> itself. Otherwise, the &lt;code>assertedConstraint&lt;/code> is the &lt;code>featureTarget&lt;/code> of the &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code>, which must be a &lt;code>ConstraintUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1661877851424_647432_359" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>assertedConstraint =
+    if referencedFeatureTarget() = null then self
+    else if referencedFeatureTarget().oclIsKindOf(ConstraintUsage) then
+        referencedFeatureTarget().oclAsType(ConstraintUsage)
+    else null
+    endif endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676861809960_161639_27402" name="checkAssertConstraintUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1581045078368_47459_9326">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676862058207_857585_27404" annotatedElement="_19_0_4_12e503d9_1676861809960_161639_27402">
+            <body>&lt;p>If a &lt;code>AssertConstraintUsage&lt;/code> is negated, then it must directly or indirectly specialize the &lt;code>ConstraintUsage&lt;/code> &lt;code>&lt;em>Constraints::negatedConstraintChecks&lt;/em>&lt;/code>. Otherwise, it must directly or indirectly specialize the &lt;code>ConstraintUsage&lt;/code> &lt;code>&lt;em>Constraints::assertedConstraintChecks&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676861809973_44427_27403" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if isNegated then
+    specializesFromLibrary('Constraints::negatedConstraintChecks')
+else
+    specializesFromLibrary('Constraints::assertedConstraintChecks')
+endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698945137360_430649_110" name="validateAssertConstraintUsageReference" visibility="public" constrainedElement="_19_0_2_12e503d9_1581045078368_47459_9326">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698945211024_788871_112" annotatedElement="_19_0_4_12e503d9_1698945137360_430649_110">
+            <body>&lt;p>If an &lt;code>AssertConstraintUsage&lt;/code> has an &lt;code>ownedReferenceSubsetting&lt;/code>, then the &lt;code>featureTarget&lt;/code> of its &lt;code>referencedFeature&lt;/code> must be a &lt;/code>ConstraintUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698945137377_756275_111" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referencedFeatureTarget() &lt;> null implies
+    referencedFeatureTarget().oclIsKindOf(ConstraintUsage)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1581045096529_911386_9379" general="_19_0_2_12e503d9_1578067096274_745288_1478"/>
+        <generalization xmi:id="_19_0_2_12e503d9_1581045121380_374538_9426">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_2_12e503d9_1578025014367_499614_936"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1581045158665_239617_9458" name="assertedConstraint" visibility="public" type="_19_0_2_12e503d9_1578067096274_745288_1478" isDerived="true" association="_19_0_2_12e503d9_1581045158665_865397_9457">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1581046466847_53010_9603" annotatedElement="_19_0_2_12e503d9_1581045158665_239617_9458">
+            <body>&lt;p>The &lt;code>ConstraintUsage&lt;/code> to be performed by the &lt;code>AssertConstraintUsage&lt;/code>. It is the &lt;code>referenceFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> for the &lt;code>AssertConstraintUsage&lt;/code>, if there is one, and, otherwise, the &lt;code>AssertConstraintUsage&lt;/code> itself.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1581045169438_730476_9474" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1581045169439_399007_9475" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1582985729353_121513_787" name="Requirements" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1583377448339_649796_389" name="A_requiredConstraint_requiringRequirement" visibility="public" memberEnd="_19_0_2_12e503d9_1583377448339_252740_390 _19_0_2_12e503d9_1583377448340_603710_391">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1583377448340_603710_391" name="requiringRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isDerived="true" association="_19_0_2_12e503d9_1583377448339_649796_389">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586314503578_663816_789" annotatedElement="_19_0_2_12e503d9_1583377448340_603710_391">
+            <body>&lt;p>The RequirementUsage that has a certain ConstraintUsage as a &lt;code>requiredConstraint&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583377472062_562413_430" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583377472063_430354_431" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1583377612865_323213_534" name="A_assumedConstraint_assumingRequirement" visibility="public" memberEnd="_19_0_2_12e503d9_1583377612865_991722_535 _19_0_2_12e503d9_1583377612866_947871_536">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1583377612866_947871_536" name="assumingRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isDerived="true" association="_19_0_2_12e503d9_1583377612865_323213_534">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313249621_333974_650" annotatedElement="_19_0_2_12e503d9_1583377612866_947871_536">
+            <body>&lt;p>The RequirementUsage that has a certain ConstraintUsage as an &lt;cod>assumedConstraint&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583377697698_942601_609" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583377697699_851403_610" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1583185037723_897508_2331" name="A_satisfiedRequirement_requirementSatisfaction" visibility="public" memberEnd="_19_0_2_12e503d9_1583185037725_699150_2332 _19_0_2_12e503d9_1583185037730_978111_2333">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1583185037730_978111_2333" name="requirementSatisfaction" visibility="public" type="_19_0_2_12e503d9_1583184587272_448420_2009" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1581045158672_291459_9459" association="_19_0_2_12e503d9_1583185037723_897508_2331">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313044821_49495_643" annotatedElement="_19_0_2_12e503d9_1583185037730_978111_2333">
+            <body>&lt;p>The SatifyRequirementUsages that have a certain RequirementUsage as their &lt;tt>satisfiedRequirement&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583185452012_483310_2579" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583185452013_653716_2580" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1582990729262_130404_898" name="RequirementDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1583186543197_898388_2682" annotatedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <body>&lt;p>A &lt;code>RequirementDefinition&lt;/code> is a &lt;code>ConstraintDefinition&lt;/code> that defines a requirement used in the context of a specification as a constraint that a valid solution must satisfy. The specification is relative to a specified subject, possibly in collaboration with one or more external actors.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676655325311_692958_762" name="deriveRequirementDefinitionText" visibility="public" constrainedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676655499260_317278_764" annotatedElement="_19_0_4_12e503d9_1676655325311_692958_762">
+            <body>&lt;p>The &lt;code>texts&lt;/code> of a&lt;code>RequirementDefinition&lt;/code> are the &lt;code>bodies&lt;/code> of the &lt;code>documentation&lt;/code> of the &lt;code>RequirementDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676655325325_352469_763" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>text = documentation.body</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676655506174_572014_765" name="deriveRequirementDefinitionAssumedConstraint" visibility="public" constrainedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676655656262_266108_767" annotatedElement="_19_0_4_12e503d9_1676655506174_572014_765">
+            <body>&lt;p>The &lt;code>assumedConstraints&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> are the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code> with &lt;code>kind = assumption&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676655506177_42075_766" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>assumedConstraint = ownedFeatureMembership->
+    selectByKind(RequirementConstraintMembership)->
+    select(kind = RequirementConstraintKind::assumption).
+    ownedConstraint</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676655691746_552111_768" name="deriveRequirementDefinitionRequiredConstraint" visibility="public" constrainedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676655826153_862165_774" annotatedElement="_19_0_4_12e503d9_1676655691746_552111_768">
+            <body>&lt;p>The &lt;code>requiredConstraints&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> are the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code> with &lt;code>kind = requirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676655691754_625084_769" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>requiredConstraint = ownedFeatureMembership->
+    selectByKind(RequirementConstraintMembership)->
+    select(kind = RequirementConstraintKind::requirement).
+    ownedConstraint</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676655837328_440544_775" name="deriveRequirementDefinitionSubjectParameter" visibility="public" constrainedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676656140584_832559_791" annotatedElement="_19_0_4_12e503d9_1676655837328_440544_775">
+            <body>&lt;p>The &lt;code>subjectParameter&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> is the &lt;code>ownedSubjectParameter&lt;/code> of its &lt;code>SubjectMembership&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676655837340_104370_776" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>subjectParameter =
+    let subjects : OrderedSet(SubjectMembership) = 
+        featureMembership->selectByKind(SubjectMembership) in
+    if subjects->isEmpty() then null
+    else subjects->first().ownedSubjectParameter
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676656196816_375834_792" name="deriveRequirementDefinitionFramedConcern" visibility="public" constrainedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676656359393_189119_802" annotatedElement="_19_0_4_12e503d9_1676656196816_375834_792">
+            <body>&lt;p>The &lt;code>framedConcerns&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> are the &lt;code>ownedConcerns&lt;/code> of the &lt;code>FramedConcernMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676656196822_753944_793" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>framedConcern = featureMembership->
+    selectByKind(FramedConcernMembership).
+    ownedConcern</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676656273773_438381_794" name="deriveRequirementDefinitionActorParameter" visibility="public" constrainedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676656447725_468617_803" annotatedElement="_19_0_4_12e503d9_1676656273773_438381_794">
+            <body>&lt;p>The &lt;code>actorParameters&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> are the &lt;code>ownedActorParameters&lt;/code> of the &lt;code>ActorMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676656273790_612317_795" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>actorParameter = featureMembership->
+    selectByKind(ActorMembership).
+    ownedActorParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676656459500_593286_804" name="deriveRequirementDefinitionStakeholderParameter" visibility="public" constrainedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676656530555_322917_806" annotatedElement="_19_0_4_12e503d9_1676656459500_593286_804">
+            <body>&lt;p>The &lt;code>stakeHolderParameters&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> are the &lt;code>ownedStakeholderParameters&lt;/code> of the &lt;code>StakeholderMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676656459502_279465_805" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>stakeholderParameter = featureMembership->
+    selectByKind(StakholderMembership).
+    ownedStakeholderParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676656604853_392729_817" name="validateRequirementDefinitionOnlyOneSubject" visibility="public" constrainedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676656717822_518200_819" annotatedElement="_19_0_4_12e503d9_1676656604853_392729_817">
+            <body>&lt;p>A &lt;code>RequirementDefinition&lt;/code> must have at most one &lt;code>featureMembership&lt;/code> that is a &lt;code>SubjectMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676656604864_347822_818" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureMembership->	
+    selectByKind(SubjectMembership)->
+    size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676732581338_727054_748" name="validateRequirementDefinitionSubjectParameterPosition" visibility="public" constrainedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676732697896_196066_750" annotatedElement="_19_0_4_12e503d9_1676732581338_727054_748">
+            <body>&lt;p>The &lt;code>subjectParameter&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> must be its first &lt;code>input&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676732581383_365490_749" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>input->notEmpty() and input->first() = subjectParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676734523187_169434_859" name="checkRequirementDefinitionSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1582990729262_130404_898">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676734605363_471165_861" annotatedElement="_19_0_4_12e503d9_1676734523187_169434_859">
+            <body>&lt;p>A &lt;code>RequirementDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>RequirementDefinition&lt;/code> &lt;code>&lt;em>Requirements::RequirementCheck&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676734523194_905962_860" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Requirements::RequirementCheck')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1582991070554_181330_1141" general="_19_0_2_12e503d9_1578067054125_439104_1452"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583376411386_270321_92" name="reqId" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301717285_378553_567" annotatedElement="_19_0_2_12e503d9_1583376411386_270321_92">
+            <body>&lt;p>An optional modeler-specified identifier for this &lt;code>RequirementDefinition&lt;/code> (used, e.g., to link it to an original requirement text in some source document), which is the &lt;code>declaredShortName&lt;/code> for the &lt;code>RequirementDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1586301546600_962278_558" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1586301546605_527380_559" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1594160442439_915308_4153"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583376433122_189839_94" name="text" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301787915_914452_569" annotatedElement="_19_0_2_12e503d9_1583376433122_189839_94">
+            <body>&lt;p>An optional textual statement of the requirement represented by this &lt;code>RequirementDefinition&lt;/code>, derived from the &lt;code>bodies&lt;/code> of the &lt;code>documentation&lt;/code> of the &lt;code>RequirementDefinition&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1586301556055_64152_560" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1586301556057_152619_561" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1595189007408_784255_586" name="subjectParameter" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1595189007407_366933_585">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1595189628613_813775_953" annotatedElement="_19_0_2_12e503d9_1595189007408_784255_586">
+            <body>&lt;p>The &lt;code>parameter&lt;/code> of this &lt;code>RequirementDefinition&lt;/code> that represents its subject.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595189024932_185672_596" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595189024932_909699_597" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948010065_362066_20413"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_48981_27786"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621564041941_652319_2722" name="actorParameter" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1621564041941_436555_2721">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621564795478_133971_2945" annotatedElement="_19_0_4_12e503d9_1621564041941_652319_2722">
+            <body>&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>RequirementDefinition&lt;/code> that represent actors involved in the requirement.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621564216068_786247_2747" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621564216070_85614_2748" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948010065_362066_20413"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_48981_27786"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624033010374_29375_40166" name="stakeholderParameter" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1624033010374_739400_40165">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624033480107_102397_40378" annotatedElement="_19_0_4_12e503d9_1624033010374_29375_40166">
+            <body>&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>RequirementDefinition&lt;/code> that represent stakeholders for the requirement.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624033094315_393113_40208" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624033094315_507041_40209" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948010065_362066_20413"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_48981_27786"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583376806647_629021_133" name="assumedConstraint" visibility="public" type="_19_0_2_12e503d9_1578067096274_745288_1478" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1583376806646_723384_132">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301845346_351670_571" annotatedElement="_19_0_2_12e503d9_1583376806647_629021_133">
+            <body>&lt;p>The owned &lt;code>ConstraintUsages&lt;/code> that represent assumptions of this &lt;code>RequirementDefinition&lt;/code>, which are the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code> with &lt;code>kind = assumption&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583376841892_224264_143" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583376841893_196769_144" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_226999_43167"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583376932997_792124_158" name="requiredConstraint" visibility="public" type="_19_0_2_12e503d9_1578067096274_745288_1478" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1583376932997_22788_157">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301893890_5931_572" annotatedElement="_19_0_2_12e503d9_1583376932997_792124_158">
+            <body>&lt;p>The owned &lt;code>ConstraintUsages&lt;/code> that represent requirements of this &lt;code>RequirementDefinition&lt;/code>, derived as the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code> with &lt;code>kind&lt;/code> = &lt;code>requirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583376993830_239442_168" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583376993831_783326_169" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_226999_43167"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617116733499_587735_3242" name="framedConcern" visibility="public" type="_19_0_4_12e503d9_1617051561652_163085_1288" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583376932997_792124_158" association="_19_0_4_12e503d9_1617116733499_254226_3241">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617116906526_914580_3256" annotatedElement="_19_0_4_12e503d9_1617116733499_587735_3242">
+            <body>&lt;p>The &lt;code>ConcernUsages&lt;/code> framed by this &lt;code>RequirementDefinition&lt;/code>, which are the &lt;code>ownedConcerns&lt;/code> of all &lt;code>FramedConcernMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617116757256_777280_3252" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617116757263_36107_3253" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1583378847285_187229_1395" name="A_satisfyingFeature_satisfiedRequirement" visibility="public" memberEnd="_19_0_2_12e503d9_1583378847285_929988_1396 _19_0_2_12e503d9_1583378847286_824940_1397">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1583378847286_824940_1397" name="satisfiedRequirement" visibility="public" type="_19_0_2_12e503d9_1583184587272_448420_2009" isDerived="true" association="_19_0_2_12e503d9_1583378847285_187229_1395">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313075805_415928_644" annotatedElement="_19_0_2_12e503d9_1583378847286_824940_1397">
+            <body>&lt;p>The SatisfyRequirementUsages that have a certain Feature as their &lt;tt>satisfyingFeature&lt;/tt>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583378997486_186302_1550" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583378997486_582321_1551" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1583000408904_155679_1222" name="A_requirementDefinition_definedRequirement" visibility="public" memberEnd="_19_0_2_12e503d9_1583000408905_769743_1223 _19_0_2_12e503d9_1583000408905_309783_1224">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1583000408905_309783_1224" name="definedRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1578067546711_808430_1746" association="_19_0_2_12e503d9_1583000408904_155679_1222">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313164221_507772_647" annotatedElement="_19_0_2_12e503d9_1583000408905_309783_1224">
+            <body>&lt;p>The RequirementUsages typed by a certain RequirementDefinition.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583000867256_551480_1301" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583000867257_189797_1302" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1583376806646_723384_132" name="A_assumedConstraint_assumingRequirementDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1583376806647_629021_133 _19_0_2_12e503d9_1583376806648_36714_134">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1583376806648_36714_134" name="assumingRequirementDefinition" visibility="public" type="_19_0_2_12e503d9_1582990729262_130404_898" isDerived="true" association="_19_0_2_12e503d9_1583376806646_723384_132">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313203944_980207_648" annotatedElement="_19_0_2_12e503d9_1583376806648_36714_134">
+            <body>&lt;p>The RequirementDefinition that has a certain ConstraintUsage as an &lt;code>assumedConstraint&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583376918479_73275_149" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583376918480_649649_150" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1583184587272_448420_2009" name="SatisfyRequirementUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1583186970556_510595_2686" annotatedElement="_19_0_2_12e503d9_1583184587272_448420_2009">
+          <body>&lt;p>A &lt;code>SatisfyRequirementUsage&lt;/code> is an &lt;code>AssertConstraintUsage&lt;/code> that asserts, by default, that a satisfied &lt;code>RequirementUsage&lt;/code> is true for a specific &lt;code>satisfyingFeature&lt;/code>, or, if &lt;code>isNegated = true&lt;/code>, that the &lt;code>RequirementUsage&lt;/code> is false. The satisfied &lt;code>RequirementUsage&lt;/code> is related to the &lt;code>SatisfyRequirementUsage&lt;/code> by a &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationship&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676731114070_662884_740" name="deriveSatisfyRequirementUsageSatisfyingFeature" visibility="public" constrainedElement="_19_0_2_12e503d9_1583184587272_448420_2009">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676731688663_443008_742" annotatedElement="_19_0_4_12e503d9_1676731114070_662884_740">
+            <body>&lt;p>The &lt;code>satisfyingFeature&lt;/code> of a &lt;code>SatisfyRequirementUsage&lt;/code> is the &lt;code>Feature&lt;/code> to which the &lt;code>subjectParameter&lt;/code> is bound.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676731114087_475328_741" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>satisfyingFeature =
+    let bindings: BindingConnector = ownedMember->
+        selectByKind(BindingConnector)->
+        select(b | b.relatedElement->includes(subjectParameter)) in
+    if bindings->isEmpty() or 
+       not bindings->first().relatedElement->exits(r | r &lt;> subjectParameter) 
+    then null
+    else bindings->first().relatedElement->any(r | r &lt;> subjectParameter)
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676731692309_709182_743" name="checkSatisfyRequirementUsageBindingConnector" visibility="public" constrainedElement="_19_0_2_12e503d9_1583184587272_448420_2009">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676731924703_255156_745" annotatedElement="_19_0_4_12e503d9_1676731692309_709182_743">
+            <body>&lt;p>A &lt;code>SatisfyRequirementUsage&lt;/code> must have exactly one &lt;code>ownedMember&lt;/code> that is a &lt;code>BindingConnector&lt;/code> between its &lt;code>subjectParameter&lt;/code> and some &lt;code>Feature&lt;/code> other than the &lt;code>subjectParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676731692313_442681_744" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedMember->selectByKind(BindingConnector)->
+    select(b |
+        b.relatedElement->includes(subjectParameter) and
+        b.relatedElement->exists(r | r &lt;> subjectParameter))->
+    size() = 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698945229721_494315_113" name="validateSatisfyRequirementUsageReference" visibility="public" constrainedElement="_19_0_2_12e503d9_1583184587272_448420_2009">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698945327248_821941_115" annotatedElement="_19_0_4_12e503d9_1698945229721_494315_113">
+            <body>&lt;p>If a &lt;code>SatisfyRequirementUsage&lt;/code> has an &lt;code>ownedReferenceSubsetting&lt;/code>, then the &lt;code>featureTarget&lt;/code> of its &lt;code>referencedFeature&lt;/code> must be a &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698945229740_103548_114" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referencedFeatureTarget() &lt;> null implies
+    referencedFeatureTarget().oclIsKindOf(RequirementUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1736983932537_6167_521" name="checkSatisfyRequirementUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1583184587272_448420_2009">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1736983991804_145085_523" annotatedElement="_2022x_2_12e503d9_1736983932537_6167_521">
+            <body>&lt;p>If a &lt;code>SatisfyRequirementUsage&lt;/code> is negated, then it must directly or indirectly specialize the &lt;code>RequirementUsage&lt;/code> &lt;em>&lt;code>Requirements::notSatisfiedRequirementChecks&lt;/code>&lt;/em>. Otherwise, it must directly or indirectly specialize the &lt;code>RequirementUsage&lt;/code> &lt;em>&lt;code>Requirements::satisfiedRequirementChecks&lt;/code>&lt;/em>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1736983932537_120821_522" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>if isNegated then
+    specializesFromLibrary('Requirements::notSatisfiedRequirementChecks')
+else
+    specializesFromLibrary('Requirements::satisfiedRequirementChecks')
+endif</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1583184871700_639392_2082" general="_19_0_2_12e503d9_1582991078230_41497_1143"/>
+        <generalization xmi:id="_19_0_2_12e503d9_1583184881684_624958_2099" general="_19_0_2_12e503d9_1581045078368_47459_9326"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583185037725_699150_2332" name="satisfiedRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1581045158665_239617_9458" association="_19_0_2_12e503d9_1583185037723_897508_2331">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1583187172499_74347_2687" annotatedElement="_19_0_2_12e503d9_1583185037725_699150_2332">
+            <body>&lt;p>The &lt;code>RequirementUsage&lt;/code> that is satisfied by the &lt;code>satisfyingSubject&lt;/code> of this &lt;code>SatisfyRequirementUsage&lt;/code>. It is the &lt;code>assertedConstraint&lt;/code> of the &lt;code>SatisfyRequirementUsage&lt;/code> considered as an &lt;code>AssertConstraintUsage&lt;/code>, which must be a &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583185090286_248099_2384" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583185090296_438579_2385" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583378847285_929988_1396" name="satisfyingFeature" visibility="public" isDerived="true" association="_19_0_2_12e503d9_1583378847285_187229_1395">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586312999150_187569_642" annotatedElement="_19_0_2_12e503d9_1583378847285_929988_1396">
+            <body>&lt;p>The &lt;code>Feature&lt;/code> that represents the actual subject that is asserted to satisfy the &lt;code>satisfiedRequirement&lt;/code>. The &lt;code>satisfyingFeature&lt;/code> is bound to the &lt;code>subjectParameter&lt;/code> of the &lt;code>SatisfyRequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583378887418_213122_1432" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583378887418_893096_1433" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1582991078230_41497_1143" name="RequirementUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1583186769729_488724_2683" annotatedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <body>&lt;p>A &lt;code>RequirementUsage&lt;/code> is a &lt;code>Usage&lt;/code> of a &lt;code>RequirementDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676657502862_688322_878" name="deriveRequirementUsageActorParameter" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676657502907_211553_887" annotatedElement="_19_0_4_12e503d9_1676657502862_688322_878">
+            <body>&lt;p>The &lt;code>actorParameters&lt;/code> of a &lt;code>RequirementUsage&lt;/code> are the &lt;code>ownedActorParameters&lt;/code> of the &lt;code>ActorMemberships&lt;/code> of the &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676657502898_479655_886" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>actorParameter = featureMembership->
+    selectByKind(ActorMembership).
+    ownedActorParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676657502894_158517_879" name="deriveRequirementUsageAssumedConstraint" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676657502910_352132_889" annotatedElement="_19_0_4_12e503d9_1676657502894_158517_879">
+            <body>&lt;p>The &lt;code>assumedConstraints&lt;/code> of a &lt;code>RequirementUsage&lt;/code> are the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementDefinition&lt;/code> with &lt;code>kind = assumption&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676657502909_744744_888" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>assumedConstraint = ownedFeatureMembership->
+    selectByKind(RequirementConstraintMembership)->
+    select(kind = RequirementConstraintKind::assumption).
+    ownedConstraint</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676657502895_184998_880" name="deriveRequirementUsageFramedConcern" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676657502910_33278_891" annotatedElement="_19_0_4_12e503d9_1676657502895_184998_880">
+            <body>&lt;p>The &lt;code>framedConcerns&lt;/code> of a &lt;code>RequirementUsage&lt;/code> are the &lt;code>ownedConcerns&lt;/code> of the &lt;code>FramedConcernMemberships&lt;/code> of the &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676657502910_314502_890" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>framedConcern = featureMembership->
+    selectByKind(FramedConcernMembership).
+    ownedConcern</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676657502896_826886_881" name="deriveRequirementUsageRequiredConstraint" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676657502911_629996_893" annotatedElement="_19_0_4_12e503d9_1676657502896_826886_881">
+            <body>&lt;p>The &lt;code>requiredConstraints&lt;/code> of a &lt;code>RequirementUsage&lt;/code> are the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementUsage&lt;/code> with &lt;code>kind = requirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676657502910_554745_892" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>requiredConstraint = ownedFeatureMembership->
+    selectByKind(RequirementConstraintMembership)->
+    select(kind = RequirementConstraintKind::requirement).
+    ownedConstraint</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676657502896_837713_882" name="deriveRequirementUsageStakeholderParameter" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676657502911_98212_895" annotatedElement="_19_0_4_12e503d9_1676657502896_837713_882">
+            <body>&lt;p>The &lt;code>stakeHolderParameters&lt;/code> of a &lt;code>RequirementUsage&lt;/code> are the &lt;code>ownedStakeholderParameters&lt;/code> of the &lt;code>StakeholderMemberships&lt;/code> of the &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676657502911_16558_894" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>stakeholderParameter = featureMembership->
+    selectByKind(AStakholderMembership).
+    ownedStakeholderParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676657502896_651840_883" name="deriveRequirementUsageSubjectParameter" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676657502912_138533_897" annotatedElement="_19_0_4_12e503d9_1676657502896_651840_883">
+            <body>&lt;p>The &lt;code>subjectParameter&lt;/code> of a &lt;code>RequirementUsage&lt;/code> is the &lt;code>ownedSubjectParameter&lt;/code> of its &lt;code>SubjectMembership&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676657502911_447551_896" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>subjectParameter =
+    let subjects : OrderedSet(SubjectMembership) = 
+        featureMembership->selectByKind(SubjectMembership) in
+    if subjects->isEmpty() then null
+    else subjects->first().ownedSubjectParameter
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676657502896_800348_884" name="deriveRequirementUsageText" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676657502912_627780_899" annotatedElement="_19_0_4_12e503d9_1676657502896_800348_884">
+            <body>&lt;p>The &lt;code>texts&lt;/code> of a&lt;code>RequirementUsage&lt;/code> are the &lt;code>bodies&lt;/code> of the &lt;code>documentation&lt;/code> of the &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676657502912_65045_898" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>text = documentation.body</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676657502896_683627_885" name="validateRequirementUsageOnlyOneSubject" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676657502912_787833_901" annotatedElement="_19_0_4_12e503d9_1676657502896_683627_885">
+            <body>&lt;p>A &lt;code>RequirementDefinition&lt;/code> must have at most one &lt;code>featureMembership&lt;/code> that is a &lt;code>SubjectMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676657502912_404126_900" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureMembership->
+    selectByKind(SubjectMembership)->
+    size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676732781225_614138_765" name="validateRequirementUsageSubjectParameterPosition" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676732781259_125209_767" annotatedElement="_19_0_4_12e503d9_1676732781225_614138_765">
+            <body>&lt;p>The &lt;code>subjectParameter&lt;/code> of a &lt;code>RequirementUsage&lt;/code> must be its first &lt;code>input&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676732781251_604569_766" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>input->notEmpty() and input->first() = subjectParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676734653167_73520_862" name="checkRequirementUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676734835387_268662_864" annotatedElement="_19_0_4_12e503d9_1676734653167_73520_862">
+            <body>&lt;p>A &lt;code>RequirementUsage&lt;/code> must directly or indirectly specialize the base &lt;code>RequirementUsage&lt;/code> &lt;em>&lt;code>Requirements::requirementChecks&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676734653182_295393_863" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Requirements::requirementChecks')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676734839141_778347_865" name="checkRequirementUsageSubrequirementSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676735014981_846525_867" annotatedElement="_19_0_4_12e503d9_1676734839141_778347_865">
+            <body>&lt;p>A composite &lt;code>RequirementUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code> must directly or indirectly specialize the &lt;code>RequirementUsage&lt;/code> &lt;em>&lt;code>Requirements::RequirementCheck::subrequirements&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676734839153_77570_866" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+    (owningType.oclIsKindOf(RequirementDefinition) or
+     owningType.oclIsKindOf(RequirementUsage)) implies
+    specializesFromLibrary('Requirements::RequirementCheck::subrequirements')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676738060122_717198_881" name="checkRequirementUsageObjectiveRedefinition" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676738399566_765001_883" annotatedElement="_19_0_4_12e503d9_1676738060122_717198_881">
+            <body>&lt;p>A &lt;code>RequirementUsage&lt;/code> whose &lt;code>owningFeatureMembership&lt;/code> is a &lt;code>ObjectiveMembership&lt;/code> must redefine the &lt;code>objectiveRequirement&lt;/code> of each &lt;code>CaseDefinition&lt;/code> or &lt;code>CaseUsage&lt;/code> that is specialized by the &lt;code>owningType&lt;/code> of the &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676738060145_291030_882" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningfeatureMembership &lt;> null and
+owningfeatureMembership.oclIsKindOf(ObjectiveMembership) implies
+    owningType.ownedSpecialization.general->forAll(gen |
+        (gen.oclIsKindOf(CaseDefinition) implies
+            redefines(gen.oclAsType(CaseDefinition).objectiveRequirement)) and
+        (gen.oclIsKindOf(Feature) and 
+         gen.oclAsType(Feature).featureTarget.oclIsKindOf(CaseUsage) implies
+            redefines(gen.oclAsType(Feature).featureTarget.
+                        oclAsType(CaseUsage).objectiveRequirement))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676740380765_240935_954" name="checkRequirementUsageRequirementVerificationSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1582991078230_41497_1143">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676740616486_783371_956" annotatedElement="_19_0_4_12e503d9_1676740380765_240935_954">
+            <body>&lt;p>A &lt;code>RequirementUsage&lt;/code> whose &lt;code>owningFeatureMembership&lt;/code> is a &lt;code>RequirementVerificationMembership&lt;/code> must directly or indirectly specialize the &lt;code>RequirementUsage&lt;/code> &lt;code>&lt;em>VerificationCases::VerificationCase::obj::requirementVerifications&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676740380790_339584_955" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningFeatureMembership &lt;> null and
+owningFeatureMembership.oclIsKindOf(RequirementVerificationMembership) implies
+    specializesFromLibrary('VerificationCases::VerificationCase::obj::requirementVerifications')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1582991112095_61382_1170" general="_19_0_2_12e503d9_1578067096274_745288_1478"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583000408905_769743_1223" name="requirementDefinition" visibility="public" type="_19_0_2_12e503d9_1582990729262_130404_898" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1578067546711_751168_1745" association="_19_0_2_12e503d9_1583000408904_155679_1222">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586302353295_263066_615" annotatedElement="_19_0_2_12e503d9_1583000408905_769743_1223">
+            <body>&lt;p>The &lt;code>RequirementDefinition&lt;/code> that is the single &lt;code>definition&lt;/code> of this &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583000426564_636236_1233" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583000426564_79927_1234" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583376474630_975784_96" name="reqId" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301764988_463543_568" annotatedElement="_19_0_2_12e503d9_1583376474630_975784_96">
+            <body>&lt;p>An optional modeler-specified identifier for this &lt;code>RequirementUsage&lt;/code> (used, e.g., to link it to an original requirement text in some source document), which is the &lt;code>declaredShortName&lt;/code> for the &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1586301564030_228874_562" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1586301564030_382197_563" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1594160442439_915308_4153"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583376480942_745679_99" name="text" visibility="public" isDerived="true">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301800021_432515_570" annotatedElement="_19_0_2_12e503d9_1583376480942_745679_99">
+            <body>&lt;p>An optional textual statement of the requirement represented by this &lt;code>RequirementUsage&lt;/code>, derived from the &lt;code>bodies&lt;code> of the &lt;code>documentation&lt;/code> of the &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1586301570499_798746_564" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1586301570499_636829_565" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583377448339_252740_390" name="requiredConstraint" visibility="public" type="_19_0_2_12e503d9_1578067096274_745288_1478" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1583377448339_649796_389">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301901394_338683_573" annotatedElement="_19_0_2_12e503d9_1583377448339_252740_390">
+            <body>&lt;p>The owned &lt;code>ConstraintUsages&lt;/code> that represent requirements of this &lt;code>RequirementUsage&lt;/code>, which are the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementUsage&lt;/code> with &lt;code>kind&lt;/code> = &lt;code>requirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583377476177_202152_436" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583377476180_422664_437" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_226999_43167"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1583377612865_991722_535" name="assumedConstraint" visibility="public" type="_19_0_2_12e503d9_1578067096274_745288_1478" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1583377612865_323213_534">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586302022309_143810_574" annotatedElement="_19_0_2_12e503d9_1583377612865_991722_535">
+            <body>&lt;p>The owned &lt;code>ConstraintUsages&lt;/code> that represent assumptions of this &lt;code>RequirementUsage&lt;/code>, derived as the &lt;code>ownedConstraints&lt;/code> of the &lt;code>RequirementConstraintMemberships&lt;/code> of the &lt;code>RequirementUsage&lt;/code> with &lt;code>kind&lt;/code> = &lt;code>assumption&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583377831282_378956_725" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583377831283_526333_726" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_226999_43167"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1595189397261_941898_844" name="subjectParameter" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1595189397261_261365_843">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1595189673976_59156_956" annotatedElement="_19_0_2_12e503d9_1595189397261_941898_844">
+            <body>&lt;p>The &lt;code>parameter&lt;/code> of this &lt;code>RequirementUsage&lt;/code> that represents its subject.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595189421476_126709_878" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595189421476_205683_879" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174990_213826_657"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591217543254_26688_475"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617116922864_514612_3264" name="framedConcern" visibility="public" type="_19_0_4_12e503d9_1617051561652_163085_1288" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583377448339_252740_390" association="_19_0_4_12e503d9_1617116922863_222473_3263">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617117006645_305109_3280" annotatedElement="_19_0_4_12e503d9_1617116922864_514612_3264">
+            <body>&lt;p>The &lt;code>ConcernUsages&lt;/code> framed by this &lt;code>RequirementUsage&lt;/code>, which are the &lt;code>ownedConcerns&lt;/code> of all &lt;code>FramedConcernMemberships&lt;/code> of the &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617116951379_506913_3274" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617116951379_46279_3275" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621564075474_350859_2735" name="actorParameter" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1621564075474_378274_2734">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621564814454_447739_2946" annotatedElement="_19_0_4_12e503d9_1621564075474_350859_2735">
+            <body>&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>RequirementUsage&lt;/code> that represent actors involved in the requirement.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621564219616_408516_2751" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621564219616_569253_2752" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174990_213826_657"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591217543254_26688_475"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624032823963_328647_40107" name="stakeholderParameter" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1624032823959_195129_40106">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624033499412_714837_40379" annotatedElement="_19_0_4_12e503d9_1624032823963_328647_40107">
+            <body>&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>RequirementUsage&lt;/code> that represent stakeholders for the requirement.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624032851422_229215_40117" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624032851423_752803_40118" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174990_213826_657"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591217543254_26688_475"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1583376932997_22788_157" name="A_requiredConstraint_requiringRequirementDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1583376932997_792124_158 _19_0_2_12e503d9_1583376932998_623233_159">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1583376932998_623233_159" name="requiringRequirementDefinition" visibility="public" type="_19_0_2_12e503d9_1582990729262_130404_898" isDerived="true" association="_19_0_2_12e503d9_1583376932997_22788_157">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313217620_905534_649" annotatedElement="_19_0_2_12e503d9_1583376932998_623233_159">
+            <body>&lt;p>The RequirementDefinition that has a certain ConstraintUsage as a &lt;code>requiredConstraint&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1583377030036_190702_174" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1583377030036_481355_175" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1584048366950_902075_425" name="A_ownedConstraint_requirementConstraintMembership" visibility="public" memberEnd="_19_0_2_12e503d9_1584048366950_985767_426 _19_0_2_12e503d9_1584048366951_120409_427">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1584048366951_120409_427" name="requirementConstraintMembership" visibility="public" type="_19_0_2_12e503d9_1584048032876_657748_336" isDerived="true" association="_19_0_2_12e503d9_1584048366950_902075_425">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586313932997_195411_764" annotatedElement="_19_0_2_12e503d9_1584048366951_120409_427">
+            <body>&lt;p>The RequirementConstraintMembership that owns a certain ConstraintUsage as its &lt;code>ownedConstraint&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1584048441803_924606_442" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1584048441804_553310_443" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674970_68441_43223"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1584048032876_657748_336" name="RequirementConstraintMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1586301078571_335259_540" annotatedElement="_19_0_2_12e503d9_1584048032876_657748_336">
+          <body>&lt;p>A &lt;code>RequirementConstraintMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> for an assumed or required &lt;code>ConstraintUsage&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676654052046_146437_734" name="deriveRequirementConstraintMembershipReferencedConstraint" visibility="public" constrainedElement="_19_0_2_12e503d9_1584048032876_657748_336">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676654284340_342557_736" annotatedElement="_19_0_4_12e503d9_1676654052046_146437_734">
+            <body>&lt;p>The &lt;code>referencedConstraint&lt;/code> of a &lt;code>RequirementConstraintMembership&lt;/code> is the &lt;code>featureTarget&lt;/code> of the &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> of the &lt;code>ownedConstraint&lt;/code>, if there is one, and, otherwise, the &lt;code>ownedConstraint&lt;/code> itself.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676654052066_438971_735" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referencedConstraint =
+    let referencedFeature : Feature = 
+        ownedConstraint.referencedFeatureTarget() in
+    if referencedFeature = null then ownedConstraint
+    else if referencedFeature.oclIsKindOf(ConstraintUsage) then
+        refrencedFeature.oclAsType(ConstraintUsage)
+    else null
+    endif endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676654316634_99932_737" name="validateRequirementConstraintMembershipOwningType" visibility="public" constrainedElement="_19_0_2_12e503d9_1584048032876_657748_336">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676654435987_551442_739" annotatedElement="_19_0_4_12e503d9_1676654316634_99932_737">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>RequirementConstraintMembership&lt;/code> must be a &lt;code>RequirementDefinition&lt;/code> or a &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676654316638_599212_738" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsKindOf(RequirementDefinition) or
+owningType.oclIsKindOf(RequirementUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676734416504_544158_856" name="validateRequirementConstraintMembershipIsComposite" visibility="public" constrainedElement="_19_0_2_12e503d9_1584048032876_657748_336">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676734496068_757823_858" annotatedElement="_19_0_4_12e503d9_1676734416504_544158_856">
+            <body>&lt;p>The &lt;code>ownedConstraint&lt;/code> of a &lt;code>RequirementConstraintMembership&lt;/code> must be composite.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676734416513_207579_857" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedConstraint.isComposite</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1584048056871_176549_363">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651715_740575_42237"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1584048161309_821854_390" name="kind" visibility="public" type="_19_0_2_12e503d9_1584048075177_881751_365">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301101996_886229_541" annotatedElement="_19_0_2_12e503d9_1584048161309_821854_390">
+            <body>&lt;p>Whether the &lt;code>RequirementConstraintMembership&lt;/code> is for an assumed or required &lt;code>ConstraintUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1584048366950_985767_426" name="ownedConstraint" visibility="public" type="_19_0_2_12e503d9_1578067096274_745288_1478" aggregation="composite" isDerived="true" association="_19_0_2_12e503d9_1584048366950_902075_425">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301138208_763468_542" annotatedElement="_19_0_2_12e503d9_1584048366950_985767_426">
+            <body>&lt;p>The &lt;code>ConstraintUsage&lt;/code> that is the &lt;code>ownedMemberFeature&lt;/code> of this &lt;code>RequirementConstraintMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1584048408208_967320_436" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1584048408218_878630_437" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674993_898044_43344"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617118807597_77864_3544" name="referencedConstraint" visibility="public" type="_19_0_2_12e503d9_1578067096274_745288_1478" isDerived="true" association="_19_0_4_12e503d9_1617118807597_103483_3543">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617119004872_728197_3564" annotatedElement="_19_0_4_12e503d9_1617118807597_77864_3544">
+            <body>&lt;p> The &lt;code>ConstraintUsage&lt;/code> that is referenced through this &lt;code>RequirementConstraintMembership&lt;/code>. It is the &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> of the &lt;code>ownedConstraint&lt;/code>, if there is one, and, otherwise, the &lt;code>ownedConstraint&lt;/code> itself.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617118859613_79563_3554" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617118859614_768321_3555" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_19_0_2_12e503d9_1584048075177_881751_365" name="RequirementConstraintKind" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1586301185752_832728_543" annotatedElement="_19_0_2_12e503d9_1584048075177_881751_365">
+          <body>&lt;p>A &lt;code>RequirementConstraintKind&lt;/code> indicates whether a &lt;code>ConstraintUsage&lt;/code> is an assumption or a requirement in a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedLiteral xmi:id="_19_0_2_12e503d9_1584048118498_451605_386" name="assumption" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301300381_1877_544" annotatedElement="_19_0_2_12e503d9_1584048118498_451605_386">
+            <body>&lt;p>Indicates that a member &lt;code>ConstraintUsage&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code> represents an assumption.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_19_0_2_12e503d9_1584048139603_343065_388" name="requirement" visibility="public">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586301312982_132224_545" annotatedElement="_19_0_2_12e503d9_1584048139603_343065_388">
+            <body>&lt;p>Indicates that a member &lt;code>ConstraintUsage&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code>represents an requirement.&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1595189007407_366933_585" name="A_subjectParameter_subjectOwningRequirementDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1595189007408_784255_586 _19_0_2_12e503d9_1595189007408_87005_587">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1595189007408_87005_587" name="subjectOwningRequirementDefinition" visibility="public" type="_19_0_2_12e503d9_1582990729262_130404_898" isDerived="true" association="_19_0_2_12e503d9_1595189007407_366933_585">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1595189592117_142818_950" annotatedElement="_19_0_2_12e503d9_1595189007408_87005_587">
+            <body>&lt;p>The RequirementDefinitions that have a certain Usage as their &lt;code>subjectParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595189048386_858303_602" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595189048386_668813_603" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948010066_582406_20414"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565479686638_420576_23237"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1595189397261_261365_843" name="A_subjectParameter_subjectOwningRequirement" visibility="public" memberEnd="_19_0_2_12e503d9_1595189397261_941898_844 _19_0_2_12e503d9_1595189397262_345619_845">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1595189397262_345619_845" name="subjectOwningRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isDerived="true" association="_19_0_2_12e503d9_1595189397261_261365_843">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1595189714408_112002_959" annotatedElement="_19_0_2_12e503d9_1595189397262_345619_845">
+            <body>&lt;p>The RequirementUsages that have a certain Usage as their &lt;code>subjectParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595189446380_827488_894" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595189446381_121184_895" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174991_690604_658"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565472757327_504924_21260"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_59601fc_1590256833607_99707_374" name="SubjectMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591154978912_727804_4379" annotatedElement="_19_0_2_59601fc_1590256833607_99707_374">
+          <body>&lt;p>A &lt;code>SubjectMembership&lt;/code> is a &lt;code>ParameterMembership&lt;/code> that indicates that its &lt;code>ownedSubjectParameter&lt;/code> is the subject of its &lt;code>owningType&lt;/code>. The &lt;code>owningType&lt;/code> of a &lt;code>SubjectMembership&lt;/code> must be a &lt;code>RequirementDefinition&lt;/code>, &lt;code>RequirementUsage&lt;/code>, &lt;code>CaseDefinition&lt;/code>, or &lt;code>CaseUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676678947283_47970_1017" name="validateSubjectMembershipOwningType" visibility="public" constrainedElement="_19_0_2_59601fc_1590256833607_99707_374">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676718546523_21584_432" annotatedElement="_19_0_4_12e503d9_1676678947283_47970_1017">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>SubjectMembership&lt;/code> must be a &lt;code>RequirementDefinition&lt;/code>, &lt;code>RequirementUsage&lt;/code>, &lt;code>CaseDefinition&lt;/code>, or &lt;code>CaseUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676678947319_101998_1018" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsType(RequirementDefinition) or
+owningType.oclIsType(RequiremenCaseRequirementDefinition) or
+owningType.oclIsType(CaseDefinition) or
+owningType.oclIsType(CaseUsage)
+</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_59601fc_1590258248727_238357_708">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557527738711_165124_110466"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_59601fc_1590258781117_655788_845" name="ownedSubjectParameter" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" aggregation="composite" isDerived="true" association="_19_0_2_59601fc_1590258781116_359333_844">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591155274414_280118_4403" annotatedElement="_19_0_2_59601fc_1590258781117_655788_845">
+            <body>&lt;p>The &lt;code>Usage&lt;/code&lt; that is the &lt;code>ownedMemberParameter&lt;/code> of this &lt;code>SubjectMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_59601fc_1590259758992_993410_993" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_59601fc_1590259758993_477403_994" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557528016548_548098_110830"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_59601fc_1590258781116_359333_844" name="A_ownedSubjectParameter_owningSubjectMembership" visibility="public" memberEnd="_19_0_2_59601fc_1590258781117_655788_845 _19_0_2_59601fc_1590258781118_311469_846">
+        <ownedEnd xmi:id="_19_0_2_59601fc_1590258781118_311469_846" name="owningSubjectMembership" visibility="public" type="_19_0_2_59601fc_1590256833607_99707_374" isDerived="true" association="_19_0_2_59601fc_1590258781116_359333_844">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591155306865_440518_4405" annotatedElement="_19_0_2_59601fc_1590258781118_311469_846">
+            <body>&lt;p>The SubjectMembership that owns a particular Parameter as its &lt;code>ownedSubjectParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591135435729_346764_1054" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591135435729_842762_1055" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557528016548_348211_110831"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617116733499_254226_3241" name="A_framedConcern_framingRequirementDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1617116733499_587735_3242 _19_0_4_12e503d9_1617116733499_856391_3243">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617116733499_856391_3243" name="framingRequirementDefinition" visibility="public" type="_19_0_2_12e503d9_1582990729262_130404_898" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583376806648_36714_134" association="_19_0_4_12e503d9_1617116733499_254226_3241">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617117823566_570008_3495" annotatedElement="_19_0_4_12e503d9_1617116733499_856391_3243">
+            <body>&lt;p>The RequirementDefinition that addresses a certain &lt;code>addressedConcern&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617117589003_467970_3357" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617117589004_197784_3358" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617052514911_221960_2255" name="A_concernDefinition_definedConcern" visibility="public" memberEnd="_19_0_4_12e503d9_1617052514912_780627_2256 _19_0_4_12e503d9_1617052514913_953274_2257">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617052514913_953274_2257" name="definedConcern" visibility="public" type="_19_0_4_12e503d9_1617051561652_163085_1288" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000408905_309783_1224" association="_19_0_4_12e503d9_1617052514911_221960_2255">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617057220565_279747_3185" annotatedElement="_19_0_4_12e503d9_1617052514913_953274_2257">
+            <body>&lt;p>The ConcernUsages that are typed by a certain &lt;code>concernDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617052557487_114805_2298" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617052557488_316151_2299" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617120658044_450155_3772" name="A_referencedConcern_referencingConcernMembership" visibility="public" memberEnd="_19_0_4_12e503d9_1617120658044_92083_3773 _19_0_4_12e503d9_1617120658045_780218_3774">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617120658045_780218_3774" name="referencingConcernMembership" visibility="public" type="_19_0_4_12e503d9_1617120429499_126250_3667" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1617118807597_323188_3545" association="_19_0_4_12e503d9_1617120658044_450155_3772">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617124275144_178425_4436" annotatedElement="_19_0_4_12e503d9_1617120658045_780218_3774">
+            <body>&lt;p>The AddressedConcernMembership that has a certain ConcernUsage as its &lt;code>addressedConcern&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617120727228_312874_3789" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617120727235_853263_3790" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1617120429499_126250_3667" name="FramedConcernMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1617123947821_559438_4432" annotatedElement="_19_0_4_12e503d9_1617120429499_126250_3667">
+          <body>&lt;p>A &lt;code>FramedConcernMembership&lt;/code> is a &lt;code>RequirementConstraintMembership&lt;/code> for a framed &lt;code>ConcernUsage&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676653798040_748025_731" name="validateFramedConcernMembershipConstraintKind" visibility="public" constrainedElement="_19_0_4_12e503d9_1617120429499_126250_3667">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676653880787_855116_733" annotatedElement="_19_0_4_12e503d9_1676653798040_748025_731">
+            <body>&lt;p>A &lt;code>FramedConcernMembership&lt;/code> must have &lt;code>kind = requirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676653798057_466547_732" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>kind = RequirementConstraintKind::requirement</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1617120485463_127099_3696" general="_19_0_2_12e503d9_1584048032876_657748_336"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617120451812_644221_3690" name="kind" visibility="public" type="_19_0_2_12e503d9_1584048075177_881751_365" redefinedProperty="_19_0_2_12e503d9_1584048161309_821854_390">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617120451826_569220_3691" annotatedElement="_19_0_4_12e503d9_1617120451812_644221_3690">
+            <body>&lt;p>The &lt;code>kind&lt;/code> of an &lt;code>FramedConcernMembership&lt;/code> must be &lt;code>requirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_19_0_4_12e503d9_1617120462431_292056_3693" name="" visibility="public" instance="_19_0_2_12e503d9_1584048139603_343065_388"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617120590170_490370_3748" name="ownedConcern" visibility="public" type="_19_0_4_12e503d9_1617051561652_163085_1288" aggregation="composite" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1584048366950_985767_426" association="_19_0_4_12e503d9_1617120590170_336724_3747">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617124059788_772537_4433" annotatedElement="_19_0_4_12e503d9_1617120590170_490370_3748">
+            <body>&lt;p>The &lt;code>ConcernUsage&lt;/code> that is the &lt;code>ownedConstraint&lt;/code> of this &lt;code>FramedConcernMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617120617714_462646_3758" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617120617723_15619_3759" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617120658044_92083_3773" name="referencedConcern" visibility="public" type="_19_0_4_12e503d9_1617051561652_163085_1288" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1617118807597_77864_3544" association="_19_0_4_12e503d9_1617120658044_450155_3772">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617124119958_935934_4434" annotatedElement="_19_0_4_12e503d9_1617120658044_92083_3773">
+            <body>&lt;p> The &lt;code>ConcernUsage&lt;/code> that is referenced through this &lt;code>FramedConcernMembership&lt;/code>. It is the &lt;code>referencedConstraint&lt;/code> of the &lt;code>FramedConcernMembership&lt;/code> considered as a &lt;code>RequirementConstraintMembership&lt;/code>, which must be a &lt;code>ConcernUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617120709179_888024_3783" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617120709180_386783_3784" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1617051538049_980762_1225" name="ConcernDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1617056955187_311325_3184" annotatedElement="_19_0_4_12e503d9_1617051538049_980762_1225">
+          <body>&lt;p>A &lt;code>ConcernDefinition&lt;/code> is a &lt;code>RequirementDefinition&lt;/code> that one or more stakeholders may be interested in having addressed. These stakeholders are identified by the &lt;code>ownedStakeholders&lt;/code>of the &lt;code>ConcernDefinition&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676730019217_840398_727" name="checkConcernDefinitionSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1617051538049_980762_1225">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676730150503_758186_729" annotatedElement="_19_0_4_12e503d9_1676730019217_840398_727">
+            <body>&lt;p>A &lt;code>ConcernDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>ConcernDefinition&lt;/code> &lt;em>&lt;code>Requirements::ConcernCheck&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676730019237_92414_728" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Requirements::ConcernCheck')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1617051556680_373491_1282" general="_19_0_2_12e503d9_1582990729262_130404_898"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617118807597_103483_3543" name="A_referencedConstraint_referencingConstraintMembership" visibility="public" memberEnd="_19_0_4_12e503d9_1617118807597_77864_3544 _19_0_4_12e503d9_1617118807597_323188_3545">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617118807597_323188_3545" name="referencingConstraintMembership" visibility="public" type="_19_0_2_12e503d9_1584048032876_657748_336" isDerived="true" association="_19_0_4_12e503d9_1617118807597_103483_3543">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617119152273_892571_3567" annotatedElement="_19_0_4_12e503d9_1617118807597_323188_3545">
+            <body>&lt;p>The RequirementConstraintMembership that has a certain ConstraintUsage as its &lt;code>referencedConstraint&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617118920756_244300_3560" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617118920756_333104_3561" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617120590170_336724_3747" name="A_ownedConcern_framedConstraintMembership" visibility="public" memberEnd="_19_0_4_12e503d9_1617120590170_490370_3748 _19_0_4_12e503d9_1617120590172_515235_3749">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617120590172_515235_3749" name="framedConstraintMembership" visibility="public" type="_19_0_4_12e503d9_1617120429499_126250_3667" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1584048366951_120409_427" association="_19_0_4_12e503d9_1617120590170_336724_3747">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617124150755_387966_4435" annotatedElement="_19_0_4_12e503d9_1617120590172_515235_3749">
+            <body>&lt;p>The AddressedConcernMembership that owns a certain ConcernUsage as its &lt;code>ownedConcern&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617120646290_518075_3764" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617120646291_807232_3765" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1617051561652_163085_1288" name="ConcernUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1617058012095_362221_3186" annotatedElement="_19_0_4_12e503d9_1617051561652_163085_1288">
+          <body>&lt;p>A &lt;code>ConcernUsage&lt;/code> is a &lt;code>Usage&lt;/code> of a &lt;code>ConcernDefinition&lt;/code>.&lt;/p>
+
+ The &lt;code>ownedStakeholder&lt;/code> features of the ConcernUsage shall all subset the &lt;em>&lt;code>ConcernCheck::concernedStakeholders&lt;/code> &lt;/em>feature. If the ConcernUsage is an &lt;code>ownedFeature&lt;/code> of a StakeholderDefinition or StakeholderUsage, then the ConcernUsage shall have an &lt;code>ownedStakeholder&lt;/code> feature that is bound to the &lt;em>&lt;code>self&lt;/code>&lt;/em> feature of its owner.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676733930958_15325_850" name="checkConcernUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1617051561652_163085_1288">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676734040993_545611_852" annotatedElement="_19_0_4_12e503d9_1676733930958_15325_850">
+            <body>&lt;p>A &lt;code>ConcernUsage&lt;/code> must directly or indirectly specialize the base &lt;code>ConcernUsage&lt;/code> &lt;em>&lt;code>Requirements::concernChecks&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676733930977_110605_851" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Requirements::concernChecks')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676734045168_823505_853" name="checkConcernUsageFramedConcernSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1617051561652_163085_1288">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676734274991_957915_855" annotatedElement="_19_0_4_12e503d9_1676734045168_823505_853">
+            <body>&lt;p>If a &lt;code>ConcernUsage&lt;/code> is owned via a &lt;code>FramedConcernMembership&lt;/code>, then it must directly or indirectly specialize the &lt;code>ConcernUsage&lt;/code> &lt;code>&lt;em>Requirements::RequirementCheck::concerns&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676734045181_230445_854" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningFeatureMembership &lt;> null and
+owningFeatureMembership.oclIsKindOf(FramedConcernMembership) implies
+    specializesFromLibrary('Requirements::RequirementCheck::concerns')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1617051590265_453042_1343" general="_19_0_2_12e503d9_1582991078230_41497_1143"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617052514912_780627_2256" name="concernDefinition" visibility="public" type="_19_0_4_12e503d9_1617051538049_980762_1225" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1583000408905_769743_1223" association="_19_0_4_12e503d9_1617052514911_221960_2255">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617054720898_563439_3175" annotatedElement="_19_0_4_12e503d9_1617052514912_780627_2256">
+            <body>&lt;p>The ConcernDefinition that is the single type of this ConcernUsage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617052532817_231980_2280" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617052532824_506826_2281" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617116922863_222473_3263" name="A_framedConcern_framingRequirement" visibility="public" memberEnd="_19_0_4_12e503d9_1617116922864_514612_3264 _19_0_4_12e503d9_1617116922864_514213_3265">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617116922864_514213_3265" name="framingRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583377448340_603710_391" association="_19_0_4_12e503d9_1617116922863_222473_3263">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617117833230_152990_3496" annotatedElement="_19_0_4_12e503d9_1617116922864_514213_3265">
+            <body>&lt;p>The RequirementUsage that addresses a certain &lt;code>addressedConcern&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617117644927_369992_3365" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617117644928_703879_3366" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624032823959_195129_40106" name="A_stakeholderParameter_stakholderOwningRequirement" visibility="public" memberEnd="_19_0_4_12e503d9_1624032823963_328647_40107 _19_0_4_12e503d9_1624032823966_992258_40108">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624032823966_992258_40108" name="stakholderOwningRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isDerived="true" association="_19_0_4_12e503d9_1624032823959_195129_40106">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624032898955_310540_40123" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624032898956_215326_40124" name="" visibility="public" value="1"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591496406877_994044_3189"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174991_690604_658"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621564075474_378274_2734" name="A_actorParameter_actorOwningRequirement" visibility="public" memberEnd="_19_0_4_12e503d9_1621564075474_350859_2735 _19_0_4_12e503d9_1621564075475_165168_2736">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621564075475_165168_2736" name="actorOwningRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" association="_19_0_4_12e503d9_1621564075474_378274_2734">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621564757294_528169_2944" annotatedElement="_19_0_4_12e503d9_1621564075475_165168_2736">
+            <body>&lt;p>The RequirementUsages that have a certain PartUsage as an &lt;code>actorParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621564410083_149633_2807" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621564410084_879162_2808" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174991_690604_658"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591496406877_994044_3189"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621564041941_436555_2721" name="A_actorParameter_actorOwningRequirementDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1621564041941_652319_2722 _19_0_4_12e503d9_1621564041942_767470_2723">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621564041942_767470_2723" name="actorOwningRequirementDefinition" visibility="public" type="_19_0_2_12e503d9_1582990729262_130404_898" isDerived="true" association="_19_0_4_12e503d9_1621564041941_436555_2721">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621564745280_990453_2943" annotatedElement="_19_0_4_12e503d9_1621564041942_767470_2723">
+            <body>&lt;p>The RequirementDefinitions that have a certain PartUsage as an &lt;code>actorParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621564305566_470513_2757" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621564305566_132455_2758" name="" visibility="public" value="1"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591496643392_535546_3280"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948010066_582406_20414"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624034451301_735825_40821" name="A_ownedStakeholderParameter_owningStakeholderMembership" visibility="public" memberEnd="_19_0_4_12e503d9_1624034451301_6622_40822 _19_0_4_12e503d9_1624034451302_533696_40823">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624034451302_533696_40823" name="owningStakeholderMembership" visibility="public" type="_19_0_4_12e503d9_1624034341711_188515_40791" isDerived="true" association="_19_0_4_12e503d9_1624034451301_735825_40821">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624035256315_880559_41484" annotatedElement="_19_0_4_12e503d9_1624034451302_533696_40823">
+            <body>&lt;p>TheStakehplderMembership that has a certain PartUsage as its &lt;code>ownedStakeholderParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624034507174_930693_40838" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624034507174_993740_40839" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557528016548_348211_110831"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624034341711_188515_40791" name="StakeholderMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624034619504_649385_40850" annotatedElement="_19_0_4_12e503d9_1624034341711_188515_40791">
+          <body>&lt;p>A &lt;code>StakeholderMembership&lt;/code> is a &lt;code>ParameterMembership&lt;/code> that identifies a &lt;code>PartUsage&lt;/code> as a &lt;code>stakeholderParameter&lt;/code> of a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code>, which specifies a role played by an entity with concerns framed by the &lt;code>owningType&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676733025912_417875_820" name="validateStakeholderMembershipOwningType" visibility="public" constrainedElement="_19_0_4_12e503d9_1624034341711_188515_40791">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676733146900_932828_822" annotatedElement="_19_0_4_12e503d9_1676733025912_417875_820">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>StakeholderMembership&lt;/code> must be a &lt;code>RequirementDefinition&lt;/code> or &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676733025929_380655_821" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsKindOf(RequirementUsage) or
+owningType.oclIsKindOf(RequirementDefinition)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1624034372890_784968_40816">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557527738711_165124_110466"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1624034451301_6622_40822" name="ownedStakeholderParameter" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" aggregation="composite" isDerived="true" association="_19_0_4_12e503d9_1624034451301_735825_40821">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624035231644_148175_41483" annotatedElement="_19_0_4_12e503d9_1624034451301_6622_40822">
+            <body>&lt;p>The &lt;code>PartUsage&lt;/code> specifying the stakeholder.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624034478724_46634_40832" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624034478730_607583_40833" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557528016548_548098_110830"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1624033010374_739400_40165" name="A_stakeholderParameter_stakholderOwiningRequirementDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1624033010374_29375_40166 _19_0_4_12e503d9_1624033010375_744235_40167">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1624033010375_744235_40167" name="stakholderOwiningRequirementDefinition" visibility="public" type="_19_0_2_12e503d9_1582990729262_130404_898" isDerived="true" association="_19_0_4_12e503d9_1624033010374_739400_40165">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1624033211093_62998_40262" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1624033211094_286493_40263" name="" visibility="public" value="1"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591496406877_994044_3189"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174991_690604_658"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621464305450_357770_1420" name="A_ownedActorParameter_owningActorMembership" visibility="public" memberEnd="_19_0_4_12e503d9_1621464305451_983612_1421 _19_0_4_12e503d9_1621464305452_471892_1422">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621464305452_471892_1422" name="owningActorMembership" visibility="public" type="_19_0_4_12e503d9_1621464240681_650455_1312" isDerived="true" association="_19_0_4_12e503d9_1621464305450_357770_1420">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621547379134_358709_1994" annotatedElement="_19_0_4_12e503d9_1621464305452_471892_1422">
+            <body>&lt;p>The ActorMembership that has a certain PartUsage as its &lt;code>ownedActorParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621464344623_52813_1497" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621464344624_726392_1498" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557528016548_348211_110831"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1621464240681_650455_1312" name="ActorMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1621547301642_675374_1992" annotatedElement="_19_0_4_12e503d9_1621464240681_650455_1312">
+          <body>&lt;p>An &lt;code>ActorMembership&lt;/code> is a &lt;code>ParameterMembership&lt;/code> that identifies a &lt;code>PartUsage&lt;/code> as an &lt;em>actor&lt;/em> &lt;code>parameter&lt;/code>, which specifies a role played by an external entity in interaction with the &lt;code>owningType&lt;/code> of the &lt;code>ActorMembership&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676733166062_632235_825" name="validateActorMembershipOwningType" visibility="public" constrainedElement="_19_0_4_12e503d9_1621464240681_650455_1312">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676733266927_637609_831" annotatedElement="_19_0_4_12e503d9_1676733166062_632235_825">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of an &lt;code>ActorMembership&lt;/code> must be a &lt;code>RequirementDefinition&lt;/code>, &lt;code>RequirementUsage&lt;/code>, &lt;code>CaseDefinition&lt;/code>, or &lt;code>CaseUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676733166068_816007_826" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsKindOf(RequirementUsage) or
+owningType.oclIsKindOf(RequirementDefinition) or
+owningType.oclIsKindOf(CaseDefinition) or
+owningType.oclIsKindOf(CaseUsage)
+</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1621464263712_925170_1353">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557527738711_165124_110466"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621464305451_983612_1421" name="ownedActorParameter" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" aggregation="composite" isDerived="true" association="_19_0_4_12e503d9_1621464305450_357770_1420">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621547327703_626196_1993" annotatedElement="_19_0_4_12e503d9_1621464305451_983612_1421">
+            <body>&lt;p>The &lt;code>PartUsage&lt;/code> specifying the actor.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621464372372_886742_1515" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621464372373_49304_1516" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557528016548_548098_110830"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1588213079146_135775_6" name="Calculations" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1588213234752_326869_117" name="CalculationDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1588777327106_891872_3989" annotatedElement="_19_0_2_12e503d9_1588213234752_326869_117">
+          <body>&lt;p>A &lt;code>CalculationDefinition&lt;/code> is an &lt;coed>ActionDefinition&lt;/code> that also defines a &lt;code>Function&lt;/code> producing a &lt;code>result&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675402816715_407236_615" name="checkCalculationDefinitionSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1588213234752_326869_117">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675402923648_788919_617" annotatedElement="_19_0_4_12e503d9_1675402816715_407236_615">
+            <body>&lt;p>A &lt;code>CalculationDefinition&lt;/code> must directly or indirectly specialize the &lt;code>CalculationDefinition&lt;/code> &lt;em>&lt;code>Calculations::Calculation&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675402816724_536865_616" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Calculations::Calculation')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675402700632_105256_612" name="deriveCalculationUsageCalculation" visibility="public" constrainedElement="_19_0_2_12e503d9_1588213234752_326869_117">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675402790344_466990_614" annotatedElement="_19_0_4_12e503d9_1675402700632_105256_612">
+            <body>&lt;p>The &lt;code>calculations&lt;/code> of a &lt;code>CalculationDefinition&lt;/code> are those of its &lt;code>actions&lt;/code> that are &lt;code>CalculationUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675402700657_12816_613" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>calculation = action->selectByKind(CalculationUsage)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1588213332248_344582_202">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651697_513473_42183"/>
+        </generalization>
+        <generalization xmi:id="_19_0_2_12e503d9_1588213251769_216617_144" general="_18_5_3_12e503d9_1565500542970_17430_30342"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1588214479224_101961_594" name="calculation" visibility="public" type="_19_0_2_12e503d9_1588213258220_731107_146" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1588214479223_918754_593">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1588777553163_720946_3992" annotatedElement="_19_0_2_12e503d9_1588214479224_101961_594">
+            <body>&lt;p>The &lt;code>actions&lt;/code> of this &lt;code>CalculationDefinition&lt;/code> that are &lt;code>CalculationUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1588214927129_63168_607" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1588214927129_903679_608" name="" visibility="public" value="*"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565500809065_170841_30688"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948400639_301251_20841"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1588213526304_52420_301" name="A_calculationDefinition_definedCalculation" visibility="public" memberEnd="_19_0_2_12e503d9_1588213526305_899324_302 _19_0_2_12e503d9_1588213526305_854304_303">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1588213526305_854304_303" name="definedCalculation" visibility="public" type="_19_0_2_12e503d9_1588213258220_731107_146" isDerived="true" association="_19_0_2_12e503d9_1588213526304_52420_301">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1588781829294_262982_3996" annotatedElement="_19_0_2_12e503d9_1588213526305_854304_303">
+            <body>&lt;p>The CalculationUsage being typed by a certain Function.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1588213661855_564617_314" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1588213661856_443070_315" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948477241_327420_20935"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565500905804_571076_30780"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1588213258220_731107_146" name="CalculationUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1588777473000_801142_3990" annotatedElement="_19_0_2_12e503d9_1588213258220_731107_146">
+          <body>&lt;p>A &lt;code>CalculationUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that is also an &lt;code>Expression&lt;/code>, and, so, is typed by a &lt;code>Function&lt;/code>. Nominally, if the &lt;code>type&lt;/code> is a &lt;code>CalculationDefinition&lt;/code>, a &lt;code>CalculationUsage&lt;/code> is a &lt;code>Usage&lt;/code> of that &lt;code>CalculationDefinition&lt;/code> within a system. However, other kinds of kernel &lt;code>Functions&lt;/code> are also allowed, to permit use of &lt;code>Functions&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675403140451_404379_618" name="checkCalculationUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1588213258220_731107_146">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1675403239488_27397_620" annotatedElement="_19_0_4_12e503d9_1675403140451_404379_618">
+            <body>&lt;p>A &lt;code>CalculationUsage&lt;/code> must specialize directly or indirectly the &lt;code>CalculationUsage&lt;/code> &lt;em>&lt;code>Calculations::calculations&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675403140469_989549_619" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Calculations::calculations')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1675403243505_251224_621" name="checkCalculationUsageSubcalculationSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1588213258220_731107_146">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1675403243518_922440_622" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(CalculationDefinition) or
+ owningType.oclIsKindOf(CalculationUsage)) implies
+    specializesFromLibrary('Calculations::Calculation::subcalculations')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1588213354343_676784_231">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+        </generalization>
+        <generalization xmi:id="_19_0_2_12e503d9_1588213275467_645200_173" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1588213526305_899324_302" name="calculationDefinition" visibility="public" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1588213526304_52420_301">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1588781805843_403930_3995" annotatedElement="_19_0_2_12e503d9_1588213526305_899324_302">
+            <body>&lt;p>The &lt;ode>Function&lt;/code> that is the &lt;code>type&lt;/code> of this &lt;code>CalculationUsage&lt;/code>. Nominally, this would be a &lt;code>CalculationDefinition&lt;/code>, but a kernel &lt;code>Function&lt;/code> is also allowed, to permit use of &lt;code>Functions&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651697_513473_42183"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1588213676327_971271_318" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1588213676328_929727_319" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948477241_299049_20934"/>
+          <redefinedProperty href="#_18_5_3_12e503d9_1565500905804_589845_30779"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1665528806788_377579_2389" name="modelLevelEvaluable" visibility="public" bodyCondition="_19_0_4_12e503d9_1665528914829_110977_2533">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1665528854457_100260_2398" annotatedElement="_19_0_4_12e503d9_1665528806788_377579_2389">
+            <body>&lt;p>A &lt;code>CalculationUsage&lt;/code> is not model-level evaluable.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1665528914829_110977_2533" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1665528914850_916971_2534" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>false</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665614408648_84506_2707" name="visited" visibility="public">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651684_893483_42160"/>
+            <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1665614408731_423398_2708" name="" visibility="public"/>
+            <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1665614408735_97668_2709" name="" visibility="public" value="*"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1665615661978_966355_2731" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+          <redefinedOperation href="KerML_only_xmi.uml#_19_0_4_12e503d9_1665516752162_909455_1465"/>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1588214479223_918754_593" name="A_calculation_featuringCalculationDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1588214479224_101961_594 _19_0_2_12e503d9_1588214479224_250374_595">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1588214479224_250374_595" name="featuringCalculationDefinition" visibility="public" type="_19_0_2_12e503d9_1588213234752_326869_117" isDerived="true" association="_19_0_2_12e503d9_1588214479223_918754_593">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1588777497242_654101_3991" annotatedElement="_19_0_2_12e503d9_1588214479224_250374_595">
+            <body>&lt;p>The CalculationDefinitions that feature a certain CalculationUsage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1588215270587_907398_655" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1588215270587_128370_656" name="" visibility="public" value="*"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565500809066_425637_30689"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948400639_994746_20842"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1588215335100_757908_665" name="A_calculationOwningDefinition_ownedCalculation" visibility="public" memberEnd="_19_0_2_12e503d9_1588215335103_850314_666 _19_0_2_12e503d9_1588215335104_898924_667">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1588215335103_850314_666" name="calculationOwningDefinition" visibility="public" type="_18_5_3_12e503d9_1565479032244_336549_22524" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591479011613_883095_1092" association="_19_0_2_12e503d9_1588215335100_757908_665">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1588781851782_702399_3997" annotatedElement="_19_0_2_12e503d9_1588215335103_850314_666">
+            <body>&lt;p>The Definition that owns the &lt;code>ownedCalculation&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1588215474583_728769_684" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1588215474584_192100_685" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1588215112282_511532_630" name="A_calculationOwningUsage_nestedCalculation" visibility="public" memberEnd="_19_0_2_12e503d9_1588215112282_933161_631 _19_0_2_12e503d9_1588215112283_215964_632">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1588215112282_933161_631" name="calculationOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565501745143_149841_31610" association="_19_0_2_12e503d9_1588215112282_511532_630">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591137395722_465440_1980" annotatedElement="_19_0_2_12e503d9_1588215112282_933161_631">
+            <body>&lt;p>The Usage in which the &lt;code>nestedCalculation&lt;code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1588215221095_738824_647" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1588215221102_781331_648" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1591475471878_63998_162" name="Connections" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591476421094_656761_681" name="A_connectionEnd_connectionDefinitionWithEnd" visibility="public" memberEnd="_19_0_2_12e503d9_1591476421094_685440_682 _19_0_2_12e503d9_1591476421095_594435_683">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591476421095_594435_683" name="connectionDefinitionWithEnd" visibility="public" type="_19_0_2_12e503d9_1565813525877_81950_622" isDerived="true" association="_19_0_2_12e503d9_1591476421094_656761_681">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591476875672_167709_710" annotatedElement="_19_0_2_12e503d9_1591476421095_594435_683">
+            <body>&lt;p>The ConnectionDefinitions that have a certain Usage as an &lt;code>connectionEnd&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591476488998_124865_700" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591476488998_593196_701" name="" visibility="public" value="*"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1562477648742_461919_22902"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1565813525877_81950_622" name="ConnectionDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567721813593_579529_17989" annotatedElement="_19_0_2_12e503d9_1565813525877_81950_622">
+          <body>&lt;p>A &lt;code>ConnectionDefinition&lt;/code> is a &lt;code>PartDefinition&lt;/code> that is also an &lt;code>AssociationStructure&lt;/code>. The end &lt;code>Features&lt;/code> of a &lt;code>ConnectionDefinition&lt;/code> must be &lt;code>Usages&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672790532082_83177_92" name="checkConnectionDefinitionSpecializations" visibility="public" constrainedElement="_19_0_2_12e503d9_1565813525877_81950_622">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672790620278_105263_94" annotatedElement="_19_0_4_12e503d9_1672790532082_83177_92">
+            <body>&lt;p>A &lt;code>ConnectionDefinition&lt;/code> must directly or indirectly specialize the &lt;code>ConnectionDefinition&lt;/code> &lt;em>&lt;code>Connections::Connection&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672790532105_73352_93" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Connections::Connection')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672805578035_743814_112" name="checkConnectionDefinitionBinarySpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1565813525877_81950_622">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672805703336_289773_114" annotatedElement="_19_0_4_12e503d9_1672805578035_743814_112">
+            <body>&lt;p>A binary &lt;code>ConnectionDefinition&lt;/code> must directly or indirectly specialize the &lt;code>ConnectionDefinition&lt;/code> &lt;em>&lt;code>Connections::BinaryConnection&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672805578059_707852_113" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedEndFeature->size() = 2 implies
+    specializesFromLibrary('Connections::BinaryConnection')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734735076274_23077_332" name="validateConnectionDefinitionIsSufficient" visibility="public" constrainedElement="_19_0_2_12e503d9_1565813525877_81950_622">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734735121885_729007_334" annotatedElement="_2022x_2_12e503d9_1734735076274_23077_332">
+            <body>&lt;p>A &lt;code>ConnectionDefinition&lt;/code> must have &lt;code>isSufficient = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734735076274_657545_333" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isSufficient</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1565813654736_920659_734">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_b9102da_1609608726569_644338_601"/>
+        </generalization>
+        <generalization xmi:id="_19_0_2_12e503d9_1565813546431_707287_649" general="_18_5_3_12e503d9_1565469626440_455154_19856"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591476421094_685440_682" name="connectionEnd" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1591476421094_656761_681">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591476814460_139430_709" annotatedElement="_19_0_2_12e503d9_1591476421094_685440_682">
+            <body>&lt;p>The &lt;code>Usages&lt;/code> that define the things related by the &lt;code>ConnectionDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591476443340_96090_692" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591476443341_796228_693" name="" visibility="public" value="*"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1562477648742_24204_22901"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1734734871008_462076_156" name="isSufficient" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734735033713_889275_331" annotatedElement="_2022x_2_12e503d9_1734734871008_462076_156">
+            <body>&lt;p>A &lt;code>ConnectionDefinition&lt;/code> always has &lt;code>isSufficient = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_2022x_2_12e503d9_1734734893411_556655_160" name="" visibility="public" value="true"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_b9102da_1564072709069_937523_30797"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1565824079403_302443_1935" name="ConnectionUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1567722327583_407427_17991" annotatedElement="_19_0_2_12e503d9_1565824079403_302443_1935">
+          <body>&lt;p>A &lt;code>ConnectionUsage&lt;/code> is a &lt;code>ConnectorAsUsage&lt;/code> that is also a &lt;code>PartUsage&lt;/code>. Nominally, if its type is a &lt;code>ConnectionDefinition&lt;/code>, then a &lt;code>ConnectionUsage&lt;/code> is a Usage of that &lt;code>ConnectionDefinition&lt;/code>, representing a connection between parts of a system. However, other kinds of kernel &lt;code>AssociationStructures&lt;/code> are also allowed, to permit use of &lt;code>AssociationStructures&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672805877788_261138_119" name="checkConnectionUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1565824079403_302443_1935">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672805933819_768457_121" annotatedElement="_19_0_4_12e503d9_1672805877788_261138_119">
+            <body>&lt;p>A &lt;code>ConnectionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ConnectionUsage&lt;/code> &lt;em>&lt;code>Connections::connections&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672805877804_127042_120" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Connections::connections')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672805938574_109402_122" name="checkConnectionUsageBinarySpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1565824079403_302443_1935">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673036236088_917357_558" annotatedElement="_19_0_4_12e503d9_1672805938574_109402_122">
+            <body>&lt;p>A binary &lt;code>ConnectionUsage&lt;/code> must directly or indirectly specialize the &lt;code>ConnectionUsage&lt;/code> &lt;em>&lt;code>Connections::binaryConnections&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672805938582_893684_123" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedEndFeature->size() = 2 implies
+    specializesFromLibrary('Connections::binaryConnections')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_18_5_3_12e503d9_1565498996990_271126_28567" general="_19_0_4_12e503d9_1624053320057_820842_471"/>
+        <generalization xmi:id="_19_0_2_12e503d9_1565823805799_610610_1881" general="_18_5_3_12e503d9_1565471239590_312157_20701"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1594853499656_139435_802" name="connectionDefinition" visibility="public" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565471361757_649736_20796" association="_19_0_2_12e503d9_1594853499655_307260_801">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1594853696834_469199_832" annotatedElement="_19_0_2_12e503d9_1594853499656_139435_802">
+            <body>&lt;p>The &lt;code>AssociationStructures&lt;/code> that are the types of this &lt;code>ConnectionUsage&lt;/code>. Nominally, these are , but other kinds of Kernel &lt;code>AssociationStructures&lt;/code> are also allowed, to permit use of &lt;code>AssociationStructures&lt;/code> from the Kernel Model Libraries&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_b9102da_1609608726569_644338_601"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1594853562745_647277_826" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1594853562747_984072_827" name="" visibility="public" value="*"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674983_471497_43284"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1594853499655_307260_801" name="A_connectionDefinition_definedConnection" visibility="public" memberEnd="_19_0_2_12e503d9_1594853499656_139435_802 _19_0_2_12e503d9_1594853499657_181098_803">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1594853499657_181098_803" name="definedConnection" visibility="public" type="_19_0_2_12e503d9_1565824079403_302443_1935" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1594853499655_307260_801">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1595194876223_628331_1390" annotatedElement="_19_0_2_12e503d9_1594853499657_181098_803">
+            <body>&lt;p>The ConnectionUsages that have a certain AssociationStructure as their &lt;code>connectionDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595194817663_903195_1384" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595194817666_770056_1385" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674995_282523_43352"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624053404424_842165_528" name="SuccessionAsUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624054377271_781179_1227" annotatedElement="_19_0_4_12e503d9_1624053404424_842165_528">
+          <body>&lt;p>A &lt;code>SuccessionAsUsage&lt;/code> is both a &lt;code>ConnectorAsUsage&lt;/code> and a &lt;code>Succession&lt;/code>.&lt;p></body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_12e503d9_1624053430142_37790_553" general="_19_0_4_12e503d9_1624053320057_820842_471"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1624053535672_955630_671">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_71301a1_1536100248189_622183_16479"/>
+        </generalization>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624053320057_820842_471" name="ConnectorAsUsage" visibility="public" isAbstract="true">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624054334598_303062_1225" annotatedElement="_19_0_4_12e503d9_1624053320057_820842_471">
+          <body>&lt;p>A &lt;code>ConnectorAsUsage&lt;/code> is both a &lt;code>Connector&lt;/code> and a &lt;code>Usage&lt;/code>. &lt;code>ConnectorAsUsage&lt;/code> cannot itself be instantiated in a SysML model, but it is a base class for the concrete classes &lt;code>BindingConnectorAsUsage&lt;/code>, &lt;code>SuccessionAsUsage&lt;/code>, &lt;code>ConnectionUsage&lt;/code> and &lt;code>FlowUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_12e503d9_1624053345821_734780_496" general="_18_5_3_12e503d9_1565469997820_598571_19982"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1624053351221_707819_499">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651698_598377_42185"/>
+        </generalization>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624053366342_865295_501" name="BindingConnectorAsUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624054356513_595510_1226" annotatedElement="_19_0_4_12e503d9_1624053366342_865295_501">
+          <body>&lt;p>A &lt;code>BindingConnectorAsUsage&lt;/code> is both a &lt;code>BindingConnector&lt;/code> and a &lt;code>ConnectorAsUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_12e503d9_1624053558440_443615_716">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_b9102da_1543591219823_238592_17680"/>
+        </generalization>
+        <generalization xmi:id="_19_0_4_12e503d9_1624053400159_231614_526" general="_19_0_4_12e503d9_1624053320057_820842_471"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_59601fc_1590256050929_794812_47" name="Cases" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_59601fc_1590256077623_424527_107" name="CaseUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591139503132_50538_2314" annotatedElement="_19_0_2_59601fc_1590256077623_424527_107">
+          <body>&lt;p>A &lt;code>CaseUsage&lt;/code> is a &lt;code>Usage&lt;/code> of a &lt;code>CaseDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676717528546_923529_307" name="deriveCaseUsageObjectiveRequirement" visibility="public" constrainedElement="_19_0_2_59601fc_1590256077623_424527_107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676717528632_176893_310" annotatedElement="_19_0_4_12e503d9_1676717528546_923529_307">
+            <body>&lt;p>The &lt;code>objectiveRequirement&lt;/code> of a &lt;code>CaseUsage&lt;/code> is the &lt;code>RequirementUsage&lt;/code> it owns via an &lt;case>ObjectiveMembership&lt;/code>, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676717528616_281432_309" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>objectiveRequirement = 
+    let objectives: OrderedSet(RequirementUsage) = 
+        featureMembership->
+            selectByKind(ObjectiveMembership).
+            ownedRequirement in
+    if objectives->isEmpty() then null
+    else objectives->first().ownedObjectiveRequirement
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676717528608_650552_308" name="validateCaseUsageOnlyOneObjective" visibility="public" constrainedElement="_19_0_2_59601fc_1590256077623_424527_107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676717587543_718774_313" annotatedElement="_19_0_4_12e503d9_1676717528608_650552_308">
+            <body>&lt;p>A &lt;code>CaseUsage&lt;/code> must have at most one &lt;code>featureMembership&lt;/code> that is a &lt;code>ObjectiveMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676717528641_751977_311" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureMembership->
+    selectByKind(ObjectiveMembership)->
+    size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676717867680_718451_359" name="validateCaseUsageOnlyOneSubject" visibility="public" constrainedElement="_19_0_2_59601fc_1590256077623_424527_107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676717867715_629085_363" annotatedElement="_19_0_4_12e503d9_1676717867680_718451_359">
+            <body>&lt;p>A &lt;code>CaseUsage&lt;/code> must have at most one &lt;code>featureMembership&lt;/code> that is a &lt;code>SubjectMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676717867710_660357_362" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureMembership->
+	selectByKind(SubjectMembership)->
+	size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676717867708_787920_360" name="deriveCaseUsageActorParameter" visibility="public" constrainedElement="_19_0_2_59601fc_1590256077623_424527_107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676717867715_114975_365" annotatedElement="_19_0_4_12e503d9_1676717867708_787920_360">
+            <body>&lt;p>The &lt;code>actorParameters&lt;/code> of a &lt;code>CaseUsage&lt;/code> are the &lt;code>ownedActorParameters&lt;/code> of the &lt;code>ActorMemberships&lt;/code> of the &lt;code>CaseUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676717867715_114494_364" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>actorParameter = featureMembership->
+    selectByKind(ActorMembership).
+    ownedActorParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676717867709_43919_361" name="deriveCaseUsageSubjectParameter" visibility="public" constrainedElement="_19_0_2_59601fc_1590256077623_424527_107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676717867715_290429_367" annotatedElement="_19_0_4_12e503d9_1676717867709_43919_361">
+            <body>&lt;p>The &lt;code>subjectParameter&lt;/code> of a &lt;code>CaseUsage&lt;/code> is the &lt;code>ownedSubjectParameter&lt;/code> of its &lt;code>SubjectMembership&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676717867715_45922_366" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>subjectParameter =
+    let subjects : OrderedSet(SubjectMembership) = 
+        featureMembership->selectByKind(SubjectMembership) in
+    if subjects->isEmpty() then null
+    else subjects->first().ownedSubjectParameter
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676732912176_211959_807" name="validateCaseUsageSubjectParameterPosition" visibility="public" constrainedElement="_19_0_2_59601fc_1590256077623_424527_107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676732912206_201417_809" annotatedElement="_19_0_4_12e503d9_1676732912176_211959_807">
+            <body>&lt;p>The &lt;code>subjectParameter&lt;/code> of a &lt;code>CaseUsage&lt;/code> must be its first &lt;code>input&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676732912202_630351_808" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>input->notEmpty() and input->first() = subjectParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676737711038_534427_875" name="checkCaseUsageSpecialization" visibility="public" constrainedElement="_19_0_2_59601fc_1590256077623_424527_107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676737807667_888543_877" annotatedElement="_19_0_4_12e503d9_1676737711038_534427_875">
+            <body>&lt;p>A &lt;code>CaseUsage&lt;/code> must directly or indirectly specialize the base &lt;code>CaseUsage&lt;/code> &lt;em>&lt;code>Cases::cases&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676737711053_369894_876" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Cases::cases')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676737820561_528289_878" name="checkCaseUsageSubcaseSpecialization" visibility="public" constrainedElement="_19_0_2_59601fc_1590256077623_424527_107">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676737922199_553112_880" annotatedElement="_19_0_4_12e503d9_1676737820561_528289_878">
+            <body>&lt;p>A composite &lt;code>CaseUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>CaseDefinition&lt;/code> or &lt;code>CaseUsage&lt;/code> must directly or indirectly specialize the &lt;code>CaseUsage&lt;/code> &lt;em>&lt;code>Cases::Case::subcases&lt;/code>&lt;/em>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676737820570_746969_879" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and 
+    (owningType.oclIsKindOf(CaseDefinition) or
+     owningType.oclIsKindOf(CaseUsage)) implies
+    specializesFromLibrary('Cases::Case::subcases')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_59601fc_1590256706599_928817_237" general="_19_0_2_12e503d9_1588213258220_731107_146"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591138794257_404044_2145" name="objectiveRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591217543254_26688_475" association="_19_0_2_12e503d9_1591138794257_223105_2144">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591138869285_946911_2191" annotatedElement="_19_0_2_12e503d9_1591138794257_404044_2145">
+            <body>&lt;p>The &lt;code>RequirementUsage&lt;/code> representing the objective of this &lt;code>CaseUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591138811985_711191_2175" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591138811985_636143_2176" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_59601fc_1590257465225_855208_512" name="caseDefinition" visibility="public" type="_19_0_2_59601fc_1590256070522_658678_81" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1588213526305_899324_302" association="_19_0_2_59601fc_1590257465224_772574_510">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591138273580_448271_2098" annotatedElement="_19_0_2_59601fc_1590257465225_855208_512">
+            <body>&lt;p>The CaseDefinition that is the type of this CaseUsage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591134019460_414165_486" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591134019460_808757_487" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1595190279083_51021_1128" name="subjectParameter" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1595190279083_290970_1127">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1595190542777_345259_1238" annotatedElement="_19_0_2_12e503d9_1595190279083_51021_1128">
+            <body>&lt;p>The &lt;code>parameter&lt;/code> of this &lt;code>CaseUsage&lt;/code> that represents its subject.&lt;/p>
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595190293982_348832_1158" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595190293982_801791_1159" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174990_213826_657"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591217543254_26688_475"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621464633171_380461_1655" name="actorParameter" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1621464633171_942518_1654">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621546427892_290170_1972" annotatedElement="_19_0_4_12e503d9_1621464633171_380461_1655">
+            <body>&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>CaseUsage&lt;/code> that represent actors involved in the case.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621464648895_206191_1685" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621464648895_197027_1686" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174990_213826_657"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591217543254_26688_475"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591135021852_252283_735" name="A_caseOwningUsage_nestedCase" visibility="public" memberEnd="_19_0_2_12e503d9_1591135021852_369550_736 _19_0_2_12e503d9_1591135021853_494751_737">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591135021852_369550_736" name="caseOwningUsage" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1588215112282_933161_631" association="_19_0_2_12e503d9_1591135021852_252283_735">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591415510193_587365_1689" annotatedElement="_19_0_2_12e503d9_1591135021852_369550_736">
+            <body>&lt;p>The Usage in which the &lt;code>nestedCase&lt;/code> is nested.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591415498221_600919_1685" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591415498221_651865_1686" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_59601fc_1590257465224_772574_510" name="A_definedCase_caseDefinition" visibility="public" memberEnd="_19_0_2_59601fc_1590257465224_154720_511 _19_0_2_59601fc_1590257465225_855208_512">
+        <ownedEnd xmi:id="_19_0_2_59601fc_1590257465224_154720_511" name="definedCase" visibility="public" type="_19_0_2_59601fc_1590256077623_424527_107" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1588213526305_854304_303" association="_19_0_2_59601fc_1590257465224_772574_510">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591138300919_90465_2099" annotatedElement="_19_0_2_59601fc_1590257465224_154720_511">
+            <body>&lt;p>The CaseUsages being typed by a certain CaseDefinition.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591133925693_436430_482" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591133925716_366475_483" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_59601fc_1590256070522_658678_81" name="CaseDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591139273124_251110_2313" annotatedElement="_19_0_2_59601fc_1590256070522_658678_81">
+          <body>&lt;p>A &lt;code>CaseDefinition&lt;/code> is a &lt;code>CalculationDefinition&lt;/code> for a process, often involving collecting evidence or data, relative to a subject, possibly involving the collaboration of one or more other actors, producing a result that meets an objective.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676680344442_610161_276" name="deriveCaseDefinitionObjectiveRequirement" visibility="public" constrainedElement="_19_0_2_59601fc_1590256070522_658678_81">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676717386484_427442_304" annotatedElement="_19_0_4_12e503d9_1676680344442_610161_276">
+            <body>&lt;p>The &lt;code>objectiveRequirement&lt;/code> of a &lt;code>CaseDefinition&lt;/code> is the &lt;code>ownedObjectiveRequirement&lt;/code> of its &lt;case>ObjectiveMembership&lt;/code>, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676680344458_326542_277" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>objectiveRequirement = 
+    let objectives: OrderedSet(RequirementUsage) = 
+        featureMembership->
+            selectByKind(ObjectiveMembership).
+            ownedRequirement in
+    if objectives->isEmpty() then null
+    else objectives->first().ownedObjectiveRequirement
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676717448282_109412_305" name="validateCaseDefinitionOnlyOneObjective" visibility="public" constrainedElement="_19_0_2_59601fc_1590256070522_658678_81">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676717579471_329759_312" annotatedElement="_19_0_4_12e503d9_1676717448282_109412_305">
+            <body>&lt;p>A &lt;code>CaseDefinition&lt;/code> must have at most one &lt;code>featureMembership&lt;/code> that is a &lt;code>ObjectiveMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676717448314_294976_306" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureMembership->
+    selectByKind(ObjectiveMembership)->
+    size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676717700229_314891_314" name="deriveCaseDefinitionSubjectParameter" visibility="public" constrainedElement="_19_0_2_59601fc_1590256070522_658678_81">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676717700316_551387_317" annotatedElement="_19_0_4_12e503d9_1676717700229_314891_314">
+            <body>&lt;p>The &lt;code>subjectParameter&lt;/code> of a &lt;code>CaseDefinition&lt;/code> is the &lt;code>ownedSubjectParameter&lt;/code> of its &lt;code>SubjectMembership&lt;/code> (if any).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676717700313_846875_316" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>subjectParameter =
+    let subjectMems : OrderedSet(SubjectMembership) = 
+        featureMembership->selectByKind(SubjectMembership) in
+    if subjectMems->isEmpty() then null
+    else subjectMems->first().ownedSubjectParameter
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676717700301_982637_315" name="deriveCaseDefinitionActorParameter" visibility="public" constrainedElement="_19_0_2_59601fc_1590256070522_658678_81">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676717700319_250980_319" annotatedElement="_19_0_4_12e503d9_1676717700301_982637_315">
+            <body>&lt;p>The &lt;code>actorParameters&lt;/code> of a &lt;code>CaseDefinition&lt;/code> are the &lt;code>ownedActorParameters&lt;/code> of the &lt;code>ActorMemberships&lt;/code> of the &lt;code>CaseDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676717700317_856816_318" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>actorParameter = featureMembership->
+    selectByKind(ActorMembership).
+    ownedActorParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676717814407_358303_334" name="validateCaseDefinitionOnlyOneSubject" visibility="public" constrainedElement="_19_0_2_59601fc_1590256070522_658678_81">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676717814450_900882_336" annotatedElement="_19_0_4_12e503d9_1676717814407_358303_334">
+            <body>&lt;p>A &lt;code>CaseDefinition&lt;/code> must have at most one &lt;code>featureMembership&lt;/code> that is a &lt;code>SubjectMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676717814438_708420_335" name="" visibility="public">
+            <language>English</language>
+            <body>featureMembership->selectByKind(SubjectMembership)->size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676732881511_217129_798" name="validateCaseDefinitionSubjectParameterPosition" visibility="public" constrainedElement="_19_0_2_59601fc_1590256070522_658678_81">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676732881520_193403_800" annotatedElement="_19_0_4_12e503d9_1676732881511_217129_798">
+            <body>&lt;p>The &lt;code>subjectParameter&lt;/code> of a &lt;code>CaaseDefinition&lt;/code> must be its first &lt;code>input&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676732881518_446120_799" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>input->notEmpty() and input->first() = subjectParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676736684793_902692_870" name="checkCaseDefinitionSpecialization" visibility="public" constrainedElement="_19_0_2_59601fc_1590256070522_658678_81">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676736778176_296454_872" annotatedElement="_19_0_4_12e503d9_1676736684793_902692_870">
+            <body>&lt;p>A &lt;code>CaseDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>CaseDefinition&lt;/code> &lt;em>&lt;code>Cases::Case>&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676736684802_980315_871" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Cases::Case')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_59601fc_1590256700815_463264_234" general="_19_0_2_12e503d9_1588213234752_326869_117"/>
+        <ownedAttribute xmi:id="_19_0_2_59601fc_1590259317710_27529_910" name="objectiveRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565498571495_48981_27786" association="_19_0_2_59601fc_1590259317709_488814_909">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591138522102_593066_2103" annotatedElement="_19_0_2_59601fc_1590259317710_27529_910">
+            <body>&lt;p>The &lt;code>RequirementUsage&lt;/code> representing the objective of this &lt;code>CaseDefinition&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591134693845_751466_598" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591134693846_578146_599" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1595189932946_106647_973" name="subjectParameter" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_19_0_2_12e503d9_1595189932946_706102_972">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1595190505742_890840_1235" annotatedElement="_19_0_2_12e503d9_1595189932946_106647_973">
+            <body>&lt;p>The &lt;code>parameter&lt;/code> of this &lt;code>CaseDefinition&lt;/code> that represents its subject.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595189972005_145746_983" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595189972006_962875_984" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948010065_362066_20413"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_48981_27786"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621464609772_382176_1612" name="actorParameter" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1621464609772_732760_1611">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621546410315_503387_1971" annotatedElement="_19_0_4_12e503d9_1621464609772_382176_1612">
+            <body>&lt;p>The &lt;code>parameters&lt;/code> of this &lt;code>CaseDefinition&lt;/code> that represent actors involved in the case.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621464628472_287020_1642" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621464628473_987692_1643" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948010065_362066_20413"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565498571495_48981_27786"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_59601fc_1590256849943_920466_400" name="ObjectiveMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591155100546_434294_4390" annotatedElement="_19_0_2_59601fc_1590256849943_920466_400">
+          <body>&lt;p>An &lt;code>ObjectiveMembership&lt;/code> is a &lt;code>FeatureMembership&lt;/code> that indicates that its &lt;code>ownedObjectiveRequirement&lt;/code> is the objective &lt;code>RequirementUsage&lt;/code> for its &lt;code>owningType&lt;/code>, which must be a &lt;code>CaseDefinition&lt;/code> or &lt;code>CaseUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676718575560_504153_433" name="validateObjectiveMembershipOwningType" visibility="public" constrainedElement="_19_0_2_59601fc_1590256849943_920466_400">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676718575590_42714_435" annotatedElement="_19_0_4_12e503d9_1676718575560_504153_433">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of an &lt;code>ObjectiveMembership&lt;/code> must be a &lt;code>CaseDefinition&lt;/code> or &lt;code>CaseUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676718575586_397330_434" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsType(CaseDefinition) or
+owningType.oclIsType(CaseUsage)
+</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676738488458_163005_886" name="validateObjectiveMembershipIsComposite" visibility="public" constrainedElement="_19_0_2_59601fc_1590256849943_920466_400">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676738557364_345934_888" annotatedElement="_19_0_4_12e503d9_1676738488458_163005_886">
+            <body>&lt;p>The &lt;code>ownedObjectiveRequirement&lt;/code> of an &lt;code>ObjectiveMembership&lt;/code> must be composite.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676738488483_285916_887" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedObjectiveRequirement.isComposite</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_59601fc_1590258245723_310663_705">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651715_740575_42237"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_2_59601fc_1590258776804_538578_832" name="ownedObjectiveRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" aggregation="composite" isDerived="true" association="_19_0_2_59601fc_1590258776804_737506_831">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591155297416_923734_4404" annotatedElement="_19_0_2_59601fc_1590258776804_538578_832">
+            <body>&lt;p>The RequirementUsage that is the &lt;code>ownedMemberFeature&lt;/code> of this RequirementUsage.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_59601fc_1590259765192_609762_999" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_59601fc_1590259765193_506997_1000" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674993_898044_43344"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591138794257_223105_2144" name="A_objectiveRequirement_objectiveOwningCase" visibility="public" memberEnd="_19_0_2_12e503d9_1591138794257_404044_2145 _19_0_2_12e503d9_1591138794257_822537_2146">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591138794257_822537_2146" name="objectiveOwningCase" visibility="public" type="_19_0_2_59601fc_1590256077623_424527_107" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000447195_790733_1245" association="_19_0_2_12e503d9_1591138794257_223105_2144">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591139138320_718163_2265" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591139138321_598206_2266" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_59601fc_1590259317709_488814_909" name="A_objectiveRequirement_objectiveOwningCaseDefinition" visibility="public" memberEnd="_19_0_2_59601fc_1590259317710_27529_910 _19_0_2_59601fc_1590259317711_597549_911">
+        <ownedEnd xmi:id="_19_0_2_59601fc_1590259317711_597549_911" name="objectiveOwningCaseDefinition" visibility="public" type="_19_0_2_59601fc_1590256070522_658678_81" isDerived="true" association="_19_0_2_59601fc_1590259317709_488814_909">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591138611269_375516_2105" annotatedElement="_19_0_2_59601fc_1590259317711_597549_911">
+            <body>&lt;p>The CaseDefinitions that have a certain RequirementUsage as their &lt;code>objectiveRequirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_59601fc_1590259586552_338605_967" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_59601fc_1590259586552_593737_968" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_59601fc_1590258776804_737506_831" name="A_ownedObjectiveRequirement_owningObjectiveMembership" visibility="public" memberEnd="_19_0_2_59601fc_1590258776804_538578_832 _19_0_2_59601fc_1590258776805_68442_833">
+        <ownedEnd xmi:id="_19_0_2_59601fc_1590258776805_68442_833" name="owningObjectiveMembership" visibility="public" type="_19_0_2_59601fc_1590256849943_920466_400" isDerived="true" association="_19_0_2_59601fc_1590258776804_737506_831">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591155389062_372616_4406" annotatedElement="_19_0_2_59601fc_1590258776805_68442_833">
+            <body>&lt;p>The ObjectMembership that owns a particular RequirementUsage as its &lt;code>ownedObjectiveRequirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591135528430_87570_1211" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591135528431_137203_1212" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557528016548_348211_110831"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1595189932946_706102_972" name="A_subjectParameter_subjectOwningCaseDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1595189932946_106647_973 _19_0_2_12e503d9_1595189932946_211087_974">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1595189932946_211087_974" name="subjectOwningCaseDefinition" visibility="public" type="_19_0_2_59601fc_1590256070522_658678_81" isDerived="true" association="_19_0_2_12e503d9_1595189932946_706102_972">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1595190470439_853235_1232" annotatedElement="_19_0_2_12e503d9_1595189932946_211087_974">
+            <body>&lt;p>The CaseDefinitions that have a certain Usage as their &lt;code>subjectParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595190003069_229424_989" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595190003070_796157_990" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948010066_582406_20414"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565479686638_420576_23237"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1595190279083_290970_1127" name="A_subjectParameter_subjectOwningCase" visibility="public" memberEnd="_19_0_2_12e503d9_1595190279083_51021_1128 _19_0_2_12e503d9_1595190279084_493413_1129">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1595190279084_493413_1129" name="subjectOwningCase" visibility="public" type="_19_0_2_59601fc_1590256077623_424527_107" association="_19_0_2_12e503d9_1595190279083_290970_1127">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1595190583608_260562_1241" annotatedElement="_19_0_2_12e503d9_1595190279084_493413_1129">
+            <body>&lt;p>The CaseUsages that have a certain Usage as their &lt;code>subjectParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1595190322262_134067_1182" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1595190322262_410792_1183" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174991_690604_658"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565472757327_504924_21260"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621464609772_732760_1611" name="A_actorParameter_actorOwningCaseDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1621464609772_382176_1612 _19_0_4_12e503d9_1621464609772_171892_1613">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621464609772_171892_1613" name="actorOwningCaseDefinition" visibility="public" type="_19_0_2_59601fc_1590256070522_658678_81" association="_19_0_4_12e503d9_1621464609772_732760_1611">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621546569659_69420_1973" annotatedElement="_19_0_4_12e503d9_1621464609772_171892_1613">
+            <body>&lt;p>The CaseDefinitions that have a certain PartUsage as an &lt;code>actorParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621464752224_232733_1717" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621464752225_659816_1718" name="" visibility="public" value="1"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591496643392_535546_3280"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948010066_582406_20414"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621464633171_942518_1654" name="A_actorParameter_actorOwningCase" visibility="public" memberEnd="_19_0_4_12e503d9_1621464633171_380461_1655 _19_0_4_12e503d9_1621464633177_815204_1656">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621464633177_815204_1656" name="actorOwningCase" visibility="public" type="_19_0_2_59601fc_1590256077623_424527_107" isDerived="true" association="_19_0_4_12e503d9_1621464633171_942518_1654">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621546579795_646834_1974" annotatedElement="_19_0_4_12e503d9_1621464633177_815204_1656">
+            <body>&lt;p>The CaseUsages that have a certain PartUsage as an &lt;code>actorParameter&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621465064912_543627_1828" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621465064913_549709_1829" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_2_12e503d9_1595189174991_690604_658"/>
+          <subsettedProperty href="#_19_0_2_12e503d9_1591496406877_994044_3189"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_59601fc_1590256043549_386915_46" name="AnalysisCases" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_59601fc_1590945152797_594088_220" name="A_resultExpression_analysisCaseDefintion" visibility="public" memberEnd="_19_0_2_59601fc_1590945152798_315308_221 _19_0_2_59601fc_1590945152799_582256_222">
+        <ownedEnd xmi:id="_19_0_2_59601fc_1590945152799_582256_222" name="analysisCaseDefintion" visibility="public" type="_19_0_2_59601fc_1590260221442_937295_1064" isDerived="true" association="_19_0_2_59601fc_1590945152797_594088_220">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591153717991_902492_4128" annotatedElement="_19_0_2_59601fc_1590945152799_582256_222">
+            <body>&lt;p>The AnalysisCaseDefinitions that have a certain Expression as their &lt;code>resultExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591151325005_111217_2591" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591151325005_786145_2592" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674971_573157_43226"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948400639_994746_20842"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591152217935_430588_2920" name="A_analysisCaseDefinition_definedAnalysisCase" visibility="public" memberEnd="_19_0_2_12e503d9_1591152217935_225164_2921 _19_0_2_12e503d9_1591152217936_160134_2922">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591152217936_160134_2922" name="definedAnalysisCase" visibility="public" type="_19_0_2_59601fc_1590260225615_617039_1090" isOrdered="true" isDerived="true" redefinedProperty="_19_0_2_59601fc_1590257465224_154720_511" association="_19_0_2_12e503d9_1591152217935_430588_2920">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591153776410_884410_4130" annotatedElement="_19_0_2_12e503d9_1591152217936_160134_2922">
+            <body>&lt;p>The AnalysisCaseUsages being typed by a certain AnalysisCaseDefinition.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591152250694_527046_2963" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591152250695_192557_2964" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_59601fc_1590260225615_617039_1090" name="AnalysisCaseUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591153417263_234984_4122" annotatedElement="_19_0_2_59601fc_1590260225615_617039_1090">
+          <body>&lt;p>An &lt;code>AnalysisCaseUsage&lt;/code> is a &lt;code>Usage&lt;/code> of an &lt;code>AnalysisCaseDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676720771494_718567_471" name="deriveAnalysisCaseUsageResultExpression" visibility="public" constrainedElement="_19_0_2_59601fc_1590260225615_617039_1090">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676720771508_713788_475" annotatedElement="_19_0_4_12e503d9_1676720771494_718567_471">
+            <body>&lt;p>The &lt;code>resultExpression&lt;/code> of a &lt;code>AnalysisCaseUsage&lt;/code> is the &lt;code>ownedResultExpression&lt;/code> of its &lt;code>ResultExpressionMembership&lt;/code>, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676720771507_37777_474" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>resultExpression =
+    let results : OrderedSet(ResultExpressionMembership) =
+        featureMembersip->
+            selectByKind(ResultExpressionMembership) in
+    if results->isEmpty() then null
+    else results->first().ownedResultExpression
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676738688422_374174_892" name="checkAnalysisCaseUsageSpecialization" visibility="public" constrainedElement="_19_0_2_59601fc_1590260225615_617039_1090">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676738775201_652287_894" annotatedElement="_19_0_4_12e503d9_1676738688422_374174_892">
+            <body>&lt;p>An &lt;code>AnalysisCaseUsage&lt;/code> must directly or indirectly specialize the base &lt;code>AnalysisCaseUsage&lt;/code> &lt;code>&lt;em>AnalysisCases::analysisCases&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676738688448_791664_893" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('AnalysisCases::analysisCases')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676738782241_392043_895" name="checkAnalysisCaseUsageSubAnalysisCaseSpecialization" visibility="public" constrainedElement="_19_0_2_59601fc_1590260225615_617039_1090">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676739004530_51254_897" annotatedElement="_19_0_4_12e503d9_1676738782241_392043_895">
+            <body>&lt;p>A composite &lt;code>AnalysisCaseUsage&lt;/code> whose &lt;code>owningType&lt;/code> is an &lt;code>AnalysisCaseDefinition&lt;/code> or &lt;code>AnalysisCaseUsage&lt;/code> must specialize the &lt;code>AnalysisCaseUsage&lt;/code> &lt;code>&lt;em>AnalysisCases::AnalysisCase::subAnalysisCases&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676738782246_887268_896" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+    (owningType.oclIsKindOf(AnalysisCaseDefinition) or
+     owningType.oclIsKindOf(AnalysisCaseUsage)) implies
+    specializesFromLibrary('AnalysisCases::AnalysisCase::subAnalysisCases')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_59601fc_1590260255205_150125_1120" general="_19_0_2_59601fc_1590256077623_424527_107"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591152217935_225164_2921" name="analysisCaseDefinition" visibility="public" type="_19_0_2_59601fc_1590260221442_937295_1064" isDerived="true" redefinedProperty="_19_0_2_59601fc_1590257465225_855208_512" association="_19_0_2_12e503d9_1591152217935_430588_2920">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591153709570_581427_4127" annotatedElement="_19_0_2_12e503d9_1591152217935_225164_2921">
+            <body>&lt;p>The &lt;code>AnalysisCaseDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>AnalysisCaseUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591152228652_163532_2943" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591152228653_699707_2944" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1591151453868_910052_2600" name="resultExpression" visibility="public" isDerived="true" association="_19_0_2_12e503d9_1591151453868_101362_2599">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591153620525_155658_4124" annotatedElement="_19_0_2_12e503d9_1591151453868_910052_2600">
+            <body>&lt;p>An &lt;code>Expression&lt;/code> used to compute the &lt;code>result&lt;/code> of the &lt;code>AnalysisCaseUsage&lt;/code>, owned via a &lt;code>ResultExpressionMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591151469265_348080_2610" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591151469266_151848_2611" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_226999_43167"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1591151453868_101362_2599" name="A_resultExpression_analysisCase" visibility="public" memberEnd="_19_0_2_12e503d9_1591151453868_910052_2600 _19_0_2_12e503d9_1591151453868_873832_2601">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1591151453868_873832_2601" name="analysisCase" visibility="public" type="_19_0_2_59601fc_1590260225615_617039_1090" isDerived="true" association="_19_0_2_12e503d9_1591151453868_101362_2599">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591153755755_656309_4129" annotatedElement="_19_0_2_12e503d9_1591151453868_873832_2601">
+            <body>&lt;p>The AnalysisCaseUsages that have a certain Expression as their &lt;code>resultExpression&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591151507640_743208_2616" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591151507641_632768_2617" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_59601fc_1590260221442_937295_1064" name="AnalysisCaseDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591153236711_406170_4119" annotatedElement="_19_0_2_59601fc_1590260221442_937295_1064">
+          <body>&lt;p>An &lt;code>AnalysisCaseDefinition&lt;/code> is a &lt;code>CaseDefinition&lt;/code> for the case of carrying out an analysis.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676720551780_273602_457" name="deriveAnalysisCaseDefinitionResultExpression" visibility="public" constrainedElement="_19_0_2_59601fc_1590260221442_937295_1064">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676720742818_293726_469" annotatedElement="_19_0_4_12e503d9_1676720551780_273602_457">
+            <body>&lt;p>The &lt;code>resultExpression&lt;/code> of a &lt;code>AnalysisCaseDefinition&lt;/code> is the &lt;code>ownedResultExpression&lt;/code> of its &lt;code>ResultExpressionMembership&lt;/code>, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676720551800_988457_458" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>resultExpression =
+    let results : OrderedSet(ResultExpressionMembership) =
+        featureMembersip->
+            selectByKind(ResultExpressionMembership) in
+    if results->isEmpty() then null
+    else results->first().ownedResultExpression
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676738591849_90692_889" name="checkAnalysisCaseDefinitionSpecialization" visibility="public" constrainedElement="_19_0_2_59601fc_1590260221442_937295_1064">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676738661226_733190_891" annotatedElement="_19_0_4_12e503d9_1676738591849_90692_889">
+            <body>&lt;p>An &lt;code>AnalysisCaseDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>AnalysisCaseDefinition&lt;/code> &lt;code>&lt;em>AnalysisCases::AnalysisCase&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676738591865_326717_890" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('AnalysisCases::AnalysisCase')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_59601fc_1590260251738_375973_1117" general="_19_0_2_59601fc_1590256070522_658678_81"/>
+        <ownedAttribute xmi:id="_19_0_2_59601fc_1590945152798_315308_221" name="resultExpression" visibility="public" isDerived="true" association="_19_0_2_59601fc_1590945152797_594088_220">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1591153533953_392483_4123" annotatedElement="_19_0_2_59601fc_1590945152798_315308_221">
+            <body>&lt;p>An &lt;code>Expression&lt;/code> used to compute the &lt;code>result&lt;/code> of the &lt;code>AnalysisCaseDefinition&lt;/code>, owned via a &lt;code>ResultExpressionMembership&lt;/code>.&lt;/p>
+</body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1591151031902_329254_2583" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1591151031907_994306_2584" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1543948400639_301251_20841"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674959_226999_43167"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1591216530530_182959_26" name="Items" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_18_5_3_12e503d9_1565480460114_846184_24270" name="ItemUsage" visibility="public">
+        <ownedComment xmi:id="_18_5_3_12e503d9_1565480945253_9574_24381" annotatedElement="_18_5_3_12e503d9_1565480460114_846184_24270">
+          <body>&lt;p>An &lt;code>ItemUsage&lt;/code> is an &lt;code>OccurrenceUsage&lt;/code> whose &lt;code>definition&lt;/code> is a &lt;code>Structure&lt;/code>. Nominally, if the &lt;code>definition&lt;/code> is an &lt;code>ItemDefinition&lt;/code>, an &lt;code>ItemUsage&lt;/code> is a &lt;code>ItemUsage&lt;/code> of that &lt;code>ItemDefinition&lt;/code> within a system. However, other kinds of Kernel &lt;code>Structures&lt;/code> are also allowed, to permit use of &lt;code>Structures&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672603764009_704051_353" name="deriveItemUsageItemDefinition" visibility="public" constrainedElement="_18_5_3_12e503d9_1565480460114_846184_24270">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672603863772_427929_355" annotatedElement="_19_0_4_12e503d9_1672603764009_704051_353">
+            <body>&lt;p>The &lt;code>itemDefinitions&lt;/code> of an &lt;code>ItemUsage&lt;/code> are those &lt;code>occurrenceDefinitions&lt;/code> that are &lt;code>Structures&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672603764024_564341_354" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>itemDefinition = occurrenceDefinition->selectByKind(Structure)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672603878784_672084_356" name="checkItemUsageSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565480460114_846184_24270">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672603985238_748569_358" annotatedElement="_19_0_4_12e503d9_1672603878784_672084_356">
+            <body>&lt;p>An &lt;code>ItemUsage&lt;/code> must directly or indirectly specialize the Systems Model Library &lt;code>ItemUsage&lt;/code> &lt;em>&lt;code>items&lt;/code>&lt;/em>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672603878789_251054_357" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Items::items')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672603998984_358422_359" name="checkItemUsageSubitemSpecialization" visibility="public" constrainedElement="_18_5_3_12e503d9_1565480460114_846184_24270">
+          <ownedComment xmi:id="_2024x_2_12e503d9_1778878381250_468865_66" annotatedElement="_19_0_4_12e503d9_1672603998984_358422_359">
+            <body>&lt;p>A composite &lt;code>ItemUsage&lt;/code> whose &lt;code>owningType&lt;/code> is an &lt;code>ItemDefinition&lt;/code> or &lt;code>ItemUsage&lt;/code> must directly or indirectly specialize the Systems Model Library &lt;code>ItemUsage&lt;/code> &lt;em>&lt;code>Items::Item::subitems&lt;/code>&lt;/em>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672603998996_16957_360" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(ItemDefinition) or
+ owningType.oclIsKindOf(ItemUsage)) implies
+    specializesFromLibrary('Items::Item::subitem')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1618946734267_545076_876" general="_19_0_4_12e503d9_1618943737195_33207_138"/>
+        <ownedAttribute xmi:id="_18_5_3_12e503d9_1565471361757_649736_20796" name="itemDefinition" visibility="public" isOrdered="true" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943843466_158863_236" association="_18_5_3_12e503d9_1565471361757_216899_20795">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1586294170332_620895_349" annotatedElement="_18_5_3_12e503d9_1565471361757_649736_20796">
+            <body>&lt;p>The Structures that are the &lt;code>definitions&lt;/code> of this ItemUsage. Nominally, these are ItemDefinitions, but other kinds of Kernel Structures are also allowed, to permit use of Structures from the Kernel Library.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_b9102da_1609606051359_625961_451"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_18_5_3_12e503d9_1565471670712_503274_20901" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_18_5_3_12e503d9_1565471670713_38719_20902" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1591216581238_805702_84" name="ItemDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1591220379060_975820_568" annotatedElement="_19_0_2_12e503d9_1591216581238_805702_84">
+          <body>&lt;p>An &lt;code>ItemDefinition&lt;/code> is an &lt;code>OccurrenceDefinition&lt;/code> of the &lt;code>Structure&lt;/code> of things that may themselves be systems or parts of systems, but may also be things that are acted on by a system or parts of a system, but which do not necessarily perform actions themselves. This includes items that can be exchanged between parts of a system, such as water or electrical signals.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672603456602_416038_350" name="checkItemDefinitionSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1591216581238_805702_84">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672603558505_693169_352" annotatedElement="_19_0_4_12e503d9_1672603456602_416038_350">
+            <body>&lt;p>An &lt;code>ItemDefinition&lt;/code> must directly or indirectly specialize the Systems Library Model &lt;code>ItemDefinition&lt;/code> &lt;em>&lt;code>Items::Item&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672603456622_894659_351" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Items::Item')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1591216704920_574081_360">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_b9102da_1609606051359_625961_451"/>
+        </generalization>
+        <generalization xmi:id="_19_0_4_12e503d9_1618946707865_8120_834" general="_19_0_4_12e503d9_1618943693347_790503_111"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1596643665458_232849_342" name="Views" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1596649640349_746765_3429" name="ViewpointDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1596747302275_32858_7069" annotatedElement="_19_0_2_12e503d9_1596649640349_746765_3429">
+          <body>&lt;p>A &lt;code>ViewpointDefinition&lt;/code> is a &lt;code>RequirementDefinition&lt;/code> that specifies one or more stakeholder concerns that are to be satisfied by creating a view of a model.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676727539937_927879_683" name="deriveViewpointDefinitionViewpointStakeholder" visibility="public" constrainedElement="_19_0_2_12e503d9_1596649640349_746765_3429">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676727828258_21141_685" annotatedElement="_19_0_4_12e503d9_1676727539937_927879_683">
+            <body>&lt;p>The &lt;code>viewpointStakeholders&lt;/code> of a &lt;code>ViewpointDefinition&lt;/code> are the &lt;code>ownedStakeholderParameters&lt;/code> of all &lt;code>featureMemberships&lt;/code> that are &lt;code>StakeholderMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676727539953_9536_684" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>viewpointStakeholder = framedConcern.featureMemberhsip->
+    selectByKind(StakeholderMembership).
+    ownedStakeholderParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676743228427_638858_1006" name="checkViewpointDefinitionSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1596649640349_746765_3429">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676743293530_391937_1008" annotatedElement="_19_0_4_12e503d9_1676743228427_638858_1006">
+            <body>&lt;p>A &lt;code>ViewpointDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>ViewpointDefinition&lt;/code> &lt;code>&lt;em>Views::ViewpointCheck&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676743228432_22849_1007" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Views::ViewpointCheck')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1596649654832_306461_3474" general="_19_0_2_12e503d9_1582990729262_130404_898"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617117194003_518610_3310" name="viewpointStakeholder" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1617117194002_842455_3309">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617117999534_685680_3499" annotatedElement="_19_0_4_12e503d9_1617117194003_518610_3310">
+            <body>&lt;p>The &lt;code>PartUsages&lt;/code> that identify the stakeholders with concerns framed by this &lt;code>ViewpointDefinition&lt;/code>, which are the owned and inherited &lt;code>stakeholderParameters&lt;/code> of the &lt;code>framedConcerns&lt;/code> of this &lt;code>ViewpointDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617117369920_739697_3333" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617117369921_821071_3334" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596648681657_962206_2704" name="A_exposedElement_exposingView" visibility="public" memberEnd="_19_0_2_12e503d9_1596648681658_691767_2705 _19_0_2_12e503d9_1596648681658_824767_2706">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596648681658_824767_2706" name="exposingView" visibility="public" type="_19_0_2_12e503d9_1596644366280_485907_701" isDerived="true" association="_19_0_2_12e503d9_1596648681657_962206_2704">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596746399549_437940_7064" annotatedElement="_19_0_2_12e503d9_1596648681658_824767_2706">
+            <body>&lt;p>A ViewUsage exposing a certain &lt;code>exposedElement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596649055415_947096_2883" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596649055415_375524_2884" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674980_717955_43271"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596741320784_361720_6305" name="A_renderingDefinition_definedRendering" visibility="public" memberEnd="_19_0_2_12e503d9_1596741320785_268295_6306 _19_0_2_12e503d9_1596741320786_847875_6307">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596741320786_847875_6307" name="definedRendering" visibility="public" type="_19_0_2_12e503d9_1596657138882_432286_4810" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591475180488_240858_122" association="_19_0_2_12e503d9_1596741320784_361720_6305">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596747936172_513627_7084" annotatedElement="_19_0_2_12e503d9_1596741320786_847875_6307">
+            <body>&lt;p>The RenderingUsages defined by a certain &lt;code>renderingDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596741360841_44896_6360" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596741360841_677207_6361" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1596644366280_485907_701" name="ViewUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1596744079806_648198_7040" annotatedElement="_19_0_2_12e503d9_1596644366280_485907_701">
+          <body>&lt;p>A &lt;code>ViewUsage&lt;/code> is a usage of a &lt;code>ViewDefinition&lt;/code> to specify the generation of a view of the &lt;code>members&lt;/code> of a collection of &lt;code>exposedNamespaces&lt;/code>. The &lt;code>ViewUsage&lt;/code> can satisfy more &lt;code>viewpoints&lt;/code> than its definition, and it can specialize the &lt;code>viewRendering&lt;/code> specified by its definition.&lt;p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1668970911262_799757_54" name="deriveViewUsageExposedElement" visibility="public" constrainedElement="_19_0_2_12e503d9_1596644366280_485907_701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1705964850920_212857_57" annotatedElement="_19_0_4_12e503d9_1668970911262_799757_54">
+            <body>&lt;p>The &lt;code>exposedElements&lt;/code> of a &lt;code>ViewUsage&lt;/code> are those &lt;code>memberElements&lt;/code> of the imported &lt;code>Memberships&lt;/code> from all the &lt;code>Expose&lt;/code> &lt;code>Relationships&lt;/code> for which the &lt;code>includeAsExposed&lt;/code> operation returns true.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1668970911293_497595_55" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>exposedElement = ownedImport->selectByKind(Expose).
+    importedMemberships(Set{}).memberElement->
+    select(elm | includeAsExposed(elm))->
+    asOrderedSet()</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676727195669_985847_633" name="deriveViewUsageSatisfiedViewpoint" visibility="public" constrainedElement="_19_0_2_12e503d9_1596644366280_485907_701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676727195702_986330_639" annotatedElement="_19_0_4_12e503d9_1676727195669_985847_633">
+            <body>&lt;p>The &lt;code>satisfiedViewpoints&lt;/code> of a &lt;code>ViewUsage&lt;/code> are its &lt;code>ownedRequirements&lt;/code> that are composite &lt;code>ViewpointUsages&lt;/code>. </body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676727195695_823967_638" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>satisfiedViewpoint = ownedRequirement->
+    selectByKind(ViewpointUsage)->
+    select(isComposite)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676727195692_598742_635" name="deriveViewUsageViewCondition" visibility="public" constrainedElement="_19_0_2_12e503d9_1596644366280_485907_701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676727195704_931989_643" annotatedElement="_19_0_4_12e503d9_1676727195692_598742_635">
+            <body>&lt;p>The &lt;code>viewConditions&lt;/code> of a &lt;code>ViewUsage&lt;/code> are the &lt;code>conditions&lt;/code> of its owned &lt;code>ElementFilterMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676727195704_357680_642" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>viewCondition = ownedMembership->
+    selectByKind(ElementFilterMembership).
+    condition</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676727195693_349597_636" name="deriveViewUsageViewRendering" visibility="public" constrainedElement="_19_0_2_12e503d9_1596644366280_485907_701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676727195704_275697_645" annotatedElement="_19_0_4_12e503d9_1676727195693_349597_636">
+            <body>&lt;p>The &lt;code>viewRendering&lt;/code> of a &lt;code>ViewUsage&lt;/code> is the &lt;code>referencedRendering&lt;/code> of its owned &lt;code>ViewRenderingMembership&lt;code>, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676727195704_710188_644" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>viewRendering =
+    let renderings: OrderedSet(ViewRenderingMembership) =
+        featureMembership->selectByKind(ViewRenderingMembership) in
+    if renderings->isEmpty() then null
+    else renderings->first().referencedRendering
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676727195693_292453_637" name="validateViewUsageOnlyOneViewRendering" visibility="public" constrainedElement="_19_0_2_12e503d9_1596644366280_485907_701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676957806816_980315_69355" annotatedElement="_19_0_4_12e503d9_1676727195693_292453_637">
+            <body>&lt;p>A &lt;code>ViewUsage&lt;/code> must have at most one &lt;code>ViewRenderingMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676727195704_905290_646" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureMembership->
+    selectByKind(ViewRenderingMembership)->
+    size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676743945620_473772_1017" name="checkViewUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1596644366280_485907_701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676744037355_123107_1019" annotatedElement="_19_0_4_12e503d9_1676743945620_473772_1017">
+            <body>&lt;p>A &lt;code>ViewUsage&lt;/code> must directly or indirectly specialize the base &lt;code>ViewUsage&lt;/code> &lt;code>&lt;em>Views::views&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676743945636_274280_1018" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Views::views')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676744061720_737079_1020" name="checkViewUsageSubviewSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1596644366280_485907_701">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676744235093_252246_1022" annotatedElement="_19_0_4_12e503d9_1676744061720_737079_1020">
+            <body>&lt;p>A &lt;code>ViewUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>ViewDefinition&lt;/code> or &lt;code>ViewUsage&lt;/code> must specialize the &lt;code>ViewUsage&lt;/code> &lt;code>&lt;em>Views::View::subviews&lt;/em>&lt;/code> from the Systems Library Model.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676744061735_397601_1021" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(ViewDefinition) or
+ owningType.oclIsKindOf(ViewUsage)) implies
+    specializesFromLibrary('Views::View::subviews')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1596644385911_240085_728" general="_18_5_3_12e503d9_1565471239590_312157_20701"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596644438889_580287_734" name="viewDefinition" visibility="public" type="_19_0_2_59601fc_1583087286915_926479_556" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1591475180488_929065_121" association="_19_0_2_12e503d9_1596644438889_305535_733">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596744405807_675114_7042" annotatedElement="_19_0_2_12e503d9_1596644438889_580287_734">
+            <body>&lt;p>The &lt;code>ViewDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>ViewUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596644446739_674957_744" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596644446740_701842_745" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596645688987_502277_1282" name="satisfiedViewpoint" visibility="public" type="_19_0_2_59601fc_1583087291401_74297_590" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000447195_878123_1244" association="_19_0_2_12e503d9_1596645688986_81959_1281">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596745785565_817460_7049" annotatedElement="_19_0_2_12e503d9_1596645688987_502277_1282">
+            <body>&lt;p>The &lt;code>nestedRequirements&lt;/code> of this &lt;code>ViewUsage&lt;/code> that are &lt;code>ViewpointUsages&lt;/code> for (additional) viewpoints satisfied by the &lt;code>ViewUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596645697526_769973_1306" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596645697527_561735_1307" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596648681658_691767_2705" name="exposedElement" visibility="public" isOrdered="true" isDerived="true" association="_19_0_2_12e503d9_1596648681657_962206_2704">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596744961146_588553_7046" annotatedElement="_19_0_2_12e503d9_1596648681658_691767_2705">
+            <body>&lt;p>The &lt;code>Elements&lt;/code> that are exposed by this &lt;code>ViewUsage&lt;/code>, which are those &lt;code>memberElements&lt;/code> of the imported &lt;code>Memberships&lt;/code> from all the &lt;code>Expose&lt;/code> &lt;code>Relationships&lt;/code> that meet all the owned and inherited &lt;code>viewConditions&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596648758593_246776_2774" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596648713068_782020_2766" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674979_644335_43267"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596657318021_274182_5067" name="viewRendering" visibility="public" type="_19_0_2_12e503d9_1596657138882_432286_4810" isDerived="true" association="_19_0_2_12e503d9_1596657318021_872369_5066">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596746076786_453594_7052" annotatedElement="_19_0_2_12e503d9_1596657318021_274182_5067">
+            <body>&lt;p>The &lt;code>RenderingUsage&lt;/code> to be used to render views defined by this &lt;code>ViewUsage&lt;/code>, which is the &lt;code>referencedRendering&lt;/code> of the &lt;code>ViewRenderingMembership&lt;/code> of the &lt;code>ViewUsage&lt;/code>.&lt;p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596657965411_414873_5876" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596657965411_797508_5877" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1606938933668_437943_4809" name="viewCondition" visibility="public" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1606938933666_172300_4808">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606939584110_56016_5135" annotatedElement="_19_0_4_12e503d9_1606938933668_437943_4809">
+            <body>&lt;p>The &lt;code>Expressions&lt;/code> related to this &lt;code>ViewUsage&lt;/code> by &lt;code>ElementFilterMemberships&lt;/code>, which specify conditions on &lt;code>Elements&lt;/code> to be rendered in a view.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606938967475_426585_4825" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606938967476_342325_4826" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674979_259543_43268"/>
+        </ownedAttribute>
+        <ownedOperation xmi:id="_19_0_4_12e503d9_1668970519047_597955_47" name="includeAsExposed" visibility="public" bodyCondition="_19_0_4_12e503d9_1668970856419_302583_52">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1668970652044_119004_51" annotatedElement="_19_0_4_12e503d9_1668970519047_597955_47">
+            <body>&lt;p>Determine whether the given &lt;code>element&lt;/code> meets all the owned and inherited &lt;code>viewConditions&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <ownedRule xmi:id="_19_0_4_12e503d9_1668970856419_302583_52" name="unnamed1" visibility="public">
+            <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1668970856460_503942_53" name="" visibility="public">
+              <language>OCL2.0</language>
+              <body>let metadataFeatures: Sequence(AnnotatingElement) = 
+    element.ownedAnnotation.annotatingElement->
+        select(oclIsKindOf(MetadataFeature)) in
+self.membership->selectByKind(ElementFilterMembership).
+    condition->forAll(cond | 
+        metadataFeatures->exists(elem | 
+            cond.checkCondition(elem)))</body>
+            </specification>
+          </ownedRule>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1668970551544_750214_49" name="element" visibility="public">
+            <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651703_306405_42199"/>
+          </ownedParameter>
+          <ownedParameter xmi:id="_19_0_4_12e503d9_1668970551827_628491_50" name="" visibility="public" direction="return">
+            <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          </ownedParameter>
+        </ownedOperation>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596657318021_872369_5066" name="A_viewRendering_renderingOwningView" visibility="public" memberEnd="_19_0_2_12e503d9_1596657318021_274182_5067 _19_0_2_12e503d9_1596657318022_263153_5068">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596657318022_263153_5068" name="renderingOwningView" visibility="public" type="_19_0_2_12e503d9_1596644366280_485907_701" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565472757327_504924_21260" association="_19_0_2_12e503d9_1596657318021_872369_5066">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596746147632_659217_7054" annotatedElement="_19_0_2_12e503d9_1596657318022_263153_5068">
+            <body>&lt;p>The ViewUsage that owns a certain &lt;code>rendering&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596657814394_216283_5533" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596657814394_682002_5534" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596657187664_421111_4913" name="A_viewRendering_renderingOwningViewDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1596657187664_758418_4914 _19_0_2_12e503d9_1596657187664_287522_4915">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596657187664_287522_4915" name="renderingOwningViewDefinition" visibility="public" type="_19_0_2_59601fc_1583087286915_926479_556" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565479686638_420576_23237" association="_19_0_2_12e503d9_1596657187664_421111_4913">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596746281416_656368_7060" annotatedElement="_19_0_2_12e503d9_1596657187664_287522_4915">
+            <body>&lt;p>The ViewDefinition that owns a certain &lt;code>rendering&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596657364878_760800_5113" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596657364878_324036_5114" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596645688986_81959_1281" name="A_satisfiedViewpoint_viewpointSatisfyingView" visibility="public" memberEnd="_19_0_2_12e503d9_1596645688987_502277_1282 _19_0_2_12e503d9_1596645688987_656952_1283">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596645688987_656952_1283" name="viewpointSatisfyingView" visibility="public" type="_19_0_2_12e503d9_1596644366280_485907_701" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591217543255_292723_476" association="_19_0_2_12e503d9_1596645688986_81959_1281">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596745834380_350948_7050" annotatedElement="_19_0_2_12e503d9_1596645688987_656952_1283">
+            <body>p>The ViewUsage that owns a certain &lt;code>satisfiedViewpoint&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596645745281_676679_1418" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596645745281_297075_1419" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596645596182_790331_1208" name="A_satisfiedViewpoint_viewpointSatisfyingViewDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1596645596183_374903_1209 _19_0_2_12e503d9_1596645596183_794802_1210">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596645596183_794802_1210" name="viewpointSatisfyingViewDefinition" visibility="public" type="_19_0_2_59601fc_1583087286915_926479_556" subsettedProperty="_18_5_3_12e503d9_1565479686638_420576_23237" association="_19_0_2_12e503d9_1596645596182_790331_1208">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596745989409_423223_7051" annotatedElement="_19_0_2_12e503d9_1596645596183_794802_1210">
+            <body>&lt;p>The ViewDefinition that owns a certain &lt;code>satisfiedViewpoint&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596645683617_458194_1267" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596645683617_859725_1268" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596644452170_651371_752" name="A_view_featuringView" visibility="public" memberEnd="_19_0_2_12e503d9_1596644452170_21813_753 _19_0_2_12e503d9_1596644452170_28116_754">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596644452170_28116_754" name="featuringView" visibility="public" type="_19_0_2_59601fc_1583087286915_926479_556" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565498571495_18876_27787" association="_19_0_2_12e503d9_1596644452170_651371_752">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596744585008_291958_7045" annotatedElement="_19_0_2_12e503d9_1596644452170_28116_754">
+            <body>&lt;p>The ViewDefinitions that feature a certain ViewUsage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596644555019_623773_775" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596644555020_469778_776" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1596657122569_397556_4766" name="RenderingDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1596747558348_115328_7072" annotatedElement="_19_0_2_12e503d9_1596657122569_397556_4766">
+          <body>&lt;p>A &lt;code>RenderingDefinition&lt;/code> is a &lt;code>PartDefinition&lt;/code> that defines a specific rendering of the content of a model view (e.g., symbols, style, layout, etc.).&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676723615104_410653_544" name="deriveRenderingDefinitionRendering" visibility="public" constrainedElement="_19_0_2_12e503d9_1596657122569_397556_4766">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676723723181_181799_546" annotatedElement="_19_0_4_12e503d9_1676723615104_410653_544">
+            <body>&lt;p>The &lt;code>renderings&lt;/code> of a &lt;code>RenderingDefinition&lt;/code> are all its &lt;code>usages&lt;/code> that are &lt;code>RenderingUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676723615129_667236_545" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>rendering = usages->selectByKind(RenderingUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676741985202_515273_991" name="checkRenderingDefinitionSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1596657122569_397556_4766">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676742070878_450477_993" annotatedElement="_19_0_4_12e503d9_1676741985202_515273_991">
+            <body>&lt;p>A &lt;code>RenderingDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>RenderingDefinition&lt;/code> &lt;code>&lt;em>Views::Rendering&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676741985225_445843_992" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Views::Rendering')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1596741280610_709771_6248" general="_18_5_3_12e503d9_1565469626440_455154_19856"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596741367270_249607_6373" name="rendering" visibility="public" type="_19_0_2_12e503d9_1596657138882_432286_4810" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565498571495_48981_27786" association="_19_0_2_12e503d9_1596741367270_495988_6372">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596747967604_448385_7085" annotatedElement="_19_0_2_12e503d9_1596741367270_249607_6373">
+            <body>&lt;p>The &lt;code>usages&lt;/code> of a &lt;code>RenderingDefinition&lt;/code> that are &lt;code>RenderingUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596741377890_533255_6397" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596741377891_297079_6398" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_59601fc_1583087291401_74297_590" name="ViewpointUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1596747392923_803351_7071" annotatedElement="_19_0_2_59601fc_1583087291401_74297_590">
+          <body>&lt;p>A &lt;code>ViewpointUsage&lt;/code> is a &lt;code>Usage&lt;/code> of a &lt;code>ViewpointDefinition&lt;/code>.&lt;/p>
+
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676727921882_164856_686" name="deriveViewpointUsageViewpointStakeholder" visibility="public" constrainedElement="_19_0_2_59601fc_1583087291401_74297_590">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676727921921_713899_688" annotatedElement="_19_0_4_12e503d9_1676727921882_164856_686">
+            <body>&lt;p>The &lt;code>viewpointStakeholders&lt;/code> of a &lt;code>ViewpointUsage&lt;/code> are the &lt;code>ownedStakeholderParameters&lt;/code> of all &lt;code>featureMemberships&lt;/code> that are &lt;code>StakeholderMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676727921912_690644_687" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>viewpointStakeholder = framedConcern.featureMemberhsip->
+    selectByKind(StakeholderMembership).
+    ownedStakeholderParameter</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676743306486_30409_1009" name="checkViewpointUsageSpecialization" visibility="public" constrainedElement="_19_0_2_59601fc_1583087291401_74297_590">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676743402679_515883_1011" annotatedElement="_19_0_4_12e503d9_1676743306486_30409_1009">
+            <body>&lt;p>A &lt;code>ViewpointUsage&lt;/code> must directly or indirectly specialize the base &lt;code>ViewpointUsage&lt;/code> &lt;code>&lt;em>Views::viewpointChecks&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676743306494_440641_1010" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Views::viewpointChecks')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676743646170_468774_1014" name="checkViewpointUsageViewpointSatisfactionSpecialization" visibility="public" constrainedElement="_19_0_2_59601fc_1583087291401_74297_590">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676743912514_940189_1016" annotatedElement="_19_0_4_12e503d9_1676743646170_468774_1014">
+            <body>&lt;p>A composite &lt;code>ViewpointUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>ViewDefinition&lt;/code> or &lt;code>ViewUsage&lt;/code> must directly or indirectly specialize the &lt;code>ViewpointUsage&lt;/code> &lt;code>&lt;em>Views::View::viewpointSatisfactions&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676743646180_329406_1015" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(ViewDefinition) or
+ owningType.oclIsKindOf(ViewUsage)) implies
+    specializesFromLibrary('Views::View::viewpointSatisfactions')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1596649633867_655191_3417" general="_19_0_2_12e503d9_1582991078230_41497_1143"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596649684798_569222_3524" name="viewpointDefinition" visibility="public" type="_19_0_2_12e503d9_1596649640349_746765_3429" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1583000408905_769743_1223" association="_19_0_2_12e503d9_1596649684798_564931_3523">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596747674518_327804_7076" annotatedElement="_19_0_2_12e503d9_1596649684798_569222_3524">
+            <body>&lt;p>The &lt;code>ViewpointDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>ViewpointUsage&lt;code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596649692365_775584_3546" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596649692366_92259_3547" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617117200628_940407_3323" name="viewpointStakeholder" visibility="public" type="_18_5_3_12e503d9_1565471239590_312157_20701" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1617117200627_955146_3322">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617118019471_664793_3500" annotatedElement="_19_0_4_12e503d9_1617117200628_940407_3323">
+            <body>&lt;p>The &lt;code>PartUsages&lt;/code> that identify the stakeholders with concerns framed by this &lt;code>ViewpointUsage&lt;/code>, which are the owned and inherited &lt;code>stakeholderParameters&lt;/code> of the &lt;code>framedConcerns&lt;/code> of this &lt;code>ViewpointUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617117451915_165174_3339" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617117451922_479399_3340" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596644438889_305535_733" name="A_viewDefinition_definedView" visibility="public" memberEnd="_19_0_2_12e503d9_1596644438889_580287_734 _19_0_2_12e503d9_1596644438889_267970_735">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596644438889_267970_735" name="definedView" visibility="public" type="_19_0_2_12e503d9_1596644366280_485907_701" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591475180488_240858_122" association="_19_0_2_12e503d9_1596644438889_305535_733">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596745733775_894351_7048" annotatedElement="_19_0_2_12e503d9_1596644438889_267970_735">
+            <body>&lt;p>The ViewUsages that have a certain &lt;code>ViewDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596644519596_172916_769" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596644519597_650697_770" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596649684798_564931_3523" name="A_viewpointDefinition_definedViewpoint" visibility="public" memberEnd="_19_0_2_12e503d9_1596649684798_569222_3524 _19_0_2_12e503d9_1596649684798_776069_3525">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596649684798_776069_3525" name="definedViewpoint" visibility="public" type="_19_0_2_59601fc_1583087291401_74297_590" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000408905_309783_1224" association="_19_0_2_12e503d9_1596649684798_564931_3523">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596649741573_695993_3584" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596649741573_249829_3585" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_59601fc_1583087286915_926479_556" name="ViewDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1596743967552_733721_7039" annotatedElement="_19_0_2_59601fc_1583087286915_926479_556">
+          <body>&lt;p>A &lt;code>ViewDefinition&lt;/code> is a &lt;code>PartDefinition&lt;/code> that specifies how a view artifact is constructed to satisfy a &lt;code>viewpoint&lt;/code>. It specifies a &lt;code>viewConditions&lt;/code> to define the model content to be presented and a &lt;code>viewRendering&lt;/code> to define how the model content is presented.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676723980083_542435_567" name="deriveViewDefinitionView" visibility="public" constrainedElement="_19_0_2_59601fc_1583087286915_926479_556">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676724052597_849628_569" annotatedElement="_19_0_4_12e503d9_1676723980083_542435_567">
+            <body>&lt;p>The &lt;code>views&lt;/code> of a &lt;code>ViewDefinition&lt;/code> are all its &lt;code>usages&lt;/code> that are &lt;code>ViewUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676723980095_186383_568" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>view = usage->selectByKind(ViewUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676724062119_264025_570" name="deriveViewDefinitionSatisfiedViewpoint" visibility="public" constrainedElement="_19_0_2_59601fc_1583087286915_926479_556">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676724454263_69532_574" annotatedElement="_19_0_4_12e503d9_1676724062119_264025_570">
+            <body>&lt;p>The &lt;code>satisfiedViewpoints&lt;/code> of a &lt;code>ViewDefinition&lt;/code> are its &lt;code>ownedRequirements&lt;/code> that are composite &lt;code>ViewpointUsages&lt;/code>. </body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676724062136_430157_571" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>satisfiedViewpoint = ownedRequirement->
+    selectByKind(ViewpointUsage)->
+    select(isComposite)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676726303035_830998_625" name="deriveViewDefinitionViewRendering" visibility="public" constrainedElement="_19_0_2_59601fc_1583087286915_926479_556">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676726514198_101415_627" annotatedElement="_19_0_4_12e503d9_1676726303035_830998_625">
+            <body>&lt;p>The &lt;code>viewRendering&lt;/code> of a &lt;code>ViewDefinition&lt;/code> is the &lt;code>referencedRendering&lt;/code> of its owned &lt;code>ViewRenderingMembership&lt;code>, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676726303053_627726_626" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>viewRendering =
+    let renderings: OrderedSet(ViewRenderingMembership) =
+        featureMembership->selectByKind(ViewRenderingMembership) in
+    if renderings->isEmpty() then null
+    else renderings->first().referencedRendering
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676726519910_379002_628" name="deriveViewDefinitionViewCondition" visibility="public" constrainedElement="_19_0_2_59601fc_1583087286915_926479_556">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676726665268_458294_630" annotatedElement="_19_0_4_12e503d9_1676726519910_379002_628">
+            <body>&lt;p>The &lt;code>viewConditions&lt;/code> of a &lt;code>ViewDefinition&lt;/code> are the &lt;code>conditions&lt;/code> of its owned &lt;code>ElementFilterMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676726519920_627008_629" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>viewCondition = ownedMembership->
+    selectByKind(ElementFilterMembership).
+    condition</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676727112772_994685_631" name="validateViewDefinitionOnlyOneViewRendering" visibility="public" constrainedElement="_19_0_2_59601fc_1583087286915_926479_556">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676957801907_51493_69354" annotatedElement="_19_0_4_12e503d9_1676727112772_994685_631">
+            <body>&lt;p>A &lt;code>ViewDefinition&lt;/code> must have at most one &lt;code>ViewRenderingMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676727112795_789232_632" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>featureMembership->
+    selectByKind(ViewRenderingMembership)->
+    size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676743145896_517329_1003" name="checkViewDefinitionSpecialization" visibility="public" constrainedElement="_19_0_2_59601fc_1583087286915_926479_556">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676743207367_622464_1005" annotatedElement="_19_0_4_12e503d9_1676743145896_517329_1003">
+            <body>&lt;/p>A &lt;code>ViewDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>ViewDefinition&lt;/code> &lt;code>&lt;em>Views::View&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676743145908_952445_1004" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Views::View')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1596644362803_325711_699" general="_18_5_3_12e503d9_1565469626440_455154_19856"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596644452170_21813_753" name="view" visibility="public" type="_19_0_2_12e503d9_1596644366280_485907_701" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565498571495_48981_27786" association="_19_0_2_12e503d9_1596644452170_651371_752">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596744550694_762275_7044" annotatedElement="_19_0_2_12e503d9_1596644452170_21813_753">
+            <body>&lt;p>The &lt;code>usages&lt;/code> of this &lt;code>ViewDefinition&lt;/code> that are &lt;code>ViewUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596644461781_630465_763" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596644461781_287477_764" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596645596183_374903_1209" name="satisfiedViewpoint" visibility="public" type="_19_0_2_59601fc_1583087291401_74297_590" isOrdered="true" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1583000559760_444344_1273" association="_19_0_2_12e503d9_1596645596182_790331_1208">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596745712484_270767_7047" annotatedElement="_19_0_2_12e503d9_1596645596183_374903_1209">
+            <body>&lt;p>The composite &lt;code>ownedRequirements&lt;/code> of this &lt;code>ViewDefinition&lt;/code> that are &lt;code>ViewpointUsages&lt;/code> for viewpoints satisfied by the &lt;code>ViewDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596645626066_404846_1233" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596645626066_957934_1234" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596657187664_758418_4914" name="viewRendering" visibility="public" type="_19_0_2_12e503d9_1596657138882_432286_4810" isDerived="true" association="_19_0_2_12e503d9_1596657187664_421111_4913">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596746114029_117617_7053" annotatedElement="_19_0_2_12e503d9_1596657187664_758418_4914">
+            <body>&lt;p>The &lt;code>RenderingUsage&lt;/code> to be used to render views defined by this &lt;code>ViewDefinition&lt;/code>, which is the &lt;code>referencedRendering&lt;/code> of the &lt;code>ViewRenderingMembership&lt;/code> of the &lt;code>ViewDefinition&lt;/code>.&lt;p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596657199809_874977_4942" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596657199810_498748_4943" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1606938929077_183245_4796" name="viewCondition" visibility="public" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1606938929070_188272_4795">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606939574655_157847_5134" annotatedElement="_19_0_4_12e503d9_1606938929077_183245_4796">
+            <body>&lt;p>The &lt;code>Expressions&lt;/code> related to this &lt;code>ViewDefinition&lt;/code> by &lt;code>ElementFilterMemberships&lt;/code>, which specify conditions on &lt;code>Elements&lt;/code> to be rendered in a view.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651686_908654_42163"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606938958809_520848_4819" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606938958815_423774_4820" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674979_259543_43268"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1573075516960_794934_94" name="Expose" visibility="public" isAbstract="true">
+        <ownedComment xmi:id="_19_0_2_59601fc_1586212684281_887756_423" annotatedElement="_19_0_2_12e503d9_1573075516960_794934_94">
+          <body>&lt;p>An &lt;code>Expose&lt;/code> is an &lt;code>Import&lt;/code> of &lt;code>Memberships&lt;/code> into a &lt;code>ViewUsage&lt;/code> that provide the &lt;code>Elements&lt;/code> to be included in a view. Visibility is always ignored for an &lt;code>Expose&lt;/code> (i.e., &lt;code>isImportAll = true&lt;/code>).&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1622578781544_321946_117" name="validateExposeIsImportAll" visibility="public" constrainedElement="_19_0_2_12e503d9_1573075516960_794934_94">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1622578853949_904338_125" annotatedElement="_19_0_4_12e503d9_1622578781544_321946_117">
+            <body>&lt;p>An &lt;code>Expose&lt;/code> always imports all &lt;code>Elements&lt;/code>, regardless of visibility.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1622578781545_515255_118" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isImportAll</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676723267771_649167_531" name="validateExposeOwningNamespace" visibility="public" constrainedElement="_19_0_2_12e503d9_1573075516960_794934_94">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676723340188_764051_533" annotatedElement="_19_0_4_12e503d9_1676723267771_649167_531">
+            <body>&lt;p>The &lt;code>importOwningNamespace&lt;/code> of an &lt;code>Expose&lt;/code> must be a &lt;code>ViewUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676723267782_975883_532" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>importOwningNamespace.oclIsType(ViewUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1720469232327_348594_1144" name="validateExposeVisibility" visibility="public" constrainedElement="_19_0_2_12e503d9_1573075516960_794934_94">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720469282417_776259_1146" annotatedElement="_2022x_2_12e503d9_1720469232327_348594_1144">
+            <body>&lt;p>An &lt;code>Expose&lt;/code> always has &lt;code>protected&lt;/code> visibility.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1720469232327_691812_1145" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>visibility = VisibilityKind::protected</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1573075564133_26950_121">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651693_673132_42174"/>
+        </generalization>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1720469034555_222060_1140" name="visibility" visibility="public">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1720469150619_172064_1143" annotatedElement="_2022x_2_12e503d9_1720469034555_222060_1140">
+            <body>&lt;p>An &lt;code>Expose&lt;/code> always has &lt;code>protected&lt;/code> visibility.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Enumeration" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651691_865992_42172"/>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_2022x_2_12e503d9_1720469089902_528664_1142" name="" visibility="public">
+            <instance xmi:type="uml:EnumerationLiteral" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674975_217055_43252"/>
+          </defaultValue>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674976_798509_43257"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1622578615027_762161_80" name="isImportAll" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1622578866909_456536_126" annotatedElement="_19_0_4_12e503d9_1622578615027_762161_80">
+            <body>&lt;p>An &lt;code>Expose&lt;/code> always imports all &lt;code>Elements&lt;/code>, regardless of visibility (&lt;code>isImportAll = true&lt;/code>).&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1622578628075_601553_82" name="" visibility="public" value="true"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_19_0_4_12e503d9_1622577942205_869984_64"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596741367270_495988_6372" name="A_rendering_featuringRenderingDefinition" visibility="public" memberEnd="_19_0_2_12e503d9_1596741367270_249607_6373 _19_0_2_12e503d9_1596741367271_66048_6374">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596741367271_66048_6374" name="featuringRenderingDefinition" visibility="public" type="_19_0_2_12e503d9_1596657122569_397556_4766" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565498571495_18876_27787" association="_19_0_2_12e503d9_1596741367270_495988_6372">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596747995210_818868_7086" annotatedElement="_19_0_2_12e503d9_1596741367271_66048_6374">
+            <body>&lt;p>The RenderingDefinitions that feature a certain &lt;code>rendering&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596741396296_214633_6407" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596741396297_792442_6408" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1596657138882_432286_4810" name="RenderingUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1596747646067_167753_7073" annotatedElement="_19_0_2_12e503d9_1596657138882_432286_4810">
+          <body>&lt;p>A &lt;code>RenderingUsage&lt;/code> is the usage of a &lt;code>RenderingDefinition&lt;/code> to specify the rendering of a specific model view to produce a physical view artifact.&lt;/p>
+
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676742092795_70664_994" name="checkRenderingUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1596657138882_432286_4810">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676742226911_54795_996" annotatedElement="_19_0_4_12e503d9_1676742092795_70664_994">
+            <body>&lt;p>A &lt;code>RenderingUsage&lt;/code> must directly or indirectly specialize the base &lt;code>RenderingUsage&lt;/code> &lt;code>&lt;em>Views::renderings&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676742092804_665714_995" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Views::renderings')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676742292687_809417_997" name="checkRenderingUsageSubrenderingSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1596657138882_432286_4810">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676742611167_546238_999" annotatedElement="_19_0_4_12e503d9_1676742292687_809417_997">
+            <body>&lt;p>A &lt;code>RenderingUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>RenderingDefinition&lt;/code> or &lt;code>RenderingUsage&lt;/code> must directly or indirectly specialize the &lt;code>RenderingUsage&lt;/code> &lt;code>&lt;em>Views::Rendering::subrenderings&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676742292700_845795_998" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(RenderingDefinition) or
+ owningType.oclIsKindOf(RenderingUsage)) implies
+    specializesFromLibrary('Views::Rendering::subrenderings')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676742671271_876751_1000" name="checkRenderingUsageRedefinition" visibility="public" constrainedElement="_19_0_2_12e503d9_1596657138882_432286_4810">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676743112769_534415_1002" annotatedElement="_19_0_4_12e503d9_1676742671271_876751_1000">
+            <body>&lt;p>A &lt;code>RenderingUsage&lt;/code> whose &lt;code>owningFeatureMembership&lt;/code> is a &lt;code>ViewRenderingMembership&lt;/code> must redefine the &lt;code>RenderingUsage&lt;/code> &lt;code>&lt;em>Views::View::viewRendering&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676742671277_578030_1001" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningFeatureMembership &lt;> null and
+owningFeatureMembership.oclIsKindOf(ViewRenderingMembership) implies
+    redefinesFromLibrary('Views::View::viewRendering')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1596741274669_97549_6245" general="_18_5_3_12e503d9_1565471239590_312157_20701"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596741320785_268295_6306" name="renderingDefinition" visibility="public" type="_19_0_2_12e503d9_1596657122569_397556_4766" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1591475180488_929065_121" association="_19_0_2_12e503d9_1596741320784_361720_6305">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596747907202_843036_7083" annotatedElement="_19_0_2_12e503d9_1596741320785_268295_6306">
+            <body>&lt;p>The &lt;code>RenderingDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>RenderingUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596741357643_87751_6354" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596741357643_619914_6355" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1606938933666_172300_4808" name="A_viewCondition_owningView" visibility="public" memberEnd="_19_0_4_12e503d9_1606938933668_437943_4809 _19_0_4_12e503d9_1606938933669_45828_4810">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1606938933669_45828_4810" name="owningView" visibility="public" type="_19_0_2_12e503d9_1596644366280_485907_701" isDerived="true" association="_19_0_4_12e503d9_1606938933666_172300_4808">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606939661241_296079_5137" annotatedElement="_19_0_4_12e503d9_1606938933669_45828_4810">
+            <body>&lt;p>The ViewUsage that owns a certain &lt;code>viewCondition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606939068861_390932_4833" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606939068862_189997_4834" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1606938929070_188272_4795" name="A_viewCondition_owningViewDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1606938929077_183245_4796 _19_0_4_12e503d9_1606938929081_188229_4797">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1606938929081_188229_4797" name="owningViewDefinition" visibility="public" type="_19_0_2_59601fc_1583087286915_926479_556" isDerived="true" association="_19_0_4_12e503d9_1606938929070_188272_4795">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606939634726_259299_5136" annotatedElement="_19_0_4_12e503d9_1606938929081_188229_4797">
+            <body>&lt;p>The ViewDefinition that owns a certain &lt;code>viewCondition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606939072574_931965_4837" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606939072574_298192_4838" name="" visibility="public" value="1"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674965_592215_43200"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617117194002_842455_3309" name="A_viewpointStakeholder_viewpointDefinitionForStakeholder" visibility="public" memberEnd="_19_0_4_12e503d9_1617117194003_518610_3310 _19_0_4_12e503d9_1617117194003_351265_3311">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617117194003_351265_3311" name="viewpointDefinitionForStakeholder" visibility="public" type="_19_0_2_12e503d9_1596649640349_746765_3429" isDerived="true" association="_19_0_4_12e503d9_1617117194002_842455_3309">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617118046976_199777_3501" annotatedElement="_19_0_4_12e503d9_1617117194003_351265_3311">
+            <body>&lt;p>The ViewpointDefinition that has a certain &lt;code>viewpointStakeholder&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617117490189_558026_3345" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617117490190_917377_3346" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617134244546_748192_5999" name="A_ownedRendering_viewRenderingMembership" visibility="public" memberEnd="_19_0_4_12e503d9_1617134244546_130200_6000 _19_0_4_12e503d9_1617134244546_897359_6001">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617134244546_897359_6001" name="viewRenderingMembership" visibility="public" type="_19_0_4_12e503d9_1617134177967_461389_5877" isDerived="true" association="_19_0_4_12e503d9_1617134244546_748192_5999">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617134289947_277422_6062" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617134289947_498480_6063" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1617134177967_461389_5877" name="ViewRenderingMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1617134418983_597295_6165" annotatedElement="_19_0_4_12e503d9_1617134177967_461389_5877">
+          <body>&lt;p>A &lt;code>ViewRenderingMembership&lt;/code> is a &lt;coed>FeatureMembership&lt;/code> that identifies the &lt;code>viewRendering&lt;/code> of a &lt;code>ViewDefinition&lt;/code> or &lt;code>ViewUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676728293373_598548_700" name="deriveVewRenderingMembershipReferencedRendering" visibility="public" constrainedElement="_19_0_4_12e503d9_1617134177967_461389_5877">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676728573043_204674_702" annotatedElement="_19_0_4_12e503d9_1676728293373_598548_700">
+            <body>&lt;p>The &lt;code>referencedRendering&lt;/code> of a &lt;code>ViewRenderingMembership&lt;/code> is the the &lt;code>featureTarget&lt;/code> of the &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> (which must be a &lt;code>RenderingUsage&lt;/code>) of the &lt;code>ownedRendering&lt;/code>, if there is one, and, otherwise, the &lt;code>ownedRendering&lt;/code> itself.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676728293382_277208_701" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referencedRendering =
+    let referencedFeature : Feature = 
+        ownedRendering.referencedFeatureTarget() in
+    if referencedFeature = null then ownedRendering
+    else if referencedFeature.oclIsKindOf(RenderingUsage) then
+        refrencedFeature.oclAsType(RenderingUsage)
+    else null
+    endif endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676728591873_513231_703" name="validateViewRenderingMembershipOwningType" visibility="public" constrainedElement="_19_0_4_12e503d9_1617134177967_461389_5877">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676728678427_651448_705" annotatedElement="_19_0_4_12e503d9_1676728591873_513231_703">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>ViewRenderingMembership&lt;/code> must be a &lt;code>ViewDefinition&lt;/code> or a &lt;code>ViewUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676728591891_537328_704" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsKindOf(ViewDefinition) or
+owningType.oclIsKindOf(ViewUsage)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1617134201100_91357_5928">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160651715_740575_42237"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617134244546_130200_6000" name="ownedRendering" visibility="public" type="_19_0_2_12e503d9_1596657138882_432286_4810" aggregation="composite" isDerived="true" association="_19_0_4_12e503d9_1617134244546_748192_5999">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676728288089_851869_699" annotatedElement="_19_0_4_12e503d9_1617134244546_130200_6000">
+            <body>&lt;p>The owned &lt;code>RenderingUsage&lt;/code> that is either itself the &lt;code>referencedRendering&lt;/code> or subsets the &lt;code>referencedRendering&lt;/code>.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617134265308_965839_6034" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617134265310_787832_6035" name="" visibility="public" value="1"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1533160674993_898044_43344"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1617134300857_286392_6081" name="referencedRendering" visibility="public" type="_19_0_2_12e503d9_1596657138882_432286_4810" isDerived="true" association="_19_0_4_12e503d9_1617134300857_6783_6080">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617135621257_656619_6169" annotatedElement="_19_0_4_12e503d9_1617134300857_286392_6081">
+            <body>&lt;p> The &lt;code>RenderingUsage&lt;/code> that is referenced through this &lt;code>ViewRenderingMembership&lt;/code>. It is the &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> for the &lt;code>ownedRendering&lt;/code>, if there is one, and, otherwise, the &lt;code>ownedRendering&lt;/code> itself.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617134326677_879623_6113" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617134326677_393363_6114" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617117200627_955146_3322" name="A_viewpointStakeholder_viewpointForStakeholder" visibility="public" memberEnd="_19_0_4_12e503d9_1617117200628_940407_3323 _19_0_4_12e503d9_1617117200629_426661_3324">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617117200629_426661_3324" name="viewpointForStakeholder" visibility="public" type="_19_0_2_59601fc_1583087291401_74297_590" isDerived="true" association="_19_0_4_12e503d9_1617117200627_955146_3322">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1617118057877_371977_3502" annotatedElement="_19_0_4_12e503d9_1617117200629_426661_3324">
+            <body>&lt;p>The ViewpointUsage that has a certain &lt;code>viewpointStakeholder&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617117523428_735301_3351" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617117523431_67446_3352" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1617134300857_6783_6080" name="A_referencedRendering_referencingRenderingMembership" visibility="public" memberEnd="_19_0_4_12e503d9_1617134300857_286392_6081 _19_0_4_12e503d9_1617134300858_808531_6082">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1617134300858_808531_6082" name="referencingRenderingMembership" visibility="public" type="_19_0_4_12e503d9_1617134177967_461389_5877" isDerived="true" association="_19_0_4_12e503d9_1617134300857_6783_6080">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1617134353570_58564_6143" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1617134353577_456832_6144" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1668805386737_851862_212" name="NamespaceExpose" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1668806138964_278008_644" annotatedElement="_19_0_4_12e503d9_1668805386737_851862_212">
+          <body>&lt;p>A &lt;code>NamespaceExpose&lt;/code> is an &lt;code>Expose&lt;/code> &lt;code>Relationship&lt;/code> that exposes the &lt;code>Memberships&lt;/code> of a specific &lt;code>importedNamespace&lt;/code> and, if &lt;code>isRecursive = true&lt;/code>, additional &lt;code>Memberships&lt;/code> recursively.&lt;/p></body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_12e503d9_1668805401307_863059_253" general="_19_0_2_12e503d9_1573075516960_794934_94"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1668805499219_54986_380">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_12e503d9_1668208114894_902739_132"/>
+        </generalization>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1668805350620_499865_159" name="MembershipExpose" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1668806094791_484488_643" annotatedElement="_19_0_4_12e503d9_1668805350620_499865_159">
+          <body>&lt;p>A &lt;code>MembershipExpose&lt;/code> is an &lt;code>Expose&lt;/code> &lt;code.Relationship&lt;/code> that exposes a specific &lt;code>importedMembership&lt;/code> and, if &lt;code>isRecursive = true&lt;/code>, additional &lt;code>Memberships&lt;/code> recursively.&lt;/p></body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_12e503d9_1668805450383_959759_327">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_12e503d9_1668208086726_425885_108"/>
+        </generalization>
+        <generalization xmi:id="_19_0_4_12e503d9_1668805376034_811381_202" general="_19_0_2_12e503d9_1573075516960_794934_94"/>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_2_12e503d9_1596821267055_541754_9785" name="VerificationCases" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1596821335655_850182_10186" name="VerificationCaseDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1596821888408_450355_10746" annotatedElement="_19_0_2_12e503d9_1596821335655_850182_10186">
+          <body>&lt;p>A &lt;code>VerificationCaseDefinition&lt;/code> is a &lt;code>CaseDefinition&lt;/code> for the purpose of verification of the subject of the case against its requirements.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676721587035_609560_495" name="deriveVerificationCaseDefinitionVerifiedRequirement" visibility="public" constrainedElement="_19_0_2_12e503d9_1596821335655_850182_10186">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676721755671_699765_503" annotatedElement="_19_0_4_12e503d9_1676721587035_609560_495">
+            <body>&lt;p>The &lt;code>verifiedRequirements&lt;/code> of a &lt;code>VerificationCaseDefinition&lt;/code> are the &lt;code>verifiedRequirements&lt;/code> of its &lt;code>RequirementVerificationMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676721587055_972168_496" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>verifiedRequirement =
+    if objectiveRequirement = null then OrderedSet{}
+    else 
+        objectiveRequirement.featureMembership->
+            selectByKind(RequirementVerificationMembership).
+            verifiedRequirement->asOrderedSet()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676739726615_264232_945" name="checkVerificationCaseSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1596821335655_850182_10186">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676739793233_748724_947" annotatedElement="_19_0_4_12e503d9_1676739726615_264232_945">
+            <body>&lt;p>A &lt;code>VerificationCaseDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>VerificationCaseDefinition&lt;/code> &lt;em>&lt;code>VerificationCases::VerificationCase&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676739726626_455222_946" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('VerificationCases::VerificationCase')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1596821381139_42843_10269" general="_19_0_2_59601fc_1590256070522_658678_81"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1603922371399_701592_338" name="verifiedRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1603922371392_146547_337">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603922665631_147688_395" annotatedElement="_19_0_4_12e503d9_1603922371399_701592_338">
+            <body>&lt;p>The &lt;code>RequirementUsages&lt;/code> verified by this &lt;code>VerificationCaseDefinition&lt;/code>, which are the &lt;code>verifiedRequirements&lt;/code> of all &lt;code>RequirementVerificationMemberships&lt;/code> of the &lt;code>objectiveRequirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603922390030_873725_348" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603922390031_625640_349" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_2_12e503d9_1596821408365_865624_10315" name="A_verificationCaseDefinition_definedVerificationCase" visibility="public" memberEnd="_19_0_2_12e503d9_1596821408366_748769_10316 _19_0_2_12e503d9_1596821408366_411884_10317">
+        <ownedEnd xmi:id="_19_0_2_12e503d9_1596821408366_411884_10317" name="definedVerificationCase" visibility="public" type="_19_0_2_12e503d9_1596821359347_71332_10236" isDerived="true" subsettedProperty="_19_0_2_59601fc_1590257465224_154720_511" association="_19_0_2_12e503d9_1596821408365_865624_10315">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596822035946_34300_10759" annotatedElement="_19_0_2_12e503d9_1596821408366_411884_10317">
+            <body>&lt;p>The VerificationUsages that are defined by a certain &lt;code>verificationCaseDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596821444465_246564_10358" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596821444466_480169_10359" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_2_12e503d9_1596821359347_71332_10236" name="VerificationCaseUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_2_12e503d9_1596821971244_989002_10747" annotatedElement="_19_0_2_12e503d9_1596821359347_71332_10236">
+          <body>&lt;p>A &lt;code>VerificationCaseUsage&lt;/code> is a &lt;/code>Usage&lt;/code> of a &lt;code>VerificationCaseDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676721917975_914312_504" name="deriveVerificationCaseUsageVerifiedRequirement" visibility="public" constrainedElement="_19_0_2_12e503d9_1596821359347_71332_10236">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676721918035_841316_506" annotatedElement="_19_0_4_12e503d9_1676721917975_914312_504">
+            <body>&lt;p>The &lt;code>verifiedRequirements&lt;/code> of a &lt;code>VerificationCaseUsage&lt;/code> are the &lt;code>verifiedRequirements&lt;/code> of its &lt;code>RequirementVerificationMemberships&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676721918014_569023_505" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>verifiedRequirement =
+    if objectiveRequirement = null then OrderedSet{}
+    else 
+        objectiveRequirement.featureMembership->
+            selectByKind(RequirementVerificationMembership).
+            verifiedRequirement->asOrderedSet()
+    endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676739809597_328426_948" name="checkVerificationCaseUsageSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1596821359347_71332_10236">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676739943443_253474_950" annotatedElement="_19_0_4_12e503d9_1676739809597_328426_948">
+            <body>&lt;p>A &lt;code>VerificationCaseUsage&lt;/code> must subset, directly or indirectly, the base &lt;code>VerificationCaseUsage&lt;/code> &lt;code>&lt;em>VerificationCases::verificationCases&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676739809607_69453_949" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('VerificationCases::verificationCases')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676739949960_909664_951" name="checkVerificationCaseUsageSubVerificationCaseSpecialization" visibility="public" constrainedElement="_19_0_2_12e503d9_1596821359347_71332_10236">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676740108908_580330_953" annotatedElement="_19_0_4_12e503d9_1676739949960_909664_951">
+            <body> If it is composite and owned by a &lt;code>VerificationCaseDefinition&lt;/code> or &lt;code>VerificationCaseUsage&lt;/code>, then it must specialize &lt;code>VerificationCaseUsage&lt;/code> &lt;code>&lt;em>VerificationCases::VerificationCase::subVerificationCases&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676739949969_807565_952" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+    (owningType.oclIsKindOf(VerificationCaseDefinition) or
+     owningType.oclIsKindOf(VerificationCaseUsage)) implies 
+    specializesFromLibrary('VerificationCases::VerificationCase::subVerificationCases')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_2_12e503d9_1596821384738_913765_10296" general="_19_0_2_59601fc_1590256077623_424527_107"/>
+        <ownedAttribute xmi:id="_19_0_2_12e503d9_1596821408366_748769_10316" name="verificationCaseDefinition" visibility="public" type="_19_0_2_12e503d9_1596821335655_850182_10186" isDerived="true" subsettedProperty="_19_0_2_59601fc_1590257465225_855208_512" association="_19_0_2_12e503d9_1596821408365_865624_10315">
+          <ownedComment xmi:id="_19_0_2_12e503d9_1596822008905_555390_10758" annotatedElement="_19_0_2_12e503d9_1596821408366_748769_10316">
+            <body>&lt;p>The &lt;code>VerificationCase&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>VerificationCaseUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_2_12e503d9_1596821423015_283721_10340" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_2_12e503d9_1596821423017_990071_10341" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1603922396599_812331_357" name="verifiedRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1603922396592_290534_356">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603922689012_206790_396" annotatedElement="_19_0_4_12e503d9_1603922396599_812331_357">
+            <body>&lt;p>The &lt;code>RequirementUsages&lt;/code> verified by this &lt;code>VerificationCaseUsage&lt;/code>, which are the &lt;code>verifiedRequirements&lt;/code> of all &lt;code>RequirementVerificationMemberships&lt;/code> of the &lt;code>objectiveRequirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603922422535_434307_367" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603922422542_483872_368" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1603921329650_646450_146" name="A_ownedRequirement_requirementVerificationMembership" visibility="public" memberEnd="_19_0_4_12e503d9_1603921329650_612380_147 _19_0_4_12e503d9_1603921329651_708262_148">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1603921329651_708262_148" name="requirementVerificationMembership" visibility="public" type="_19_0_4_12e503d9_1603921138449_428307_72" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1584048366951_120409_427" association="_19_0_4_12e503d9_1603921329650_646450_146">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603922136497_553031_330" annotatedElement="_19_0_4_12e503d9_1603921329651_708262_148">
+            <body>&lt;p>The RequirementVerificationMembership that owns a certain RequirementUsage as its &lt;code>ownedRequirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603921376171_299387_163" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603921376171_122190_164" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1603921138449_428307_72" name="RequirementVerificationMembership" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1603921679217_759130_279" annotatedElement="_19_0_4_12e503d9_1603921138449_428307_72">
+          <body>&lt;p>A &lt;code>RequirementVerificationMembership&lt;/code> is a &lt;code>RequirementConstraintMembership &lt;/code> used in the objective of a &lt;code>VerificationCase&lt;/code> to identify a &lt;code>RequirementUsage&lt;/code> that is verified by the &lt;code>VerificationCase&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676721326265_602870_492" name="validateRequirementVerificationMembershipKind" visibility="public" constrainedElement="_19_0_4_12e503d9_1603921138449_428307_72">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676721409722_588452_494" annotatedElement="_19_0_4_12e503d9_1676721326265_602870_492">
+            <body>&lt;p>A &lt;code>RequirementVerificationMembership&lt;/code> must have &lt;code>kind = requirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676721326286_984145_493" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>kind = RequirementConstraintKind::requirement</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676740688226_846575_957" name="validateRequirementVerificationMembershipOwningType" visibility="public" constrainedElement="_19_0_4_12e503d9_1603921138449_428307_72">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676740895963_687460_959" annotatedElement="_19_0_4_12e503d9_1676740688226_846575_957">
+            <body>&lt;p>The &lt;code>owningType&lt;/code> of a &lt;code>RequirementVerificationMembership&lt;/code> must a &lt;code>RequirementUsage&lt;/code> that is owned by an &lt;code>ObjectiveMembership&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676740688242_630426_958" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType.oclIsKindOf(RequirementUsage) and
+owningType.owningFeatureMembership &lt;> null and
+owningType.owningFeatureMembership.oclIsKindOf(ObjectiveMembership)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1603921159690_395808_97" general="_19_0_2_12e503d9_1584048032876_657748_336"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1603921329650_612380_147" name="ownedRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" aggregation="composite" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1584048366950_985767_426" association="_19_0_4_12e503d9_1603921329650_646450_146">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603922049665_455849_329" annotatedElement="_19_0_4_12e503d9_1603921329650_612380_147">
+            <body>&lt;p>The owned &lt;code>RequirementUsage&lt;/code> that acts as the &lt;code>ownedConstraint&lt;/code> for this &lt;code>RequirementVerificationMembership&lt;/code>. This will either be the &lt;code>verifiedRequirement&lt;/code>, or it will subset the &lt;code>verifiedRequirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603921365809_580785_157" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603921365810_188933_158" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1603921465292_637146_187" name="kind" visibility="public" type="_19_0_2_12e503d9_1584048075177_881751_365" redefinedProperty="_19_0_2_12e503d9_1584048161309_821854_390">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603923251828_172370_423" annotatedElement="_19_0_4_12e503d9_1603921465292_637146_187">
+            <body>&lt;p>The &lt;code>kind&lt;/code> of a &lt;code>RequirementVerificationMembership&lt;/code> must be &lt;code>requirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_19_0_4_12e503d9_1603921488979_43343_191" name="" visibility="public" instance="_19_0_2_12e503d9_1584048139603_343065_388"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1603921870169_98378_309" name="verifiedRequirement" visibility="public" type="_19_0_2_12e503d9_1582991078230_41497_1143" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1617118807597_77864_3544" association="_19_0_4_12e503d9_1603921870169_194157_308">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603922317639_931242_331" annotatedElement="_19_0_4_12e503d9_1603921870169_98378_309">
+            <body>&lt;p> The &lt;code>RequirementUsage&lt;/code> that is identified as being verified. It is the &lt;code>referencedConstraint&lt;/code> of the &lt;code>RequirementVerificationMembership&lt;/code> considered as a &lt;code>RequirementConstraintMembership&lt;/code>, which must be a &lt;code>RequirementUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603921900083_737141_319" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603921900084_472251_320" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1603922396592_290534_356" name="A_verifiedRequirement_verifyingCase" visibility="public" memberEnd="_19_0_4_12e503d9_1603922396599_812331_357 _19_0_4_12e503d9_1603922396600_129883_358">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1603922396600_129883_358" name="verifyingCase" visibility="public" type="_19_0_2_12e503d9_1596821359347_71332_10236" isDerived="true" association="_19_0_4_12e503d9_1603922396592_290534_356">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603923126601_524705_398" annotatedElement="_19_0_4_12e503d9_1603922396600_129883_358">
+            <body>&lt;p>The VerificationCaseUsages that verify a certain &lt;code>verifiedRequirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603922542769_428142_391" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603922542769_30295_392" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1603922371392_146547_337" name="A_verifiedRequirement_verifyingCaseDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1603922371399_701592_338 _19_0_4_12e503d9_1603922371400_562869_339">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1603922371400_562869_339" name="verifyingCaseDefinition" visibility="public" type="_19_0_2_12e503d9_1596821335655_850182_10186" association="_19_0_4_12e503d9_1603922371392_146547_337">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603923006720_981141_397" annotatedElement="_19_0_4_12e503d9_1603922371400_562869_339">
+            <body>&lt;p>The VerificationCaseDefinitions that verify a certain &lt;code>verifiedRequirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603922521428_227564_385" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603922521428_805544_386" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1603921870169_194157_308" name="A_verifiedRequirement_requirementVerification" visibility="public" memberEnd="_19_0_4_12e503d9_1603921870169_98378_309 _19_0_4_12e503d9_1603921870170_825996_310">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1603921870170_825996_310" name="requirementVerification" visibility="public" type="_19_0_4_12e503d9_1603921138449_428307_72" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1617118807597_323188_3545" association="_19_0_4_12e503d9_1603921870169_194157_308">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1603922349487_896592_332" annotatedElement="_19_0_4_12e503d9_1603921870170_825996_310">
+            <body>&lt;p>The RequirementVerificationMembership that has a certain RequirementUsage as its &lt;code>verifiedRequirement&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1603921931034_66579_325" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1603921931036_4666_326" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_4_12e503d9_1606946411509_147562_2" name="Enumerations" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1606946467364_179493_153" name="EnumerationDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1606947804181_872091_683" annotatedElement="_19_0_4_12e503d9_1606946467364_179493_153">
+          <body>&lt;p>An &lt;code>EnumerationDefinition&lt;/code> is an &lt;code>AttributeDefinition&lt;/code> all of whose instances are given by an explicit list of &lt;code>enumeratedValues&lt;/code>. This is realized by requiring that the &lt;code>EnumerationDefinition&lt;/code> have &lt;code>isVariation = true&lt;/code>, with the &lt;code>enumeratedValues&lt;/code> being its &lt;code>variants&lt;/code>.&lt;/p> </body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672351343600_446538_107" name="validateEnumerationDefinitionIsVariation" visibility="public" constrainedElement="_19_0_4_12e503d9_1606946467364_179493_153">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672351451636_884497_109" annotatedElement="_19_0_4_12e503d9_1672351343600_446538_107">
+            <body>&lt;p>An &lt;code>EnumerationDefinition&lt;/code> must be a variation.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672351343616_571448_108" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isVariation</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1606946482055_656517_178" general="_18_5_3_12e503d9_1565471213468_167708_20650"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1606946634788_959145_265" name="enumeratedValue" visibility="public" type="_19_0_4_12e503d9_1606946489455_954016_180" isOrdered="true" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1590979457191_746167_951" association="_19_0_4_12e503d9_1606946634788_22019_264">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606948153567_277981_804" annotatedElement="_19_0_4_12e503d9_1606946634788_959145_265">
+            <body>&lt;p>&lt;code>EnumerationUsages&lt;/code> of this &lt;code>EnumerationDefinition&lt;/code>that have distinct, fixed values. Each &lt;code>enumeratedValue&lt;/code> specifies one of the allowed instances of the &lt;code>EnumerationDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606946774417_959168_283" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606946774417_435440_284" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1606946783667_895456_287" name="isVariation" visibility="public" redefinedProperty="_19_0_2_12e503d9_1590978283180_265362_419">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606948030481_369182_803" annotatedElement="_19_0_4_12e503d9_1606946783667_895456_287">
+            <body>&lt;p>An EnumerationDefinition is considered semantically to be a variation whose allowed variants are its &lt;code>enumerationValues&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1606946800095_188719_289" name="" visibility="public" value="true"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1606946489455_954016_180" name="EnumerationUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1606947890236_520635_684" annotatedElement="_19_0_4_12e503d9_1606946489455_954016_180">
+          <body>&lt;p>An &lt;code>EnumerationUsage&lt;/code> is an &lt;code>AttributeUsage&lt;/code> whose &lt;code>attributeDefinition&lt;/code> is an &lt;code>EnumerationDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <generalization xmi:id="_19_0_4_12e503d9_1606946515107_446655_205" general="_18_5_3_12e503d9_1565471291545_950196_20762"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1606946962858_570633_331" name="enumerationDefinition" visibility="public" type="_19_0_4_12e503d9_1606946467364_179493_153" isDerived="true" redefinedProperty="_18_5_3_12e503d9_1565471811429_523492_20975" association="_19_0_4_12e503d9_1606946962858_849002_330">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606948232582_288620_806" annotatedElement="_19_0_4_12e503d9_1606946962858_570633_331">
+            <body>&lt;p>The single EnumerationDefinition that is the type of this EnumerationUsage.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606947246955_582229_431" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606947246955_37720_432" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1606946634788_22019_264" name="A_enumeratedValue_owningEnumerationDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1606946634788_959145_265 _19_0_4_12e503d9_1606946634788_794448_266">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1606946634788_794448_266" name="owningEnumerationDefinition" visibility="public" type="_19_0_4_12e503d9_1606946467364_179493_153" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1590979457198_529180_952" association="_19_0_4_12e503d9_1606946634788_22019_264">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606948182083_995494_805" annotatedElement="_19_0_4_12e503d9_1606946634788_794448_266">
+            <body>&lt;p>The EnumerationDefinition that owns a certain &lt;code>enumeratedValue&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606946948408_783346_322" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606946948411_876464_323" name="" visibility="public" value="1"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1606946962858_849002_330" name="A_enumerationDefinition_definedEnumeration" visibility="public" memberEnd="_19_0_4_12e503d9_1606946962858_570633_331 _19_0_4_12e503d9_1606946962859_962998_332">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1606946962859_962998_332" name="definedEnumeration" visibility="public" type="_19_0_4_12e503d9_1606946489455_954016_180" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565471811429_191039_20976" association="_19_0_4_12e503d9_1606946962858_849002_330">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1606948265156_530081_807" annotatedElement="_19_0_4_12e503d9_1606946962859_962998_332">
+            <body>&lt;p>The EnumerationUsages that are typed by a certain EnumerationDefinition.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1606947238615_450614_421" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1606947238618_140716_422" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_4_12e503d9_1611359555957_304604_14" name="Allocations" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1611430742949_776585_998" name="A_allocationDefinition_definedAllocation" visibility="public" memberEnd="_19_0_4_12e503d9_1611430742949_241425_999 _19_0_4_12e503d9_1611430742949_984073_1000">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1611430742949_984073_1000" name="definedAllocation" visibility="public" type="_19_0_4_12e503d9_1611430595314_523036_933" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1594853499657_181098_803" association="_19_0_4_12e503d9_1611430742949_776585_998">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611629944416_817518_467" annotatedElement="_19_0_4_12e503d9_1611430742949_984073_1000">
+            <body>&lt;p>The AllocationUsages that have a certain AllocationDefinition as their &lt;code>allocationDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1611430799104_311223_1015" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1611430799104_589642_1016" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1611430566467_608282_906" name="AllocationDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1611533756861_781089_430" annotatedElement="_19_0_4_12e503d9_1611430566467_608282_906">
+          <body>&lt;p>An &lt;code>AllocationDefinition&lt;/code> is a &lt;code>ConnectionDefinition&lt;/code> that specifies that some or all of the responsibility to realize the intent of the &lt;code>source&lt;/code> is allocated to the &lt;code>target&lt;/code> instances. Such allocations define mappings across the various structures and hierarchies of a system model, perhaps as a precursor to more rigorous specifications and implementations. An &lt;code>AllocationDefinition&lt;/code> can itself be refined using nested &lt;code>allocations&lt;/code> that give a finer-grained decomposition of the containing allocation mapping.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673062121734_231679_648" name="deriveAllocationDefinitionAllocation" visibility="public" constrainedElement="_19_0_4_12e503d9_1611430566467_608282_906">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673062249606_354647_650" annotatedElement="_19_0_4_12e503d9_1673062121734_231679_648">
+            <body>&lt;p> The &lt;code>allocations&lt;/code> of an &lt;code>AllocationDefinition&lt;/code> are all its &lt;code>usages&lt;/code> that are &lt;code>AllocationUsages&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673062121772_194499_649" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>allocation = usage->selectAsKind(AllocationUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673046635569_257698_624" name="checkAllocationDefinitionSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1611430566467_608282_906">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673046635605_427796_626" annotatedElement="_19_0_4_12e503d9_1673046635569_257698_624">
+            <body>&lt;p>An &lt;code>AllocationDefinition&lt;/code> must directly or indirectly specialize the &lt;code>AllocationDefinition&lt;/code> &lt;em>&lt;code>Allocations::Allocation&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673046635596_200075_625" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Allocations::Allocation')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1611430583370_837348_931" general="_19_0_2_12e503d9_1565813525877_81950_622"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1611430644481_402036_964" name="allocation" visibility="public" type="_19_0_4_12e503d9_1611430595314_523036_933" isOrdered="true" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565498571495_48981_27786" association="_19_0_4_12e503d9_1611430644479_320947_963">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611630060322_36098_494" annotatedElement="_19_0_4_12e503d9_1611430644481_402036_964">
+            <body>&lt;p>The &lt;code>AllocationUsages&lt;/code> that refine the allocation mapping defined by this &lt;code>AllocationDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1611430659126_845187_974" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1611430659131_818438_975" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1611430595314_523036_933" name="AllocationUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1611534875603_808301_431" annotatedElement="_19_0_4_12e503d9_1611430595314_523036_933">
+          <body>&lt;p>An &lt;code>AllocationUsage&lt;/code> is a usage of an &lt;code>AllocationDefinition&lt;/code> asserting the allocation of the &lt;code>source&lt;/code> feature to the &lt;code>target&lt;/code> feature.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1673046698220_494563_627" name="checkAllocationUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1611430595314_523036_933">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1673046698251_309103_629" annotatedElement="_19_0_4_12e503d9_1673046698220_494563_627">
+            <body>&lt;p>An &lt;code>AllocationUsage&lt;/code> must directly or indirectly specialize the &lt;code>AllocationUsage&lt;/code> &lt;em>&lt;code>Allocations::allocations&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1673046698245_844221_628" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Allocations::allocations')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1611430611443_506844_958" general="_19_0_2_12e503d9_1565824079403_302443_1935"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1611430742949_241425_999" name="allocationDefinition" visibility="public" type="_19_0_4_12e503d9_1611430566467_608282_906" isOrdered="true" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1594853499656_139435_802" association="_19_0_4_12e503d9_1611430742949_776585_998">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611629863599_5472_454" annotatedElement="_19_0_4_12e503d9_1611430742949_241425_999">
+            <body>&lt;p>The &lt;code>AllocationDefinitions&lt;/code> that are the types of this &lt;code>AllocationUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1611430750666_185779_1009" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1611430750667_748657_1010" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1611430644479_320947_963" name="A_allocation_featuringAllocationDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1611430644481_402036_964 _19_0_4_12e503d9_1611430644483_866911_965">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1611430644483_866911_965" name="featuringAllocationDefinition" visibility="public" type="_19_0_4_12e503d9_1611430566467_608282_906" isDerived="true" subsettedProperty="_18_5_3_12e503d9_1565498571495_18876_27787" association="_19_0_4_12e503d9_1611430644479_320947_963">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1611630109227_660700_495" annotatedElement="_19_0_4_12e503d9_1611430644483_866911_965">
+            <body>&lt;p>The AllocationDefinitions that feature a certain &lt;code>allocation&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1611430715757_892608_990" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1611430715758_909576_991" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_4_12e503d9_1618943401342_939944_44" name="Occurrences" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1618958878774_866633_7089" name="A_individualDefinition_individualUsage" visibility="public" memberEnd="_19_0_4_12e503d9_1618958878775_52798_7090 _19_0_4_12e503d9_1618958878775_345537_7091">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1618958878775_345537_7091" name="individualUsage" visibility="public" type="_19_0_4_12e503d9_1618943737195_33207_138" isDerived="true" association="_19_0_4_12e503d9_1618958878774_866633_7089">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618961061049_246813_7155" annotatedElement="_19_0_4_12e503d9_1618958878775_345537_7091">
+            <body>&lt;p>The &lt;code>OccurrenceUsage&lt;/code> that has a certain &lt;code>individualDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1618958920669_961507_7106" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1618958920669_343074_7107" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_19_0_4_12e503d9_1618959332017_453918_7117" name="PortionKind" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1618961099199_111758_7156" annotatedElement="_19_0_4_12e503d9_1618959332017_453918_7117">
+          <body>&lt;p>&lt;code>PortionKind&lt;/code> is an enumeration of the specific kinds of &lt;code>&lt;em>Occurrence&lt;/em>&lt;/code> portions that can be represented by an &lt;code>OccurrenceUsage&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedLiteral xmi:id="_19_0_4_12e503d9_1618959388090_294567_7142" name="timeslice" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618961129654_844782_7158" annotatedElement="_19_0_4_12e503d9_1618959388090_294567_7142">
+            <body>&lt;p>A time slice of an &lt;code>Occurrence&lt;/code> (a portion over time).&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:id="_19_0_4_12e503d9_1618959391986_485437_7144" name="snapshot" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618961151670_175001_7159" annotatedElement="_19_0_4_12e503d9_1618959391986_485437_7144">
+            <body>&lt;p>A snapshot of an &lt;code>Occurrence&lt;/code> (a time slice with zero duration).&lt;/p></body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1618943737195_33207_138" name="OccurrenceUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1618945741778_116685_690" annotatedElement="_19_0_4_12e503d9_1618943737195_33207_138">
+          <body>&lt;p>An &lt;code>OccurrenceUsage&lt;/code> is a &lt;code>Usage&lt;/code> whose &lt;code>types&lt;/code> are all &lt;code>Classes&lt;/code>. Nominally, if a &lt;code>type&lt;/code> is an &lt;code>OccurrenceDefinition&lt;/code>, an &lt;code>OccurrenceUsage&lt;/code> is a &lt;code>Usage&lt;/code> of that &lt;code>OccurrenceDefinition&lt;/code> within a system. However, other types of Kernel &lt;code>Classes&lt;/code> are also allowed, to permit use of &lt;code>Classes&lt;/code> from the Kernel Model Libraries.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1597202002525_622574_73711" name="deriveOccurrenceUsageIndividualDefinition" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943737195_33207_138">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1619024960017_874365_7168" annotatedElement="_19_0_4_12e503d9_1597202002525_622574_73711">
+            <body>&lt;p>The &lt;code>individualDefinition&lt;/code> of an &lt;code>OccurrenceUsage&lt;/code> is the &lt;code>occurrenceDefinition&lt;/code> that is an &lt;code>OccurrenceDefinition&lt;/code> with &lt;code>isIndividual = true&lt;/code>, if any.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1597202002525_82374_73712" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>individualDefinition =
+    let individualDefinitions : OrderedSet(OccurrenceDefinition) = 
+        occurrenceDefinition->
+            selectByKind(OccurrenceDefinition)->
+            select(isIndividual) in
+    if individualDefinitions->isEmpty() then null
+    else individualDefinitions->first() endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1619035294568_73473_7462" name="validateOccurrenceUsageIndividualUsage" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943737195_33207_138">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1619035409907_444618_7464" annotatedElement="_19_0_4_12e503d9_1619035294568_73473_7462">
+            <body>&lt;p>If an &lt;code>OccurrenceUsage&lt;/code> has &lt;code>isIndividual = true&lt;/code>, then it must have an &lt;code>individualDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1619035294594_509928_7463" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isIndividual implies individualDefinition &lt;> null</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672443798416_319169_140" name="checkOccurrenceUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943737195_33207_138">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672443830720_129485_142" annotatedElement="_19_0_4_12e503d9_1672443798416_319169_140">
+            <body>&lt;p>An &lt;code>OccurrenceUsage&lt;/code> must directly or indirectly specialize &lt;code>&lt;em>Occurrences::occurrences&lt;/em>&lt;/code> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672443798425_307880_141" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Occurrences::occurrences')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672443885699_579133_143" name="checkOccurrenceUsageSuboccurrenceSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943737195_33207_138">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672444426656_378514_145" annotatedElement="_19_0_4_12e503d9_1672443885699_579133_143">
+            <body>&lt;p>A composite &lt;code>OccurrenceUsage&lt;/code>, whose &lt;code>ownedType&lt;/code> is a &lt;code>Class&lt;/code>, another &lt;code>OccurrenceUsage&lt;/code>, or any kind of &lt;code>Feature&lt;/code> typed by a &lt;code>Class&lt;/code>, must directly or indirectly specialize &lt;em>&lt;code>Occurrences::Occurrence::suboccurrences&lt;/code>&lt;/em>.</body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672443885710_798848_144" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and
+owningType &lt;> null and
+(owningType.oclIsKindOf(Class) or
+ owningType.oclIsKindOf(OccurrenceUsage) or
+ owningType.oclIsKindOf(Feature) and
+    owningType.oclAsType(Feature).type->
+        exists(oclIsKind(Class))) implies
+    specializesFromLibrary('Occurrences::Occurrence::suboccurrences')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672443527176_977983_136" name="validateOccurrenceUsageIndividualDefinition" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943737195_33207_138">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672443641753_532541_138" annotatedElement="_19_0_4_12e503d9_1672443527176_977983_136">
+            <body>&lt;p>An &lt;code>OccurrenceUsage&lt;/code> must have at most one &lt;code>occurrenceDefinition&lt;/code> with &lt;code>isIndividual = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672443527187_936295_137" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>occurrenceDefinition->
+    selectByKind(OccurrenceDefinition)->
+    select(isIndividual).size() &lt;= 1</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739749464904_8448_131" name="checkOccurrenceUsageSnapshotSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943737195_33207_138">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739749541475_489307_133" annotatedElement="_2022x_2_12e503d9_1739749464904_8448_131">
+            <body>&lt;p>If an &lt;code>OccurrenceUsage&lt;/code> has &lt;code>portionKind = snapshot&lt;/code>, then it must directly or indirectly specialize &lt;em>&lt;code>Occurrences::Occurrence::snapshots&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739749464904_777837_132" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>portionKind = PortionKind::snapshot implies
+    specializesFromLibrary('Occurrences::Occurrence::snapshots')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739748904532_719118_128" name="checkOccurrenceUsageTimeSliceSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943737195_33207_138">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739749271707_949444_130" annotatedElement="_2022x_2_12e503d9_1739748904532_719118_128">
+            <body>&lt;p>If an &lt;code>OccurrenceUsage&lt;/code> has &lt;code>portionKind = timeslice&lt;/code>, then it must directly or indirectly specialize &lt;em>&lt;code>Occurrences::Occurrence::timeSlices&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739748904533_121524_129" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>portionKind = PortionKind::timeslice implies 
+    specializesFromLibrary('Occurrences::Occurrence::timeSlices')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739749572930_676639_134" name="validateOccurrenceUsagePortionKind" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943737195_33207_138">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739749724916_367265_136" annotatedElement="_2022x_2_12e503d9_1739749572930_676639_134">
+            <body>&lt;p>If an &lt;code>OccurrenceUsage&lt;/code> has a non-null &lt;code>portionKind&lt;/code>, then its &lt;code>owningType&lt;/code> must be an &lt;code>OccurrenceDefinition&lt;/code> or an &lt;code>OccurrenceUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739749572931_269462_135" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>portionKind &lt;> null implies
+    owningType &lt;> null and
+    (owningType.oclIsKindOf(OccurrenceDefinition) or
+     owningType.oclIsKindOf(OccurrenceUsage))</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739748247372_745526_126" name="validateOccurrenceUsageIsPortion" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943737195_33207_138">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739749781019_682769_137" annotatedElement="_2022x_2_12e503d9_1739748247372_745526_126">
+            <body>&lt;p>If an &lt;code>OccurrenceUsage&lt;/code> has a non-null &lt;code>portionKind&lt;/code>, then it must have &lt;code>isPortion = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739748247372_56483_127" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>portionKind &lt;> null implies isPortion</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1618943760705_930689_163" general="_18_5_3_12e503d9_1565469997820_598571_19982"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1618943843466_158863_236" name="occurrenceDefinition" visibility="public" isOrdered="true" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1591477641252_179221_958" association="_19_0_4_12e503d9_1618943843466_699487_235">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618945193675_746571_686" annotatedElement="_19_0_4_12e503d9_1618943843466_158863_236">
+            <body>&lt;p>The &lt;code>Classes&lt;/code> that are the types of this &lt;code>OccurrenceUsage&lt;/code>. Nominally, these are &lt;code>OccurrenceDefinitions&lt;/code>, but other kinds of kernel &lt;code>Classes&lt;/code> are also allowed, to permit use of &lt;code>Classes&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557527582956_258352_110280"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1618944218148_481941_341" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1618944218153_404102_342" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1618958878775_52798_7090" name="individualDefinition" visibility="public" type="_19_0_4_12e503d9_1618943693347_790503_111" isDerived="true" subsettedProperty="_19_0_4_12e503d9_1618943843466_158863_236" association="_19_0_4_12e503d9_1618958878774_866633_7089">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618959026678_140215_7112" annotatedElement="_19_0_4_12e503d9_1618958878775_52798_7090">
+            <body>&lt;p>The at most one &lt;code>occurrenceDefinition&lt;/code> that has &lt;code>isIndividual = true&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1618958891738_274006_7100" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1618958891738_947479_7101" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1618959865886_548379_7149" name="isIndividual" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618960899568_837916_7154" annotatedElement="_19_0_4_12e503d9_1618959865886_548379_7149">
+            <body>&lt;p>Whether this &lt;code>OccurrenceUsage&lt;/code> represents the usage of the specific individual represented by its &lt;code>individualDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1618960092393_484822_7151" name="" visibility="public"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1618959362712_182798_7138" name="portionKind" visibility="public" type="_19_0_4_12e503d9_1618959332017_453918_7117">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618959622351_421986_7148" annotatedElement="_19_0_4_12e503d9_1618959362712_182798_7138">
+            <body>&lt;p>The kind of temporal portion (time slice or snapshot) is represented by this &lt;code>OccurrenceUsage&lt;/code>. If &lt;code>portionKind&lt;/code> is not null, then the &lt;code>owningType&lt;/code> of the &lt;code>OccurrenceUsage&lt;/code> must be non-null, and the &lt;code>OccurrenceUsage&lt;/code> represents portions of the featuring instance of the &lt;code>owningType&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1618959412281_7231_7146" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1618959412281_357176_7147" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1622831790392_320401_194" name="A_eventOccurrence_referencingOccurrence" visibility="public" memberEnd="_19_0_4_12e503d9_1622831790393_676695_195 _19_0_4_12e503d9_1622831790393_898128_196">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1622831790393_898128_196" name="referencingOccurrence" visibility="public" type="_19_0_4_12e503d9_1622831611763_442921_132" isDerived="true" association="_19_0_4_12e503d9_1622831790392_320401_194">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1624032304924_548058_39938" annotatedElement="_19_0_4_12e503d9_1622831790393_898128_196">
+            <body>&lt;p>The EventOccurrenceUsages that reference a certain &lt;code>eventOccurrence&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1622831845732_244837_211" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1622831845732_83321_212" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1618943693347_790503_111" name="OccurrenceDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1618945372594_68538_689" annotatedElement="_19_0_4_12e503d9_1618943693347_790503_111">
+          <body>&lt;p>An &lt;code>OccurrenceDefinition&lt;/code> is a &lt;code>Definition&lt;/code> of a &lt;code>Class&lt;/code> of individuals that have an independent life over time and potentially an extent over space. This includes both structural things and behaviors that act on such structures. If &lt;code>isIndividual&lt;/code> is true, then the &lt;code>OccurrenceDefinition&lt;/code> is constrained to have (at most) a single instance that is the entire life of a single individual.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1739744378546_372080_68" name="checkOccurrenceDefinitionIndividualSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943693347_790503_111">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1739744533922_169754_70" annotatedElement="_2022x_2_12e503d9_1739744378546_372080_68">
+            <body>&lt;p>An &lt;code>OccurrenceDefinition&lt;/code> with &lt;code>isIndividual = true&lt;/code> must directly or indirectly specialize &lt;em>&lt;code>Occurrences::Life&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1739744378547_928701_69" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isIndividual implies specializesFromLibrary('Occurrences::Life')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672520247090_282546_267" name="checkOccurrenceDefinitionMultiplicitySpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1618943693347_790503_111">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672520441551_605496_269" annotatedElement="_19_0_4_12e503d9_1672520247090_282546_267">
+            <body>&lt;p>An &lt;code>OccurrenceDefinition&lt;/code> with &lt;code>isIndividual = true&lt;/code> must have a &lt;code>multiplicity&lt;/code> that specializes &lt;em>&lt;code>Base::zeroOrOne&lt;/code>&lt;/em> from the Kernel Semantic Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672520247100_905203_268" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isIndividual implies
+    multiplicity &lt;> null and
+    multiplicity.specializesFromLibrary('Base::zeroOrOne')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1618943732243_481263_136" general="_18_5_3_12e503d9_1565479032244_336549_22524"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1618943883719_897024_320">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_12e503d9_1557527582956_258352_110280"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1618955405499_394357_6740" name="isIndividual" visibility="public">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618957968375_615086_7023" annotatedElement="_19_0_4_12e503d9_1618955405499_394357_6740">
+            <body>&lt;p>Whether this &lt;code>OccurrenceDefinition&lt;/code> is constrained to represent at most one thing.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1618955460618_841571_6744" name="" visibility="public"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1618943843466_699487_235" name="A_occurrenceDefinition_definedOccurrence" visibility="public" memberEnd="_19_0_4_12e503d9_1618943843466_158863_236 _19_0_4_12e503d9_1618943843466_481041_237">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1618943843466_481041_237" name="definedOccurrence" visibility="public" type="_19_0_4_12e503d9_1618943737195_33207_138" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1591477641253_520897_959" association="_19_0_4_12e503d9_1618943843466_699487_235">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1618945946337_623758_703" annotatedElement="_19_0_4_12e503d9_1618943843466_481041_237">
+            <body>&lt;p>The &lt;code>OccurrenceUsages&lt;/code> being typed by a certain &lt;code>Class&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1618944413616_472904_516" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1618944413616_886704_517" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1622831611763_442921_132" name="EventOccurrenceUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1622832108036_200674_215" annotatedElement="_19_0_4_12e503d9_1622831611763_442921_132">
+          <body>&lt;p>An &lt;code>EventOccurrenceUsage&lt;/code> is an &lt;code>OccurrenceUsage&lt;/code> that represents another &lt;code>OccurrenceUsage&lt;/code> occurring as a &lt;code>&lt;em>suboccurrence&lt;/em>&lt;/code> of the containing occurrence of the &lt;code>EventOccurrenceUsage&lt;/code>. Unless it is the &lt;code>EventOccurrenceUsage&lt;/code> itself, the referenced &lt;code>OccurrenceUsage&lt;/code> is related to the &lt;code>EventOccurrenceUsage&lt;/code> by a &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationship&lt;/code>.&lt;/p>
+
+&lt;p>If the &lt;code>EventOccurrenceUsage&lt;/code> is owned by an &lt;code>OccurrenceDefinition&lt;/code> or &lt;code>OccurrenceUsage&lt;/code>, then it also subsets the &lt;em>&lt;code>timeEnclosedOccurrences&lt;/code>&lt;/em> property of the &lt;code>Class&lt;/code> &lt;em>&lt;code>Occurrence&lt;/code>&lt;/em> from the Kernel Semantic Library model &lt;em>&lt;code>Occurrences&lt;/code>&lt;/em>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1661876089319_723828_302" name="deriveEventOccurrenceUsageEventOccurrence" visibility="public" constrainedElement="_19_0_4_12e503d9_1622831611763_442921_132">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661876297792_580539_305" annotatedElement="_19_0_4_12e503d9_1661876089319_723828_302">
+            <body>&lt;p>If an &lt;code>EventOccurrenceUsage&lt;/code> has no &lt;code>ownedReferenceSubsetting&lt;/code>, then its &lt;code>eventOccurrence&lt;/code> is the &lt;code>EventOccurrenceUsage&lt;/code> itself. Otherwise, the &lt;code>eventOccurrence&lt;/code> is the &lt;code>featureTarget&lt;/code> of the &lt;code>referencedFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> (which must be an &lt;code>OccurrenceUsage&lt;/code>).&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1661876089350_964899_303" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>eventOccurrence =
+    if referencedFeatureTarget() = null then self
+    else if referencedFeatureTarget().oclIsKindOf(OccurrenceUsage) then
+        referencedFeatureTarget().oclAsType(OccurrenceUsage)
+    else null
+    endif endif</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672527033169_128736_330" name="validateEventOccurrenceUsageReference" visibility="public" constrainedElement="_19_0_4_12e503d9_1622831611763_442921_132">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672527152537_765408_332" annotatedElement="_19_0_4_12e503d9_1672527033169_128736_330">
+            <body>&lt;p>If an &lt;code>EventOccurrenceUsage&lt;/code> has an &lt;code>ownedReferenceSubsetting&lt;/code>, then the &lt;code>featureTarget&lt;/code> of the &lt;code>referencedFeature&lt;/code> must be an &lt;code>OccurrenceUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672527033172_275268_331" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referencedFeatureTarget() &lt;> null implies
+    referencedFeatureTarget().oclIsKindOf(OccurrenceUsage)</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672527200000_768883_333" name="checkEventOccurrenceUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1622831611763_442921_132">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672527497357_934376_335" annotatedElement="_19_0_4_12e503d9_1672527200000_768883_333">
+            <body>&lt;p>If an &lt;code>EventOccurrenceUsage&lt;/code> has an &lt;code>owningType&lt;/code> that is an &lt;code>OccurrenceDefinition&lt;/code> or &lt;code>OccurrenceUsage&lt;/code>, then it must directly or indirectly specialize the &lt;code>Feature&lt;/code> &lt;code>&lt;em>Occurrences::Occurrence::timeEnclosedOccurrences&lt;/em>&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672527200007_698448_334" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(OccurrenceDefinition) or
+ owningType.oclIsKindOf(OccurrenceUsage)) implies
+    specializesFromLibrary('Occurrences::Occurrence::timeEnclosedOccurrences')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672526870670_442669_304" name="validateEventOccurrenceUsageIsReference" visibility="public" constrainedElement="_19_0_4_12e503d9_1622831611763_442921_132">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676643237592_279581_476" annotatedElement="_19_0_4_12e503d9_1672526870670_442669_304">
+            <body>&lt;p>An &lt;code>EventOccurrenceUsage&lt;/code> must be referential.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672526870689_934071_305" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isReference</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1622831743996_219331_189" general="_19_0_4_12e503d9_1618943737195_33207_138"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1622831790393_676695_195" name="eventOccurrence" visibility="public" type="_19_0_4_12e503d9_1618943737195_33207_138" isDerived="true" association="_19_0_4_12e503d9_1622831790392_320401_194">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1622832598180_411591_301" annotatedElement="_19_0_4_12e503d9_1622831790393_676695_195">
+            <body>&lt;p>The &lt;code>OccurrenceUsage&lt;/code> referenced as an event by this &lt;code>EventOccurrenceUsage&lt;/code>. It is the &lt;code>referenceFeature&lt;/code> of the &lt;code>ownedReferenceSubsetting&lt;/code> for the &lt;code>EventOccurrenceUsage&lt;/code>, if there is one, and, otherwise, the &lt;code>EventOccurrenceUsage&lt;/code> itself.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1622831805782_895609_205" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1622831805788_709961_206" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1672526906017_786343_306" name="isReference" visibility="public" isDerived="true" redefinedProperty="_19_0_4_12e503d9_1624035114787_488767_41423">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672526993771_552814_329" annotatedElement="_19_0_4_12e503d9_1672526906017_786343_306">
+            <body>&lt;p>Always true for an &lt;code>EventOccurrenceUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Boolean"/>
+          <defaultValue xmi:type="uml:LiteralBoolean" xmi:id="_19_0_4_12e503d9_1672526929535_633078_308" name="" visibility="public" value="true"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_4_12e503d9_1621460768958_169689_562" name="UseCases" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621461043764_178979_909" name="A_includedUseCase_includingUseCaseDefinition" visibility="public" memberEnd="_19_0_4_12e503d9_1621461043764_27_910 _19_0_4_12e503d9_1621461043764_526474_911">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621461043764_526474_911" name="includingUseCaseDefinition" visibility="public" type="_19_0_4_12e503d9_1621460866763_205297_823" isDerived="true" association="_19_0_4_12e503d9_1621461043764_178979_909">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621546166483_326226_1967" annotatedElement="_19_0_4_12e503d9_1621461043764_526474_911">
+            <body>&lt;p>The UseCaseDefinition that includes a certain &lt;code>includedUseCase&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621546034650_62092_1915" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621546034651_689736_1916" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621545989645_932692_1854" name="A_includedUseCase_includingUseCase" visibility="public" memberEnd="_19_0_4_12e503d9_1621545989647_997634_1855 _19_0_4_12e503d9_1621545989653_391427_1856">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621545989653_391427_1856" name="includingUseCase" visibility="public" type="_19_0_4_12e503d9_1621460902507_609356_850" isDerived="true" association="_19_0_4_12e503d9_1621545989645_932692_1854">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621546175831_379612_1968" annotatedElement="_19_0_4_12e503d9_1621545989653_391427_1856">
+            <body>&lt;p>The UseCaseUsage that includes a certain &lt;code>includedUseCase&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621546030715_492011_1911" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621546030715_36326_1912" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1621532125543_31659_1117" name="IncludeUseCaseUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1621542547844_978916_1803" annotatedElement="_19_0_4_12e503d9_1621532125543_31659_1117">
+          <body>&lt;p>An &lt;code>IncludeUseCaseUsage&lt;/code> is a &lt;code>UseCaseUsage&lt;/code> that represents the inclusion of a &lt;code>UseCaseUsage&lt;/code> by a &lt;code>UseCaseDefinition&lt;/code> or &lt;code>UseCaseUsage&lt;/code>. Unless it is the &lt;code>IncludeUseCaseUsage&lt;/code> itself, the &lt;code>UseCaseUsage&lt;/code> to be included is related to the &lt;code>includedUseCase&lt;/code> by a &lt;code>ReferenceSubsetting&lt;/code> &lt;code>Relationship&lt;/code>. An &lt;code>IncludeUseCaseUsage&lt;/code> is also a PerformActionUsage, with its &lt;code>useCaseIncluded&lt;/code> as the &lt;code>performedAction&lt;/code>.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676741036313_462679_962" name="checkIncludeUseCaseUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1621532125543_31659_1117">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676741422434_381643_964" annotatedElement="_19_0_4_12e503d9_1676741036313_462679_962">
+            <body>&lt;p>A &lt;code>IncludeUseCaseUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>UseCaseDefinition&lt;/code> or &lt;code>UseCaseUsage&lt;/code> must directly or indirectly specialize the &lt;code>UseCaseUsage&lt;/code> &lt;em>&lt;code>UseCases::UseCase::includedUseCases&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676741036334_536086_963" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>owningType &lt;> null and
+(owningType.oclIsKindOf(UseCaseDefinition) or
+ owningType.oclIsKindOf(UseCaseUsage) implies
+    specializesFromLibrary('UseCases::UseCase::includedUseCases')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1698945368996_986912_118" name="validateIncludeUseCaseUsageReference" visibility="public" constrainedElement="_19_0_4_12e503d9_1621532125543_31659_1117">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1698945441138_107005_120" annotatedElement="_19_0_4_12e503d9_1698945368996_986912_118">
+            <body>&lt;p>If an &lt;code>IncludeUseCaseUsage&lt;/code> has an &lt;code>ownedReferenceSubsetting&lt;/code>, then the &lt;code>featureTarget&lt;/code> of the &lt;code>referencedFeature&lt;/code> must be a &lt;code>UseCaseUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1698945369025_284364_119" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>referencedFeatureTarget() &lt;> null implies
+    referencedFeatureTarget().oclIsKindOf(UseCaseUsage)</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1621541181023_57554_1793" general="_19_0_4_12e503d9_1621460902507_609356_850"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1621532141620_871576_1160" general="_18_5_3_12e503d9_1565503273042_472885_33822"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621532149711_865323_1172" name="useCaseIncluded" visibility="public" type="_19_0_4_12e503d9_1621460902507_609356_850" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1567740791820_867719_18017" association="_19_0_4_12e503d9_1621532149710_831102_1171">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621547028490_884_1988" annotatedElement="_19_0_4_12e503d9_1621532149711_865323_1172">
+            <body>&lt;p>The &lt;code>UseCaseUsage&lt;/code> to be included by this &lt;code>IncludeUseCaseUsage&lt;/code>. It is the &lt;code>performedAction&lt;/code> of the &lt;code>IncludeUseCaseUsage&lt;/code> considered as a &lt;code>PerformActionUsage&lt;/code>, which must be a &lt;code>UseCaseUsage&lt;/code>.&lt;/p> 
+</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621532166600_259686_1202" name="" visibility="public" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621532166603_313207_1203" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621532149710_831102_1171" name="A_useCaseIncluded_useCaseInclusion" visibility="public" memberEnd="_19_0_4_12e503d9_1621532149711_865323_1172 _19_0_4_12e503d9_1621532149711_737654_1173">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621532149711_737654_1173" name="useCaseInclusion" visibility="public" type="_19_0_4_12e503d9_1621532125543_31659_1117" isDerived="true" subsettedProperty="_19_0_2_12e503d9_1567740791820_137197_18018" association="_19_0_4_12e503d9_1621532149710_831102_1171">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621547057538_487975_1989" annotatedElement="_19_0_4_12e503d9_1621532149711_737654_1173">
+            <body>&lt;p>The IncludeUseCaseUsages that have a certain UseCaseUsage as their &lt;code>includedUseCase&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621532183094_962514_1224" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621532183094_13049_1225" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1621460964889_183162_880" name="A_useCaseDefinition_definedUseCase" visibility="public" memberEnd="_19_0_4_12e503d9_1621460964889_804779_881 _19_0_4_12e503d9_1621460964889_65421_882">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1621460964889_65421_882" name="definedUseCase" visibility="public" type="_19_0_4_12e503d9_1621460902507_609356_850" isDerived="true" subsettedProperty="_19_0_2_59601fc_1590257465224_154720_511" association="_19_0_4_12e503d9_1621460964889_183162_880">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621546132552_135303_1966" annotatedElement="_19_0_4_12e503d9_1621460964889_65421_882">
+            <body>&lt;p>The UseCaseUsages being typed by a certain UseCaseDefinition.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621461366852_804809_989" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621461366853_703047_990" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1621460902507_609356_850" name="UseCaseUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1621542506961_835109_1802" annotatedElement="_19_0_4_12e503d9_1621460902507_609356_850">
+          <body>&lt;p>A &lt;code>UseCaseUsage&lt;/code> is a &lt;code>Usage&lt;/code> of a &lt;code>UseCaseDefinition&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676723092625_743679_516" name="deriveUseCaseUsageIncludedUseCase" visibility="public" constrainedElement="_19_0_4_12e503d9_1621460902507_609356_850">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676723092711_733921_518" annotatedElement="_19_0_4_12e503d9_1676723092625_743679_516">
+            <body>&lt;p>The &lt;code>includedUseCases&lt;code> of a &lt;code>UseCaseUsage&lt;/code> are the &lt;code>useCaseIncludeds&lt;/code> of the &lt;code>IncludeUseCaseUsages&lt;/code> owned by the &lt;code>UseCaseUsage&lt;code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676723092699_72353_517" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>includedUseCase = ownedUseCase->
+    selectByKind(IncludeUseCaseUsage).
+    useCaseIncluded</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676741531930_966511_969" name="checkUseCaseUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1621460902507_609356_850">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676741652835_487473_971" annotatedElement="_19_0_4_12e503d9_1676741531930_966511_969">
+            <body>&lt;p>A &lt;code>UseCaseUsage&lt;/code> must directly or indirectly specializes the base &lt;code>UseCaseUsage&lt;/code> &lt;em>&lt;code>UseCases::useCases&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676741531934_642643_970" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('UseCases::useCases')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676741671350_708211_972" name="checkUseCaseUsageSubUseCaseSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1621460902507_609356_850">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676741907349_456897_974" annotatedElement="_19_0_4_12e503d9_1676741671350_708211_972">
+            <body>&lt;p>A composite &lt;code>UseCaseUsage&lt;/code> whose &lt;code>owningType&lt;/code> is a &lt;code>UseCaseDefinition&lt;/code> or &lt;code>UseCaseUsage&lt;/code> must specialize the &lt;code>UseCaseUsage&lt;/code> &lt;em>&lt;code>UseCases::UseCase::subUseCases&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676741671363_478812_973" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>isComposite and owningType &lt;> null and
+(owningType.oclIsKindOf(UseCaseDefinition) or
+ owningType.oclIsKindOf(UseCaseUsage)) implies
+    specializesFromLibrary('UseCases::UseCase::subUseCases')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1621460920013_479486_875" general="_19_0_2_59601fc_1590256077623_424527_107"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621460964889_804779_881" name="useCaseDefinition" visibility="public" type="_19_0_4_12e503d9_1621460866763_205297_823" isDerived="true" redefinedProperty="_19_0_2_59601fc_1590257465225_855208_512" association="_19_0_4_12e503d9_1621460964889_183162_880">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621545736046_654917_1839" annotatedElement="_19_0_4_12e503d9_1621460964889_804779_881">
+            <body>&lt;p>The &lt;code>UseCaseDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>UseCaseUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621460998370_812949_901" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621460998375_783220_902" name="" visibility="public" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621545989647_997634_1855" name="includedUseCase" visibility="public" type="_19_0_4_12e503d9_1621460902507_609356_850" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1621545989645_932692_1854">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621546109637_622143_1965" annotatedElement="_19_0_4_12e503d9_1621545989647_997634_1855">
+            <body>&lt;p>The &lt;code>UseCaseUsages&lt;/code> that are included by this &lt;code>UseCaseUse&lt;/code>, which are the &lt;code>useCaseIncludeds&lt;/code> of the &lt;code>IncludeUseCaseUsages&lt;/code> owned by this &lt;code>UseCaseUsage&lt;code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621546021435_239480_1899" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621546021436_766768_1900" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1621460866763_205297_823" name="UseCaseDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1621542011698_61434_1801" annotatedElement="_19_0_4_12e503d9_1621460866763_205297_823">
+          <body>&lt;p>A &lt;code>UseCaseDefinition&lt;/code> is a &lt;code>CaseDefinition&lt;/code> that specifies a set of actions performed by its subject, in interaction with one or more actors external to the subject. The objective is to yield an observable result that is of value to one or more of the actors.&lt;/p>
+</body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676722713545_864082_513" name="deriveUseCaseDefinitionIncludedUseCase" visibility="public" constrainedElement="_19_0_4_12e503d9_1621460866763_205297_823">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676722868054_888954_515" annotatedElement="_19_0_4_12e503d9_1676722713545_864082_513">
+            <body>&lt;p>The &lt;code>includedUseCases&lt;code> of a &lt;code>UseCaseDefinition&lt;/code> are the &lt;code>useCaseIncludeds&lt;/code> of the &lt;code>IncludeUseCaseUsages&lt;/code> owned by the &lt;code>UseCaseDefinition&lt;code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676722713570_887761_514" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>includedUseCase = ownedUseCase->
+    selectByKind(IncludeUseCaseUsage).
+    useCaseIncluded</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676741457501_29637_965" name="checkUseCaseDefinitionSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1621460866763_205297_823">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676741518525_14749_967" annotatedElement="_19_0_4_12e503d9_1676741457501_29637_965">
+            <body>&lt;p>A &lt;code>UseCaseDefinition&lt;/code> must directly or indirectly specializes the base &lt;code>UseCaseDefinition&lt;/code> &lt;code>&lt;em>UseCases::UseCase&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676741518657_115815_968" annotatedElement="_19_0_4_12e503d9_1676741457501_29637_965">
+            <body></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676741457507_580372_966" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('UseCases::UseCase')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1621460885838_370618_848" general="_19_0_2_59601fc_1590256070522_658678_81"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1621461043764_27_910" name="includedUseCase" visibility="public" type="_19_0_4_12e503d9_1621460902507_609356_850" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1621461043764_178979_909">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1621545795526_470882_1841" annotatedElement="_19_0_4_12e503d9_1621461043764_27_910">
+            <body>&lt;p>The &lt;code>UseCaseUsages&lt;/code> that are included by this &lt;code>UseCaseDefinition&lt;/code>, which are the &lt;code>useCaseIncludeds&lt;/code> of the &lt;code>IncludeUseCaseUsages&lt;/code> owned by this &lt;code>UseCaseDefinition&lt;code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1621461071748_395621_920" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1621461071750_877737_921" name="" visibility="public" value="*"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_19_0_4_12e503d9_1647644866653_828723_64" name="Metadata" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1647727047667_223454_2562" name="A_metadataDefinition_definedMetadata" visibility="public" memberEnd="_19_0_4_12e503d9_1647727047674_847094_2563 _19_0_4_12e503d9_1647727047692_601931_2564">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1647727047692_601931_2564" name="definedMetadata" visibility="public" type="_19_0_4_12e503d9_1645121476406_921183_398" isDerived="true" association="_19_0_4_12e503d9_1647727047667_223454_2562">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1647727196932_439197_2603" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1647727196951_58727_2604" name="" visibility="public" value="*"/>
+          <subsettedProperty href="KerML_only_xmi.uml#_19_0_4_12e503d9_1606345564959_551738_331"/>
+          <subsettedProperty href="#_18_5_3_12e503d9_1565471361757_611715_20797"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1645121454429_912244_371" name="MetadataDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1648591524685_60257_78" annotatedElement="_19_0_4_12e503d9_1645121454429_912244_371">
+          <body>&lt;p>A &lt;code>MetadataDefinition&lt;/code> is an &lt;code>ItemDefinition&lt;/code> that is also a &lt;code>Metaclass&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676744434164_198046_1025" name="checkMetadataDefinitionSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1645121454429_912244_371">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676744514817_945777_1027" annotatedElement="_19_0_4_12e503d9_1676744434164_198046_1025">
+            <body>&lt;p>A &lt;code>MetadataDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>MetadataDefinition&lt;/code> &lt;code>&lt;em>Metadata::MetadataItem&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676744434172_855353_1026" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Metadata::MetadataItem')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1647726967635_741379_2490" general="_19_0_2_12e503d9_1591216581238_805702_84"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1645121472156_361545_396">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_12e503d9_1645120910786_720932_39"/>
+        </generalization>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1645121476406_921183_398" name="MetadataUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1648592547460_894157_167" annotatedElement="_19_0_4_12e503d9_1645121476406_921183_398">
+          <body>&lt;p>A  &lt;code>MetadataUsage&lt;/code> is a &lt;code>Usage&lt;/code> and a &lt;code>MetadataFeature&lt;/code>, used to annotate other &lt;code>Elements&lt;/code> in a system model with metadata. As a &lt;code>MetadataFeature&lt;/code>, its type must be a &lt;code>Metaclass&lt;/code>, which will nominally be a &lt;code>MetadataDefinition&lt;/code>. However, any kernel &lt;code>Metaclass&lt;/code> is also allowed, to permit use of &lt;code>Metaclasses&lt;/code> from the Kernel Model Libraries.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1676744535099_454960_1028" name="checkMetadataUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1645121476406_921183_398">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676744598912_483382_1030" annotatedElement="_19_0_4_12e503d9_1676744535099_454960_1028">
+            <body>&lt;p>A &lt;code>MetadataUsage&lt;/code> must directly or indirectly specialize the base &lt;code>MetadataUsage&lt;/code> &lt;code>&lt;em>Metadata::metadataItems&lt;/em>&lt;/code> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1676744535107_988770_1029" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Metadata::metadataItems')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1647726961071_510114_2487" general="_18_5_3_12e503d9_1565480460114_846184_24270"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1645121490133_548866_423">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_12e503d9_1606345563822_968574_178"/>
+        </generalization>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1647727047674_847094_2563" name="metadataDefinition" visibility="public" isDerived="true" association="_19_0_4_12e503d9_1647727047667_223454_2562">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1676728947315_633174_710" annotatedElement="_19_0_4_12e503d9_1647727047674_847094_2563">
+            <body>&lt;p>The &lt;code>MetadataDefinition&lt;/code> that is the &lt;code>definition&lt;/code> of this &lt;code>MetadataUsage&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_19_0_4_12e503d9_1645120910786_720932_39"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1647727113634_408384_2573" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1647727113642_191819_2574" name="" visibility="public" value="1"/>
+          <redefinedProperty href="#_18_5_3_12e503d9_1565471361757_649736_20796"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_19_0_4_12e503d9_1606345564958_925589_327"/>
+        </ownedAttribute>
+      </packagedElement>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Package" xmi:id="_2022x_2_12e503d9_1732817794805_263676_16" name="Flows" visibility="public" URI="">
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624054663096_771284_1274" name="FlowUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624055395794_367872_1832" annotatedElement="_19_0_4_12e503d9_1624054663096_771284_1274">
+          <body>&lt;p>A &lt;code>FlowUsage&lt;/code> is an &lt;code>ActionUsage&lt;/code> that is also a &lt;code>ConnectorAsUsage&lt;/code> and a KerML &lt;code>Flow&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672892939348_560879_182" name="checkFlowUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624054663096_771284_1274">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672893096816_367771_184" annotatedElement="_19_0_4_12e503d9_1672892939348_560879_182">
+            <body>&lt;p>A &lt;code>FlowUsage&lt;/code> must directly or indirectly specialize the base &lt;code>FlowUsage&lt;/code> &lt;em>&lt;code>Flows::messages&lt;/code>&lt;/em> from the Systems Library model.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672892939367_543375_183" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Flows::messages')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734639289650_749333_55" name="checkFlowUsageFlowSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624054663096_771284_1274">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734639328908_161469_57" annotatedElement="_2022x_2_12e503d9_1734639289650_749333_55">
+            <body>&lt;p>If a &lt;code>FlowUsage&lt;/code> has &lt;code>ownedEndFeatures&lt;/code>, it must directly or indirectly specialize the &lt;code>FlowUsage&lt;/code> &lt;em>&lt;code>Flows::flows&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734639289650_924715_56" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>ownedEndFeatures->notEmpty() implies
+    specializesFromLibrary('Flows::flows')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1624054679587_662098_1299" general="_19_0_4_12e503d9_1624053320057_820842_471"/>
+        <generalization xmi:id="_19_0_4_12e503d9_1624054899083_38265_1455">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_b9102da_1536869417406_861526_17744"/>
+        </generalization>
+        <generalization xmi:id="_19_0_4_12e503d9_1661893355246_560391_409" general="_18_5_3_12e503d9_1565500580749_954926_30405"/>
+        <ownedAttribute xmi:id="_19_0_4_12e503d9_1661892878973_977062_185" name="flowDefinition" visibility="public" isOrdered="true" isDerived="true" association="_19_0_4_12e503d9_1661892878963_233467_184">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661894658080_546746_1144" annotatedElement="_19_0_4_12e503d9_1661892878973_977062_185">
+            <body>&lt;p>The &lt;code>Interactions&lt;/code> that are the &lt;code>types&lt;/code> of this &lt;code>FlowUsage&lt;/code>. Nominally, these are &lt;code>FlowDefinitions&lt;/code>, but other kinds of Kernel &lt;code>Interactions&lt;/code> are also allowed, to permit use of Interactions from the Kernel Model Libraries.&lt;/p></body>
+          </ownedComment>
+          <type xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_b9102da_1536782424772_574530_21292"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661893002094_436395_205" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661893002105_91462_206" name="" visibility="public" value="*"/>
+          <redefinedProperty href="#_18_5_3_12e503d9_1565500905804_589845_30779"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_19_0_4_12e503d9_1661900477937_518125_727"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1661892471095_470217_5" name="FlowDefinition" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1661893911555_959628_1113" annotatedElement="_19_0_4_12e503d9_1661892471095_470217_5">
+          <body>&lt;p>A &lt;code>FlowDefinition&lt;/code> is an &lt;code>ActionDefinition&lt;/code> that is also an &lt;code>Interaction&lt;/code> (which is both a KerML &lt;code>Behavior&lt;/code> and &lt;code>Association&lt;/code>), representing flows between &lt;code>Usages&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672867854678_565040_148" name="checkFlowDefinitionSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1661892471095_470217_5">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672893263674_7990_185" annotatedElement="_19_0_4_12e503d9_1672867854678_565040_148">
+            <body>&lt;p>A &lt;code>FlowDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>FlowDefinition&lt;/code> &lt;em>&lt;code>Flows::MessageAction&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672867854698_675323_149" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Flows::MessageAction')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734638615167_796458_49" name="checkFlowDefinitionBinarySpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1661892471095_470217_5">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734638845707_618170_53" annotatedElement="_2022x_2_12e503d9_1734638615167_796458_49">
+            <body>&lt;p>A binary &lt;code>FlowDefinition&lt;/code> must directly or indirectly specialize the base &lt;code>FlowDefinition&lt;code> &lt;em>&lt;code>Flows::Message&lt;/code>&lt;/em> from the Systems Model Library.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734638615167_634869_50" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>flowEnd->size() = 2 implies
+    specializesFromLibrary('Flows::Message')</body>
+          </specification>
+        </ownedRule>
+        <ownedRule xmi:id="_2022x_2_12e503d9_1734638733595_928825_51" name="validateFlowDefinitionFlowEnds" visibility="public" constrainedElement="_19_0_4_12e503d9_1661892471095_470217_5">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734638874668_505150_54" annotatedElement="_2022x_2_12e503d9_1734638733595_928825_51">
+            <body>&lt;p>A &lt;code>FlowDefinition&lt;/code> may not have more than two &lt;code>flowEnds&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_2022x_2_12e503d9_1734638733596_542030_52" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>flowEnd->size() &lt;= 2</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1661892863337_443926_179">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_b9102da_1536782424772_574530_21292"/>
+        </generalization>
+        <generalization xmi:id="_19_0_4_12e503d9_1661893240443_196652_328" general="_18_5_3_12e503d9_1565500542970_17430_30342"/>
+        <ownedAttribute xmi:id="_2022x_2_12e503d9_1733008492358_136366_19515" name="flowEnd" visibility="public" type="_18_5_3_12e503d9_1565469997820_598571_19982" isDerived="true" association="_2022x_2_12e503d9_1733008492358_158208_19514">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734638488257_175179_47" annotatedElement="_2022x_2_12e503d9_1733008492358_136366_19515">
+            <body>&lt;p>The &lt;code>Usages&lt;/code> that define the things related by the &lt;code>FlowDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1733008589402_463877_19553" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1733008589403_631051_19554" name="" visibility="public" value="*"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1562477648742_24204_22901"/>
+        </ownedAttribute>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_2022x_2_12e503d9_1733008492358_158208_19514" name="A_flowEnd_flowDefinitionWithEnd" visibility="public" memberEnd="_2022x_2_12e503d9_1733008492358_136366_19515 _2022x_2_12e503d9_1733008492359_791892_19516">
+        <ownedEnd xmi:id="_2022x_2_12e503d9_1733008492359_791892_19516" name="flowDefinitionWithEnd" visibility="public" type="_19_0_4_12e503d9_1661892471095_470217_5" isDerived="true" association="_2022x_2_12e503d9_1733008492358_158208_19514">
+          <ownedComment xmi:id="_2022x_2_12e503d9_1734638569327_241621_48" annotatedElement="_2022x_2_12e503d9_1733008492359_791892_19516">
+            <body>&lt;p>The &lt;code>FlowDefinitions&lt;code> that have a certain Usage as &lt;code>flowEnd&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2022x_2_12e503d9_1733008700444_849618_19627" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2022x_2_12e503d9_1733008700444_518757_19628" name="" visibility="public" value="*"/>
+          <redefinedProperty href="KerML_only_xmi.uml#_18_5_3_12e503d9_1562477648742_461919_22902"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_19_0_4_12e503d9_1661892878963_233467_184" name="A_flowDefinition_definedFlow" visibility="public" memberEnd="_19_0_4_12e503d9_1661892878973_977062_185 _19_0_4_12e503d9_1661892878985_103062_186">
+        <ownedEnd xmi:id="_19_0_4_12e503d9_1661892878985_103062_186" name="definedFlow" visibility="public" type="_19_0_4_12e503d9_1624054663096_771284_1274" isDerived="true" redefinedProperty="_19_0_2_12e503d9_1591479011613_547927_1091" association="_19_0_4_12e503d9_1661892878963_233467_184">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1661894796115_846085_1147" annotatedElement="_19_0_4_12e503d9_1661892878985_103062_186">
+            <body>&lt;p>The &lt;code>FlowUsages&lt;code> that have a certain &lt;code>Interaction&lt;/code> as their &lt;code>flowDefinition&lt;/code>.&lt;/p></body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_19_0_4_12e503d9_1661893035564_623973_211" name="" visibility="public"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_19_0_4_12e503d9_1661893035568_958688_212" name="" visibility="public" value="*"/>
+        </ownedEnd>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_19_0_4_12e503d9_1624054686981_604189_1301" name="SuccessionFlowUsage" visibility="public">
+        <ownedComment xmi:id="_19_0_4_12e503d9_1624055450077_783991_1833" annotatedElement="_19_0_4_12e503d9_1624054686981_604189_1301">
+          <body>&lt;p>A &lt;code>SuccessionFlowUsage&lt;/code> is a &lt;code>FlowUsage&lt;/code> that is also a KerML &lt;code>SuccessionFlow&lt;/code>.&lt;/p></body>
+        </ownedComment>
+        <ownedRule xmi:id="_19_0_4_12e503d9_1672893282691_198884_186" name="checkSuccessionFlowUsageSpecialization" visibility="public" constrainedElement="_19_0_4_12e503d9_1624054686981_604189_1301">
+          <ownedComment xmi:id="_19_0_4_12e503d9_1672893372673_393095_188" annotatedElement="_19_0_4_12e503d9_1672893282691_198884_186">
+            <body>&lt;p>A &lt;code>SuccessionFlowUsage&lt;/code> must directly or indirectly specialize the base &lt;code>FlowUsage&lt;/code> &lt;em>&lt;code>Flows::successionFlows&lt;/code>&lt;/em> from the Systems Library model.&lt;/p></body>
+          </ownedComment>
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_19_0_4_12e503d9_1672893282709_750159_187" name="" visibility="public">
+            <language>OCL2.0</language>
+            <body>specializesFromLibrary('Flows::successionFlows')</body>
+          </specification>
+        </ownedRule>
+        <generalization xmi:id="_19_0_4_12e503d9_1624054903494_805111_1458">
+          <general xmi:type="uml:Class" href="KerML_only_xmi.uml#_18_5_3_b9102da_1536869794875_359922_17902"/>
+        </generalization>
+        <generalization xmi:id="_19_0_4_12e503d9_1624054708840_672250_1326" general="_19_0_4_12e503d9_1624054663096_771284_1274"/>
+      </packagedElement>
+    </packagedElement>
+  </packagedElement>
+</uml:Model>

--- a/uml4net.Tests/AssemblerTestFixture.cs
+++ b/uml4net.Tests/AssemblerTestFixture.cs
@@ -365,6 +365,88 @@ namespace uml4net.Tests
         }
 
         [Test]
+        public void Synchronize_ShouldResolveBareSameDocumentFragmentAndCrossDocumentMultiValueReference()
+        {
+            const string externalXmi = "otherdoc";
+
+            var sameDocumentTarget = new Property
+            {
+                XmiId = Guid.NewGuid().ToString(),
+                Name = "sameDocumentTarget",
+                DocumentName = this.documentName
+            };
+
+            var crossDocumentTarget = new Property
+            {
+                XmiId = Guid.NewGuid().ToString(),
+                Name = "crossDocumentTarget",
+                DocumentName = externalXmi
+            };
+
+            var property = new Property
+            {
+                XmiId = Guid.NewGuid().ToString(),
+                Name = "directedUsage",
+                DocumentName = this.documentName
+            };
+
+            // "#id" is a bare same-document fragment, "otherdoc#id" is a cross-document reference
+            property.MultiValueReferencePropertyIdentifiers.Add("subsettedProperty",
+                [$"#{sameDocumentTarget.XmiId}", $"{externalXmi}#{crossDocumentTarget.XmiId}"]);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.cache.TryAdd(property), Is.True);
+                Assert.That(this.cache.TryAdd(sameDocumentTarget), Is.True);
+                Assert.That(this.cache.TryAdd(crossDocumentTarget), Is.True);
+            }
+
+            Assert.That(property.SubsettedProperty, Is.Empty);
+
+            this.assembler.Synchronize();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(property.SubsettedProperty, Has.Count.EqualTo(2));
+                Assert.That(property.SubsettedProperty, Does.Contain(sameDocumentTarget));
+                Assert.That(property.SubsettedProperty, Does.Contain(crossDocumentTarget));
+            }
+        }
+
+        [Test]
+        public void Synchronize_ShouldResolveBareSameDocumentFragmentSingleValueReference()
+        {
+            var property = new Property
+            {
+                XmiId = Guid.NewGuid().ToString(),
+                Name = "property",
+                DocumentName = this.documentName
+            };
+
+            var primitiveType = new PrimitiveType
+            {
+                XmiId = Guid.NewGuid().ToString(),
+                Name = "string",
+                DocumentName = this.documentName
+            };
+
+            // "#id" is a bare same-document fragment
+            property.SingleValueReferencePropertyIdentifiers.Add("type", $"#{primitiveType.XmiId}");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.cache.TryAdd(property), Is.True);
+                Assert.That(this.cache.TryAdd(primitiveType), Is.True);
+            }
+
+            Assert.That(property.Type, Is.Null);
+
+            this.assembler.Synchronize();
+
+            Assert.That(property.Type, Is.SameAs(primitiveType));
+        }
+
+        [Test]
         public void Synchronize_verify_that_type_is_set()
         {
             var property = new Property

--- a/uml4net.xmi.Tests/SysML2.XmiReaderTestFixture.cs
+++ b/uml4net.xmi.Tests/SysML2.XmiReaderTestFixture.cs
@@ -28,6 +28,7 @@ namespace uml4net.xmi.Tests
     using NUnit.Framework;
     using Serilog;
 
+    using uml4net.Classification;
     using uml4net.Packages;
     using uml4net.StructuredClassifiers;
     using uml4net.xmi;
@@ -102,6 +103,83 @@ namespace uml4net.xmi.Tests
                 Assert.That(sysmlTypClass, Is.Not.Null);
                 Assert.That(isAbstractProperty, Is.Not.Null);
                 Assert.That(isAbstractProperty.Type, usingSettings ? Is.Not.Null : Is.Null);
+            }
+        }
+
+        [Test]
+        public void Verify_that_bare_same_document_href_references_are_resolved()
+        {
+            var rootPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData");
+
+            var reader = XmiReaderBuilder.Create()
+                .UsingSettings(x =>
+                {
+                    x.LocalReferenceBasePath = rootPath;
+                    x.PathMaps = new Dictionary<string, string>
+                    {
+                        ["pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml"] = Path.Combine(rootPath, "PrimitiveTypes.xmi")
+                    };
+                })
+                .WithLogger(this.loggerFactory)
+                .Build();
+
+            var xmiReaderResult = reader.Read(Path.Combine(rootPath, "SysML_only_xmi.uml"));
+
+            // The 'directedUsage' ownedAttribute of the 'Definition' class carries two <subsettedProperty> children:
+            //   href="KerML_only_xmi.uml#..."  -> 'directedFeature' (cross-document reference, always resolved)
+            //   href="#..."                    -> 'usage' (bare same-document fragment, dropped before the #192 fix)
+            var directedUsage = AllProperties(xmiReaderResult.Packages)
+                .Single(x => x.XmiId == "_18_5_3_12e503d9_1565495064714_974634_26150");
+
+            var subsettedPropertyNames = directedUsage.SubsettedProperty.Select(x => x.Name).ToList();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(directedUsage.Name, Is.EqualTo("directedUsage"));
+                Assert.That(directedUsage.SubsettedProperty, Has.Count.EqualTo(2));
+                Assert.That(subsettedPropertyNames, Does.Contain("directedFeature"));
+                Assert.That(subsettedPropertyNames, Does.Contain("usage"));
+            }
+        }
+
+        /// <summary>
+        /// Recursively enumerates every <see cref="IProperty"/> owned by the <see cref="IClass"/>es
+        /// contained (directly or transitively) in the provided <paramref name="packages"/>
+        /// </summary>
+        private static IEnumerable<IProperty> AllProperties(IEnumerable<IPackage> packages)
+        {
+            foreach (var package in packages)
+            {
+                foreach (var property in AllProperties(package))
+                {
+                    yield return property;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Recursively enumerates every <see cref="IProperty"/> owned by the <see cref="IClass"/>es
+        /// contained (directly or transitively) in the provided <paramref name="package"/>
+        /// </summary>
+        private static IEnumerable<IProperty> AllProperties(IPackage package)
+        {
+            foreach (var packagedElement in package.PackagedElement)
+            {
+                if (packagedElement is IClass @class)
+                {
+                    foreach (var attribute in @class.OwnedAttribute)
+                    {
+                        yield return attribute;
+                    }
+                }
+
+                if (packagedElement is IPackage nestedPackage)
+                {
+                    foreach (var property in AllProperties(nestedPackage))
+                    {
+                        yield return property;
+                    }
+                }
             }
         }
     }

--- a/uml4net.xmi.Tests/SysML2.XmiReaderTestFixture.cs
+++ b/uml4net.xmi.Tests/SysML2.XmiReaderTestFixture.cs
@@ -117,7 +117,7 @@ namespace uml4net.xmi.Tests
                     x.LocalReferenceBasePath = rootPath;
                     x.PathMaps = new Dictionary<string, string>
                     {
-                        ["pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml"] = Path.Combine(rootPath, "PrimitiveTypes.xmi")
+                        ["pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml"] = Path.Combine(rootPath, "SySML2", "PrimitiveTypes.xmi")
                     };
                 })
                 .WithLogger(this.loggerFactory)
@@ -133,12 +133,21 @@ namespace uml4net.xmi.Tests
 
             var subsettedPropertyNames = directedUsage.SubsettedProperty.Select(x => x.Name).ToList();
 
+            // the 'isReference' attribute is typed by a primitive resolved through the
+            // UMLPrimitiveTypes pathmap, so its resolution proves the model is fully assembled
+            var isReference = AllProperties(xmiReaderResult.Packages)
+                .Single(x => x.XmiId == "_19_0_4_12e503d9_1624050661138_649455_27");
+
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(directedUsage.Name, Is.EqualTo("directedUsage"));
                 Assert.That(directedUsage.SubsettedProperty, Has.Count.EqualTo(2));
                 Assert.That(subsettedPropertyNames, Does.Contain("directedFeature"));
                 Assert.That(subsettedPropertyNames, Does.Contain("usage"));
+
+                Assert.That(isReference.Name, Is.EqualTo("isReference"));
+                Assert.That(isReference.Type, Is.Not.Null);
+                Assert.That(isReference.Type.Name, Is.EqualTo("Boolean"));
             }
         }
 

--- a/uml4net.xmi.Tests/uml4net.xmi.Tests.csproj
+++ b/uml4net.xmi.Tests/uml4net.xmi.Tests.csproj
@@ -65,6 +65,12 @@
         <Content Include="..\resources\SySML2\SysML.uml" Link="TestData\SysML.uml">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
+        <Content Include="..\resources\SySML2\SysML_only_xmi.uml" Link="TestData\SysML_only_xmi.uml">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+        <Content Include="..\resources\SySML2\KerML_only_xmi.uml" Link="TestData\KerML_only_xmi.uml">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
       <Content Include="..\resources\UML_with_unknown_element\SysML_with_unknown_element.uml" Link="TestData\SysML_with_unknown_element.uml">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>

--- a/uml4net.xmi.Tests/uml4net.xmi.Tests.csproj
+++ b/uml4net.xmi.Tests/uml4net.xmi.Tests.csproj
@@ -71,6 +71,9 @@
         <Content Include="..\resources\SySML2\KerML_only_xmi.uml" Link="TestData\KerML_only_xmi.uml">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </Content>
+        <Content Include="..\resources\SySML2\PrimitiveTypes.xmi" Link="TestData\SySML2\PrimitiveTypes.xmi">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
       <Content Include="..\resources\UML_with_unknown_element\SysML_with_unknown_element.uml" Link="TestData\SysML_with_unknown_element.uml">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>

--- a/uml4net/Assembler.cs
+++ b/uml4net/Assembler.cs
@@ -142,7 +142,14 @@ namespace uml4net
         /// </returns>
         private bool TryGetReferencedElement(string documentName, string referenceIdKey, out IXmiElement element)
         {
-            var key = referenceIdKey.Contains("#") ? referenceIdKey : $"{documentName}#{referenceIdKey}";
+            var hashIndex = referenceIdKey.IndexOf('#');
+
+            // hashIndex > 0  -> a document part is present (e.g. "file#id"), use as-is
+            // otherwise      -> bare id ("id") or bare same-document fragment ("#id"),
+            //                   resolve within the current document
+            var key = hashIndex > 0
+                ? referenceIdKey
+                : $"{documentName}#{referenceIdKey.TrimStart('#')}";
 
             return this.cache.TryGetValue(key, out element);
         }


### PR DESCRIPTION
## Summary

The XMI reader dropped cross-reference children whose `href` is a **bare same-document fragment** (`href="#id"`), while the cross-document form (`href="file#id"`) resolved correctly. Observed for `<subsettedProperty>` / `<redefinedProperty>` but the cause was generic `href` resolution, so it affected every href-based reference element.

Fixes #192. Downstream: STARIONGROUP/SysML2.NET#315.

## Root cause

The element cache is keyed by `{DocumentName}#{XmiId}` (`XmiElement.FullyQualifiedIdentifier`). In `Assembler.TryGetReferencedElement` the lookup key was built with `referenceIdKey.Contains("#")`: a bare `#id` *contains* `#`, so it was used verbatim as the key and never matched `documentName#id` — the reference was silently dropped (only a warning logged).

## Change

`Assembler.TryGetReferencedElement` now inspects the position of `#`:

- `hashIndex > 0` → a document part is present (`file#id`) → used as-is
- otherwise → a bare id (`id`, from `xmi:idref`) or a bare same-document fragment (`#id`) → normalized to `{documentName}#{id}`

This is the single, generic resolution point every href-based reference flows through (`subsettedProperty`, `redefinedProperty`, `type`, `general`, …), so the fix is uniform. `ExternalReferenceResolver` already correctly treated bare fragments as same-document, so no change was needed there.

## Tests

- **`AssemblerTestFixture`** — unit tests for the bare-fragment single-value and multi-value resolution paths (each fails without the fix, passes with it).
- **`SysML2.XmiReaderTestFixture`** — end-to-end regression test against the real SysML2 model. Reads `SysML_only_xmi.uml` (plus cross-document `KerML_only_xmi.uml`) and asserts `directedUsage.SubsettedProperty` resolves **both** the cross-document reference (`directedFeature`) and the bare same-document reference (`usage`). Without the fix this model dropped the bare `#id` reference (count 1 instead of 2, plus ~38 "not found in cache" warnings across the model).

## Verification

- New regression test fails on the pre-fix `Assembler` and passes after.
- Full `uml4net.xmi.Tests` suite green (54/54).
- Confirmed the fix does **not** change uml4net's own generated code: the `UML.xmi` metamodel contains zero bare `href="#"` references, and regenerating through the patched Assembler produces byte-for-byte identical `AutoGenClasses`/`AutoGenInterfaces` (CorePocoGenerator exact-match tests pass).

## Notes

- Adds `resources/SySML2/SysML_only_xmi.uml` and `KerML_only_xmi.uml` as test fixtures (wired into `TestData` via the test csproj).
