### PR TITLE
[Add] XmiWriter implementation; fixes #194

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,12 +52,14 @@ The `uml4net` core project is predominantly auto-generated from the UML 2.5.1 sp
 - `uml4net/AutoGenInterfaces/` — UML element interfaces
 - `uml4net/AutoGenEnumeration/` — UML enumerations
 - `uml4net.xmi/AutoGenXmiReaders/` — XMI element reader classes
+- `uml4net.xmi/AutoGenXmiWriters/` — XMI element writer classes (regenerate via the `[Explicit]` test `XmiWriterGeneratorTestFixture.Regenerate_AutoGenXmiWriters_of_uml4net_xmi`)
 
 Generated files contain the marker: `THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!`
 
 ### Key Types & Patterns
 
-- **Entry point**: `XmiReaderBuilder.Create().Build()` returns an `IXmiReader`
+- **Entry point (reading)**: `XmiReaderBuilder.Create().Build()` returns an `IXmiReader`
+- **Entry point (writing)**: `XmiWriterBuilder.Create().Build()` returns an `IXmiWriter`; `IXmiWriterSettings.ExternalReferenceResolution` selects href vs include handling of external references
 - **IElement** is the root interface for all UML elements
 - **IContainerList\<T\>** manages owned element collections
 - **IXmiElementCache** provides element lookup by XMI ID

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Introduction
 
-Uml4net is a suite of dotnet core libraries and tools that are used to deserialize (read) a UML version 2.5.1 model in XMI form. Uml4net is typically used to support opinionated template based code-generation and is a part of `modeltopia`. Uml4net porivdes a number of libraries that are described in the following sections.
+Uml4net is a suite of dotnet core libraries and tools that are used to deserialize (read) and serialize (write) a UML version 2.5.1 model in XMI form. Uml4net is typically used to support opinionated template based code-generation and is a part of `modeltopia`. Uml4net porivdes a number of libraries that are described in the following sections.
 
 ## uml4net
 
-The core library that contains all the class definitions as they appear in the UML 2.5.1 specification. Together with uml4net.xmi it provides the capability to to read UML models and make them available as an in-memory object graph.
+The core library that contains all the class definitions as they appear in the UML 2.5.1 specification. Together with uml4net.xmi it provides the capability to to read and write UML models and make them available as an in-memory object graph.
 
 ## uml4net.Extensions
 
@@ -14,7 +14,7 @@ The **uml4net.Extensions** library provides extensions methods to the uml4net li
 
 ## uml4net.xmi
 
-The **uml4net.xmi** library provides an XMI reader implementation to read UML XMI model files.
+The **uml4net.xmi** library provides an XMI reader implementation to read UML XMI model files and an XMI writer implementation to write UML models to XMI. The writer supports writing a selected `Package`, where references to elements outside the selected package are either written as `href` references to the original document or the containing root packages are included in the written document, resulting in a self-contained XMI file.
 
 > To learn more about how to read an UML model, read about it [here](https://github.com/STARIONGROUP/uml4net/wiki/uml4net.xmi.project)
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ActivityWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ActivityWriter.cs
@@ -1,0 +1,736 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActivityWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ActivityWriter"/> is to write an instance of <see cref="IActivity"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ActivityWriter : XmiElementWriter<IActivity>, IXmiElementWriter<IActivity>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ActivityWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ActivityWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ActivityWriter>.Instance : loggerFactory.CreateLogger<ActivityWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IActivity"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActivity"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IActivity element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Activity with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Activity");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsReadOnly)
+            {
+                xmlWriter.WriteAttributeString("isReadOnly", XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (!element.IsReentrant)
+            {
+                xmlWriter.WriteAttributeString("isReentrant", XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (element.IsSingleExecution)
+            {
+                xmlWriter.WriteAttributeString("isSingleExecution", XmlConvert.ToString(element.IsSingleExecution));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                xmlWriter.WriteAttributeString("specification", element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Group)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "group", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Partition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "partition", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedBehavior", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.StructuredNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "structuredNode", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IActivity"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActivity"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IActivity element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Activity with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Activity");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsReadOnly)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReadOnly", null, XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (!element.IsReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReentrant", null, XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (element.IsSingleExecution)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isSingleExecution", null, XmlConvert.ToString(element.IsSingleExecution));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specification", null, element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Group)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "group", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Partition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "partition", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedBehavior", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.StructuredNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "structuredNode", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/AssociationWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/AssociationWriter.cs
@@ -1,0 +1,516 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AssociationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="AssociationWriter"/> is to write an instance of <see cref="IAssociation"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class AssociationWriter : XmiElementWriter<IAssociation>, IXmiElementWriter<IAssociation>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<AssociationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssociationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public AssociationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<AssociationWriter>.Instance : loggerFactory.CreateLogger<AssociationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IAssociation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAssociation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IAssociation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Association with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Association");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsDerived)
+            {
+                xmlWriter.WriteAttributeString("isDerived", XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.MemberEnd)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "memberEnd", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NavigableOwnedEnd)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "navigableOwnedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedEnd)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IAssociation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAssociation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IAssociation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Association with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Association");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsDerived)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerived", null, XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.MemberEnd)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "memberEnd", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NavigableOwnedEnd)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "navigableOwnedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedEnd)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ClassWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ClassWriter.cs
@@ -1,0 +1,576 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ClassWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ClassWriter"/> is to write an instance of <see cref="IClass"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ClassWriter : XmiElementWriter<IClass>, IXmiElementWriter<IClass>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ClassWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClassWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ClassWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ClassWriter>.Instance : loggerFactory.CreateLogger<ClassWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IClass"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClass"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IClass element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Class with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Class");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IClass"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClass"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IClass element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Class with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Class");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ConnectorWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ConnectorWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConnectorWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ConnectorWriter"/> is to write an instance of <see cref="IConnector"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ConnectorWriter : XmiElementWriter<IConnector>, IXmiElementWriter<IConnector>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ConnectorWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectorWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ConnectorWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ConnectorWriter>.Instance : loggerFactory.CreateLogger<ConnectorWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IConnector"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConnector"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IConnector element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Connector with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Connector");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsStatic)
+            {
+                xmlWriter.WriteAttributeString("isStatic", XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Contract)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "contract", writeContext);
+            }
+
+            foreach (var value in element.End)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "end", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedConnector)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedConnector", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IConnector"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConnector"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IConnector element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Connector with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Connector");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsStatic)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isStatic", null, XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Contract)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "contract", writeContext);
+            }
+
+            foreach (var value in element.End)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "end", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedConnector", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationConstraintWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationConstraintWriter.cs
@@ -1,0 +1,336 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DurationConstraintWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DurationConstraintWriter"/> is to write an instance of <see cref="IDurationConstraint"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DurationConstraintWriter : XmiElementWriter<IDurationConstraint>, IXmiElementWriter<IDurationConstraint>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DurationConstraintWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurationConstraintWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DurationConstraintWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DurationConstraintWriter>.Instance : loggerFactory.CreateLogger<DurationConstraintWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDurationConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDurationConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDurationConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DurationConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationConstraint");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                xmlWriter.WriteAttributeString("context", element.Context.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.FirstEvent)
+            {
+                xmlWriter.WriteElementString("firstEvent", XmlConvert.ToString(value));
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDurationConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDurationConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDurationConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DurationConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationConstraint");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "context", null, element.Context.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.FirstEvent)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "firstEvent", null, XmlConvert.ToString(value));
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationObservationWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationObservationWriter.cs
@@ -1,0 +1,306 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DurationObservationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DurationObservationWriter"/> is to write an instance of <see cref="IDurationObservation"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DurationObservationWriter : XmiElementWriter<IDurationObservation>, IXmiElementWriter<IDurationObservation>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DurationObservationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurationObservationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DurationObservationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DurationObservationWriter>.Instance : loggerFactory.CreateLogger<DurationObservationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDurationObservation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDurationObservation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDurationObservation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DurationObservation with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationObservation");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Event)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "event", writeContext);
+            }
+
+            foreach (var value in element.FirstEvent)
+            {
+                xmlWriter.WriteElementString("firstEvent", XmlConvert.ToString(value));
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDurationObservation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDurationObservation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDurationObservation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DurationObservation with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationObservation");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Event)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "event", writeContext);
+            }
+
+            foreach (var value in element.FirstEvent)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "firstEvent", null, XmlConvert.ToString(value));
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExceptionHandlerWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExceptionHandlerWriter.cs
@@ -1,0 +1,286 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExceptionHandlerWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExceptionHandlerWriter"/> is to write an instance of <see cref="IExceptionHandler"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExceptionHandlerWriter : XmiElementWriter<IExceptionHandler>, IXmiElementWriter<IExceptionHandler>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExceptionHandlerWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExceptionHandlerWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExceptionHandlerWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExceptionHandlerWriter>.Instance : loggerFactory.CreateLogger<ExceptionHandlerWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExceptionHandler"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExceptionHandler"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExceptionHandler element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExceptionHandler with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExceptionHandler");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ExceptionInput != null && writeContext.IsLocal(element.ExceptionInput))
+            {
+                xmlWriter.WriteAttributeString("exceptionInput", element.ExceptionInput.XmiId);
+            }
+
+            if (element.HandlerBody != null && writeContext.IsLocal(element.HandlerBody))
+            {
+                xmlWriter.WriteAttributeString("handlerBody", element.HandlerBody.XmiId);
+            }
+
+            if (element.ProtectedNode != null && writeContext.IsLocal(element.ProtectedNode))
+            {
+                xmlWriter.WriteAttributeString("protectedNode", element.ProtectedNode.XmiId);
+            }
+
+
+            if (element.ExceptionInput != null && !writeContext.IsLocal(element.ExceptionInput))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ExceptionInput, "exceptionInput", writeContext);
+            }
+
+            foreach (var value in element.ExceptionType)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "exceptionType", writeContext);
+            }
+
+            if (element.HandlerBody != null && !writeContext.IsLocal(element.HandlerBody))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.HandlerBody, "handlerBody", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.ProtectedNode != null && !writeContext.IsLocal(element.ProtectedNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ProtectedNode, "protectedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExceptionHandler"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExceptionHandler"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExceptionHandler element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExceptionHandler with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExceptionHandler");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ExceptionInput != null && writeContext.IsLocal(element.ExceptionInput))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "exceptionInput", null, element.ExceptionInput.XmiId);
+            }
+
+            if (element.HandlerBody != null && writeContext.IsLocal(element.HandlerBody))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "handlerBody", null, element.HandlerBody.XmiId);
+            }
+
+            if (element.ProtectedNode != null && writeContext.IsLocal(element.ProtectedNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "protectedNode", null, element.ProtectedNode.XmiId);
+            }
+
+
+            if (element.ExceptionInput != null && !writeContext.IsLocal(element.ExceptionInput))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ExceptionInput, "exceptionInput", writeContext);
+            }
+
+            foreach (var value in element.ExceptionType)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "exceptionType", writeContext);
+            }
+
+            if (element.HandlerBody != null && !writeContext.IsLocal(element.HandlerBody))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.HandlerBody, "handlerBody", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.ProtectedNode != null && !writeContext.IsLocal(element.ProtectedNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ProtectedNode, "protectedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExpressionWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExpressionWriter.cs
@@ -1,0 +1,326 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExpressionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExpressionWriter"/> is to write an instance of <see cref="IExpression"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExpressionWriter : XmiElementWriter<IExpression>, IXmiElementWriter<IExpression>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExpressionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpressionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExpressionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExpressionWriter>.Instance : loggerFactory.CreateLogger<ExpressionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Expression with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Expression");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Symbol))
+            {
+                xmlWriter.WriteAttributeString("symbol", element.Symbol);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Operand)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "operand", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Expression with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Expression");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Symbol))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "symbol", null, element.Symbol);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Operand)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "operand", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/GeneralizationWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/GeneralizationWriter.cs
@@ -1,0 +1,276 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="GeneralizationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="GeneralizationWriter"/> is to write an instance of <see cref="IGeneralization"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class GeneralizationWriter : XmiElementWriter<IGeneralization>, IXmiElementWriter<IGeneralization>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<GeneralizationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GeneralizationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public GeneralizationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<GeneralizationWriter>.Instance : loggerFactory.CreateLogger<GeneralizationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IGeneralization"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IGeneralization"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IGeneralization element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Generalization with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Generalization");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.General != null && writeContext.IsLocal(element.General))
+            {
+                xmlWriter.WriteAttributeString("general", element.General.XmiId);
+            }
+
+            if (!element.IsSubstitutable)
+            {
+                xmlWriter.WriteAttributeString("isSubstitutable", XmlConvert.ToString(element.IsSubstitutable));
+            }
+
+            if (element.Specific != null && writeContext.IsLocal(element.Specific))
+            {
+                xmlWriter.WriteAttributeString("specific", element.Specific.XmiId);
+            }
+
+
+            if (element.General != null && !writeContext.IsLocal(element.General))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.General, "general", writeContext);
+            }
+
+            foreach (var value in element.GeneralizationSet)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "generalizationSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Specific != null && !writeContext.IsLocal(element.Specific))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specific, "specific", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IGeneralization"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IGeneralization"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IGeneralization element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Generalization with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Generalization");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.General != null && writeContext.IsLocal(element.General))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "general", null, element.General.XmiId);
+            }
+
+            if (!element.IsSubstitutable)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isSubstitutable", null, XmlConvert.ToString(element.IsSubstitutable));
+            }
+
+            if (element.Specific != null && writeContext.IsLocal(element.Specific))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specific", null, element.Specific.XmiId);
+            }
+
+
+            if (element.General != null && !writeContext.IsLocal(element.General))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.General, "general", writeContext);
+            }
+
+            foreach (var value in element.GeneralizationSet)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "generalizationSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Specific != null && !writeContext.IsLocal(element.Specific))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specific, "specific", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralIntegerWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralIntegerWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralIntegerWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LiteralIntegerWriter"/> is to write an instance of <see cref="ILiteralInteger"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LiteralIntegerWriter : XmiElementWriter<ILiteralInteger>, IXmiElementWriter<ILiteralInteger>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LiteralIntegerWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiteralIntegerWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LiteralIntegerWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LiteralIntegerWriter>.Instance : loggerFactory.CreateLogger<LiteralIntegerWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILiteralInteger"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralInteger"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILiteralInteger element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralInteger with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralInteger");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Value != 0)
+            {
+                xmlWriter.WriteAttributeString("value", XmlConvert.ToString(element.Value));
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILiteralInteger"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralInteger"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILiteralInteger element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralInteger with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralInteger");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Value != 0)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, XmlConvert.ToString(element.Value));
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralRealWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralRealWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralRealWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LiteralRealWriter"/> is to write an instance of <see cref="ILiteralReal"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LiteralRealWriter : XmiElementWriter<ILiteralReal>, IXmiElementWriter<ILiteralReal>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LiteralRealWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiteralRealWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LiteralRealWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LiteralRealWriter>.Instance : loggerFactory.CreateLogger<LiteralRealWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILiteralReal"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralReal"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILiteralReal element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralReal with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralReal");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Value != 0)
+            {
+                xmlWriter.WriteAttributeString("value", XmlConvert.ToString(element.Value));
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILiteralReal"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralReal"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILiteralReal element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralReal with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralReal");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Value != 0)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, XmlConvert.ToString(element.Value));
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralUnlimitedNaturalWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LiteralUnlimitedNaturalWriter"/> is to write an instance of <see cref="ILiteralUnlimitedNatural"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LiteralUnlimitedNaturalWriter : XmiElementWriter<ILiteralUnlimitedNatural>, IXmiElementWriter<ILiteralUnlimitedNatural>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LiteralUnlimitedNaturalWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiteralUnlimitedNaturalWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LiteralUnlimitedNaturalWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LiteralUnlimitedNaturalWriter>.Instance : loggerFactory.CreateLogger<LiteralUnlimitedNaturalWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILiteralUnlimitedNatural"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralUnlimitedNatural"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILiteralUnlimitedNatural element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralUnlimitedNatural with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralUnlimitedNatural");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Value))
+            {
+                xmlWriter.WriteAttributeString("value", element.Value);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILiteralUnlimitedNatural"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralUnlimitedNatural"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILiteralUnlimitedNatural element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralUnlimitedNatural with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralUnlimitedNatural");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Value))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, element.Value);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/OpaqueExpressionWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/OpaqueExpressionWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OpaqueExpressionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="OpaqueExpressionWriter"/> is to write an instance of <see cref="IOpaqueExpression"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class OpaqueExpressionWriter : XmiElementWriter<IOpaqueExpression>, IXmiElementWriter<IOpaqueExpression>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<OpaqueExpressionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpaqueExpressionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public OpaqueExpressionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<OpaqueExpressionWriter>.Instance : loggerFactory.CreateLogger<OpaqueExpressionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IOpaqueExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOpaqueExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IOpaqueExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OpaqueExpression with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueExpression");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Behavior != null && writeContext.IsLocal(element.Behavior))
+            {
+                xmlWriter.WriteAttributeString("behavior", element.Behavior.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Behavior != null && !writeContext.IsLocal(element.Behavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Behavior, "behavior", writeContext);
+            }
+
+            foreach (var value in element.Body)
+            {
+                xmlWriter.WriteElementString("body", value);
+            }
+
+            foreach (var value in element.Language)
+            {
+                xmlWriter.WriteElementString("language", value);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IOpaqueExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOpaqueExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IOpaqueExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OpaqueExpression with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueExpression");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Behavior != null && writeContext.IsLocal(element.Behavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "behavior", null, element.Behavior.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Behavior != null && !writeContext.IsLocal(element.Behavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Behavior, "behavior", writeContext);
+            }
+
+            foreach (var value in element.Body)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "body", null, value);
+            }
+
+            foreach (var value in element.Language)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "language", null, value);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/PropertyWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/PropertyWriter.cs
@@ -1,0 +1,586 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PropertyWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="PropertyWriter"/> is to write an instance of <see cref="IProperty"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class PropertyWriter : XmiElementWriter<IProperty>, IXmiElementWriter<IProperty>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<PropertyWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public PropertyWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<PropertyWriter>.Instance : loggerFactory.CreateLogger<PropertyWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IProperty"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProperty"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IProperty element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Property with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Property");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Aggregation != AggregationKind.None)
+            {
+                xmlWriter.WriteAttributeString("aggregation", LowerCaseFirstLetter(element.Aggregation.ToString()));
+            }
+
+            if (element.Association != null && writeContext.IsLocal(element.Association))
+            {
+                xmlWriter.WriteAttributeString("association", element.Association.XmiId);
+            }
+
+            if (element.AssociationEnd != null && writeContext.IsLocal(element.AssociationEnd))
+            {
+                xmlWriter.WriteAttributeString("associationEnd", element.AssociationEnd.XmiId);
+            }
+
+            if (element.Class != null && writeContext.IsLocal(element.Class))
+            {
+                xmlWriter.WriteAttributeString("class", element.Class.XmiId);
+            }
+
+            if (element.Datatype != null && writeContext.IsLocal(element.Datatype))
+            {
+                xmlWriter.WriteAttributeString("datatype", element.Datatype.XmiId);
+            }
+
+            if (element.Interface != null && writeContext.IsLocal(element.Interface))
+            {
+                xmlWriter.WriteAttributeString("interface", element.Interface.XmiId);
+            }
+
+            if (element.IsDerived)
+            {
+                xmlWriter.WriteAttributeString("isDerived", XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsDerivedUnion)
+            {
+                xmlWriter.WriteAttributeString("isDerivedUnion", XmlConvert.ToString(element.IsDerivedUnion));
+            }
+
+            if (element.IsID)
+            {
+                xmlWriter.WriteAttributeString("isID", XmlConvert.ToString(element.IsID));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (element.IsReadOnly)
+            {
+                xmlWriter.WriteAttributeString("isReadOnly", XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (element.IsStatic)
+            {
+                xmlWriter.WriteAttributeString("isStatic", XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningAssociation != null && writeContext.IsLocal(element.OwningAssociation))
+            {
+                xmlWriter.WriteAttributeString("owningAssociation", element.OwningAssociation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Association != null && !writeContext.IsLocal(element.Association))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Association, "association", writeContext);
+            }
+
+            if (element.AssociationEnd != null && !writeContext.IsLocal(element.AssociationEnd))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.AssociationEnd, "associationEnd", writeContext);
+            }
+
+            if (element.Class != null && !writeContext.IsLocal(element.Class))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Class, "class", writeContext);
+            }
+
+            if (element.Datatype != null && !writeContext.IsLocal(element.Datatype))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Datatype, "datatype", writeContext);
+            }
+
+            foreach (var value in element.DefaultValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "defaultValue", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deployment", writeContext);
+            }
+
+            if (element.Interface != null && !writeContext.IsLocal(element.Interface))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Interface, "interface", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningAssociation != null && !writeContext.IsLocal(element.OwningAssociation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningAssociation, "owningAssociation", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedProperty)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedProperty", writeContext);
+            }
+
+            foreach (var value in element.SubsettedProperty)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "subsettedProperty", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IProperty"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProperty"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IProperty element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Property with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Property");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Aggregation != AggregationKind.None)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "aggregation", null, LowerCaseFirstLetter(element.Aggregation.ToString()));
+            }
+
+            if (element.Association != null && writeContext.IsLocal(element.Association))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "association", null, element.Association.XmiId);
+            }
+
+            if (element.AssociationEnd != null && writeContext.IsLocal(element.AssociationEnd))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "associationEnd", null, element.AssociationEnd.XmiId);
+            }
+
+            if (element.Class != null && writeContext.IsLocal(element.Class))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "class", null, element.Class.XmiId);
+            }
+
+            if (element.Datatype != null && writeContext.IsLocal(element.Datatype))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "datatype", null, element.Datatype.XmiId);
+            }
+
+            if (element.Interface != null && writeContext.IsLocal(element.Interface))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interface", null, element.Interface.XmiId);
+            }
+
+            if (element.IsDerived)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerived", null, XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsDerivedUnion)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerivedUnion", null, XmlConvert.ToString(element.IsDerivedUnion));
+            }
+
+            if (element.IsID)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isID", null, XmlConvert.ToString(element.IsID));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (element.IsReadOnly)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReadOnly", null, XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (element.IsStatic)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isStatic", null, XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningAssociation != null && writeContext.IsLocal(element.OwningAssociation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningAssociation", null, element.OwningAssociation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Association != null && !writeContext.IsLocal(element.Association))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Association, "association", writeContext);
+            }
+
+            if (element.AssociationEnd != null && !writeContext.IsLocal(element.AssociationEnd))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.AssociationEnd, "associationEnd", writeContext);
+            }
+
+            if (element.Class != null && !writeContext.IsLocal(element.Class))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Class, "class", writeContext);
+            }
+
+            if (element.Datatype != null && !writeContext.IsLocal(element.Datatype))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Datatype, "datatype", writeContext);
+            }
+
+            foreach (var value in element.DefaultValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "defaultValue", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deployment", writeContext);
+            }
+
+            if (element.Interface != null && !writeContext.IsLocal(element.Interface))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Interface, "interface", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningAssociation != null && !writeContext.IsLocal(element.OwningAssociation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningAssociation, "owningAssociation", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedProperty)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedProperty", writeContext);
+            }
+
+            foreach (var value in element.SubsettedProperty)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "subsettedProperty", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/StateMachineWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/StateMachineWriter.cs
@@ -1,0 +1,686 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StateMachineWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="StateMachineWriter"/> is to write an instance of <see cref="IStateMachine"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class StateMachineWriter : XmiElementWriter<IStateMachine>, IXmiElementWriter<IStateMachine>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<StateMachineWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StateMachineWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public StateMachineWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<StateMachineWriter>.Instance : loggerFactory.CreateLogger<StateMachineWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IStateMachine"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStateMachine"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IStateMachine element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StateMachine with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateMachine");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                xmlWriter.WriteAttributeString("isReentrant", XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                xmlWriter.WriteAttributeString("specification", element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ConnectionPoint)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "connectionPoint", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.ExtendedStateMachine)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "extendedStateMachine", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            foreach (var value in element.Region)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "region", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.SubmachineState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "submachineState", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IStateMachine"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStateMachine"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IStateMachine element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StateMachine with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateMachine");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReentrant", null, XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specification", null, element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ConnectionPoint)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "connectionPoint", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.ExtendedStateMachine)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "extendedStateMachine", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            foreach (var value in element.Region)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "region", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.SubmachineState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "submachineState", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/TimeConstraintWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/TimeConstraintWriter.cs
@@ -1,0 +1,336 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TimeConstraintWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TimeConstraintWriter"/> is to write an instance of <see cref="ITimeConstraint"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TimeConstraintWriter : XmiElementWriter<ITimeConstraint>, IXmiElementWriter<ITimeConstraint>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TimeConstraintWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeConstraintWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TimeConstraintWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TimeConstraintWriter>.Instance : loggerFactory.CreateLogger<TimeConstraintWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITimeConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITimeConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeConstraint");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                xmlWriter.WriteAttributeString("context", element.Context.XmiId);
+            }
+
+            if (!element.FirstEvent)
+            {
+                xmlWriter.WriteAttributeString("firstEvent", XmlConvert.ToString(element.FirstEvent));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITimeConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITimeConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeConstraint");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "context", null, element.Context.XmiId);
+            }
+
+            if (!element.FirstEvent)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "firstEvent", null, XmlConvert.ToString(element.FirstEvent));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator.Tests/Generators/XmiWriterGeneratorTestFixture.cs
+++ b/uml4net.CodeGenerator.Tests/Generators/XmiWriterGeneratorTestFixture.cs
@@ -1,0 +1,146 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiWriterGeneratorTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.CodeGenerator.Tests.Generators
+{
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Microsoft.Extensions.Logging;
+
+    using NUnit.Framework;
+
+    using Serilog;
+
+    using uml4net.CodeGenerator.Generators;
+    using uml4net.CodeGenerator.Transformers;
+    using uml4net.Extensions;
+    using uml4net.StructuredClassifiers;
+    using uml4net.xmi;
+    using uml4net.xmi.Readers;
+
+    [TestFixture]
+    public class XmiWriterGeneratorTestFixture
+    {
+        private DirectoryInfo xmiWriterDirectoryInfo;
+
+        private XmiWriterGenerator xmiWriterGenerator;
+
+        private XmiReaderResult xmiReaderResult;
+
+        private ILoggerFactory loggerFactory;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.Console()
+                .CreateLogger();
+
+            this.loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddSerilog();
+            });
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            var rootPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData");
+
+            var reader = XmiReaderBuilder.Create()
+                .UsingSettings(x => x.LocalReferenceBasePath = rootPath)
+                .WithLogger(this.loggerFactory)
+                .Build();
+
+            this.xmiReaderResult = reader.Read(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "UML.xmi"));
+
+            var modelTransformer = new ModelTransformer(loggerFactory);
+            modelTransformer.TryTransform(this.xmiReaderResult, "_0", "UML", out var updatedElements);
+
+            var directoryInfo = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+
+            this.xmiWriterDirectoryInfo = directoryInfo.CreateSubdirectory("_uml4net.xmi.AutoGenWriters");
+
+            this.xmiWriterGenerator = new XmiWriterGenerator();
+        }
+
+        [Test]
+        public async Task Verify_that_concrete_classes_are_generated([Values(
+            "Activity","Association",
+            "Class", "Connector",
+            "DurationConstraint", "DurationObservation",
+            "ExceptionHandler", "Expression",
+            "Generalization",
+            "LiteralInteger","LiteralReal","LiteralUnlimitedNatural",
+            "OpaqueExpression",
+            "Property",
+            "StateMachine",
+            "TimeConstraint")] string className)
+        {
+            var root = this.xmiReaderResult.QueryRoot(xmiId:"_0", name: "UML");
+
+            var classes = root.QueryPackages()
+                .SelectMany(x => x.PackagedElement.OfType<IClass>())
+                .Where(x => !x.IsAbstract)
+                .ToList();
+
+            var @class = classes.Single(x => x.Name == className);
+
+            var generatedCode = await this.xmiWriterGenerator.GenerateXmiWriterAsync(this.xmiWriterDirectoryInfo, @class);
+
+            var expected = await File.ReadAllTextAsync(Path.Combine(TestContext.CurrentContext.TestDirectory, $"Expected/AutoGenXmiWriters/{className}Writer.cs"));
+
+            Assert.That(generatedCode, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Verify_that_concrete_xmi_writer_classes_are_generated()
+        {
+            Assert.That(async () => await this.xmiWriterGenerator.GenerateAsync(xmiReaderResult, "_0", "UML", this.xmiWriterDirectoryInfo),
+                Throws.Nothing);
+        }
+
+        [Test]
+        public void Verify_that_GenerateXmiElementWriterFacade_is_generated()
+        {
+            Assert.That(async () => await this.xmiWriterGenerator.GenerateXmiElementWriterFacadeAsync(xmiReaderResult, "_0", "UML", this.xmiWriterDirectoryInfo),
+                Throws.Nothing);
+        }
+
+        [Test]
+        [Explicit("Regenerates the AutoGenXmiWriters of the uml4net.xmi project - the production code")]
+        public async Task Regenerate_AutoGenXmiWriters_of_uml4net_xmi()
+        {
+            var solutionDirectory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory)
+                .Parent.Parent.Parent.Parent;
+
+            var autoGenXmiWritersDirectory = new DirectoryInfo(Path.Combine(solutionDirectory.FullName, "uml4net.xmi", "AutoGenXmiWriters"));
+
+            Assert.That(autoGenXmiWritersDirectory.Exists, Is.True, $"the {autoGenXmiWritersDirectory.FullName} directory does not exist");
+
+            await this.xmiWriterGenerator.GenerateAsync(this.xmiReaderResult, "_0", "UML", autoGenXmiWritersDirectory);
+
+            await this.xmiWriterGenerator.GenerateXmiElementWriterFacadeAsync(this.xmiReaderResult, "_0", "UML", autoGenXmiWritersDirectory);
+        }
+    }
+}

--- a/uml4net.CodeGenerator.Tests/uml4net.CodeGenerator.Tests.csproj
+++ b/uml4net.CodeGenerator.Tests/uml4net.CodeGenerator.Tests.csproj
@@ -63,6 +63,13 @@
       <Compile Remove="Expected\AutoGenXmiReaders\PropertyReader.cs" />
       <Compile Remove="Expected\AutoGenXmiReaders\StateMachineReader.cs" />
       <Compile Remove="Expected\AutoGenXmiReaders\TimeConstraintReader.cs" />
+      <Compile Remove="Expected\AutoGenXmiWriters\**\*.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="Expected\AutoGenXmiWriters\**\*.cs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/uml4net.CodeGenerator/Generators/XmiWriterGenerator.cs
+++ b/uml4net.CodeGenerator/Generators/XmiWriterGenerator.cs
@@ -1,0 +1,178 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiWriterGenerator.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.CodeGenerator.Generators
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using uml4net.Extensions;
+    using uml4net.StructuredClassifiers;
+    using uml4net.xmi.Readers;
+
+    /// <summary>
+    /// A Handlebars based xmi-writer code generator
+    /// </summary>
+    public class XmiWriterGenerator : UmlHandleBarsGenerator
+    {
+        /// <summary>
+        /// Generates the XmiWriter classes based on the <see cref="IClass"/> instances
+        /// that are in the provided <see cref="XmiReaderResult"/>
+        /// </summary>
+        /// <param name="xmiReaderResult">
+        /// the <see cref="XmiReaderResult"/> that contains the UML model to generate from
+        /// </param>
+        /// <param name="rootPackageXmiId">
+        /// the unique identifier of the root package to report in
+        /// </param>
+        /// <param name="rootPackageName">
+        /// the name of the root package to report in
+        /// </param>
+        /// <param name="outputDirectory">
+        /// The target <see cref="DirectoryInfo"/>
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task GenerateAsync(XmiReaderResult xmiReaderResult, string rootPackageXmiId, string rootPackageName, DirectoryInfo outputDirectory)
+        {
+            ArgumentNullException.ThrowIfNull(xmiReaderResult);
+
+            ArgumentNullException.ThrowIfNull(outputDirectory);
+
+            var root = xmiReaderResult.QueryRoot(rootPackageXmiId, rootPackageName);
+
+            var classes = root.QueryPackages()
+                .SelectMany(x => x.PackagedElement.OfType<IClass>())
+                .Where(x => !x.IsAbstract)
+                .ToList();
+
+            foreach (var cls in classes)
+            {
+                await this.GenerateXmiWriterAsync(outputDirectory, cls);
+            }
+        }
+
+        /// <summary>
+        /// Generates the Xmi Writer class for a concrete class
+        /// </summary>
+        /// <param name="outputDirectory">
+        /// The target <see cref="DirectoryInfo"/>
+        /// </param>
+        /// <param name="class">
+        /// The <see cref="IClass"/> for which the XmiWriter is to be generated
+        /// </param>
+        /// <returns>
+        /// a string representation of the generated code
+        /// </returns>
+        public async Task<string> GenerateXmiWriterAsync(DirectoryInfo outputDirectory, IClass @class)
+        {
+            ArgumentNullException.ThrowIfNull(outputDirectory);
+
+            ArgumentNullException.ThrowIfNull(@class);
+
+            var template = this.Templates["xmi-writer-template"];
+
+            if (@class.IsAbstract)
+            {
+                throw new InvalidOperationException("XmiWriter should not be abstract");
+            }
+
+            var generatedCode = template(@class);
+
+            generatedCode = this.CodeCleanup(generatedCode);
+
+            var fileName = $"{@class.Name}Writer.cs";
+
+            await WriteAsync(generatedCode, outputDirectory, fileName);
+
+            return generatedCode;
+        }
+
+        /// <summary>
+        /// Generates the XmiElementWriterFacade based on the <see cref="IClass"/> instances
+        /// that are in the provided <see cref="XmiReaderResult"/>
+        /// </summary>
+        /// <param name="xmiReaderResult">
+        /// the <see cref="XmiReaderResult"/> that contains the UML model to generate from
+        /// </param>
+        /// <param name="rootPackageXmiId">
+        /// the unique identifier of the root package to report in
+        /// </param>
+        /// <param name="rootPackageName">
+        /// the name of the root package to report in
+        /// </param>
+        /// <param name="outputDirectory">
+        /// The target <see cref="DirectoryInfo"/>
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task GenerateXmiElementWriterFacadeAsync(XmiReaderResult xmiReaderResult, string rootPackageXmiId, string rootPackageName, DirectoryInfo outputDirectory)
+        {
+            ArgumentNullException.ThrowIfNull(xmiReaderResult);
+
+            ArgumentNullException.ThrowIfNull(outputDirectory);
+
+            var root = xmiReaderResult.QueryRoot(rootPackageXmiId, rootPackageName);
+
+            var classes = root.QueryPackages()
+                .SelectMany(x => x.PackagedElement.OfType<IClass>())
+                .Where(x => !x.IsAbstract)
+                .ToList();
+
+            var template = this.Templates["XmiElementWriterFacade-template"];
+
+            var generatedCode = template(classes);
+
+            generatedCode = this.CodeCleanup(generatedCode);
+
+            const string fileName = "XmiElementWriterFacade.cs";
+
+            await WriteAsync(generatedCode, outputDirectory, fileName);
+        }
+
+        /// <summary>
+        /// Register the custom helpers
+        /// </summary>
+        protected override void RegisterHelpers()
+        {
+            uml4net.HandleBars.StringHelper.RegisterStringHelper(this.Handlebars);
+            uml4net.HandleBars.IEnumerableHelper.RegisterEnumerableHelper(this.Handlebars);
+            uml4net.HandleBars.ClassHelper.RegisterClassHelper(this.Handlebars);
+            uml4net.HandleBars.PropertyHelper.RegisterPropertyHelper(this.Handlebars);
+            uml4net.HandleBars.GeneralizationHelper.RegisterGeneralizationHelper(this.Handlebars);
+            uml4net.HandleBars.DocumentationHelper.RegisterDocumentationHelper(this.Handlebars);
+            uml4net.HandleBars.EnumHelper.RegisterEnumHelper(this.Handlebars);
+            uml4net.HandleBars.DecoratorHelper.RegisterDecoratorHelper(this.Handlebars);
+        }
+
+        /// <summary>
+        /// Register the handlebars templates
+        /// </summary>
+        protected override void RegisterTemplates()
+        {
+            this.RegisterTemplate("xmi-writer-template");
+            this.RegisterTemplate("XmiElementWriterFacade-template");
+        }
+    }
+}

--- a/uml4net.CodeGenerator/Templates/XmiElementWriterFacade-template.hbs
+++ b/uml4net.CodeGenerator/Templates/XmiElementWriterFacade-template.hbs
@@ -1,0 +1,393 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiElementWriterFacade.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="XmiElementWriterFacade"/> is to write an <see cref="IXmiElement"/> to an
+    /// <see cref="XmlWriter"/> using the appropriate <see cref="IXmiElementWriter{TXmiElement}"/> based on the
+    /// concrete type of the <see cref="IXmiElement"/>
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class XmiElementWriterFacade : IXmiElementWriterFacade
+    {
+        /// <summary>
+        /// The injected <see cref="IXmiWriterSettings" /> that provides XMI writer settings
+        /// </summary>
+        private readonly IXmiWriterSettings xmiWriterSettings;
+
+        /// <summary>
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </summary>
+        private readonly ILoggerFactory loggerFactory;
+
+        /// <summary>
+        /// A dictionary that contains delegates to write an <see cref="IXmiElement"/> based on the name of
+        /// the concrete type of the <see cref="IXmiElement"/>
+        /// </summary>
+        private readonly Dictionary<string, Action<XmlWriter, IXmiElement, string, IXmiWriteContext>> writerCache;
+
+        /// <summary>
+        /// A dictionary that contains delegates to asynchronously write an <see cref="IXmiElement"/> based on the name of
+        /// the concrete type of the <see cref="IXmiElement"/>
+        /// </summary>
+        private readonly Dictionary<string, Func<XmlWriter, IXmiElement, string, IXmiWriteContext, Task>> writerAsyncCache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmiElementWriterFacade"/> class.
+        /// </summary>
+        /// <param name="xmiWriterSettings">
+        /// The injected <see cref="IXmiWriterSettings" /> that provides XMI writer settings
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public XmiElementWriterFacade(IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+        {
+            this.xmiWriterSettings = xmiWriterSettings;
+            this.loggerFactory = loggerFactory;
+
+            this.writerCache = new Dictionary<string, Action<XmlWriter, IXmiElement, string, IXmiWriteContext>>
+            {
+                {{ #each this as | class | }}
+                ["{{ class.Name }}"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var {{ String.LowerCaseFirstLetter class.Name }}Writer = new {{ class.Name }}Writer(this, this.xmiWriterSettings, this.loggerFactory);
+                    {{ String.LowerCaseFirstLetter class.Name }}Writer.Write(xmlWriter, (I{{ class.Name }})element, elementName, writeContext);
+                },
+                {{/each}}
+            };
+
+            this.writerAsyncCache = new Dictionary<string, Func<XmlWriter, IXmiElement, string, IXmiWriteContext, Task>>
+            {
+                {{ #each this as | class | }}
+                ["{{ class.Name }}"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var {{ String.LowerCaseFirstLetter class.Name }}Writer = new {{ class.Name }}Writer(this, this.xmiWriterSettings, this.loggerFactory);
+                    return {{ String.LowerCaseFirstLetter class.Name }}Writer.WriteAsync(xmlWriter, (I{{ class.Name }})element, elementName, writeContext);
+                },
+                {{/each}}
+            };
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> using the appropriate
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> based on the concrete type of the <see cref="IXmiElement"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// thrown when the concrete type of the <see cref="IXmiElement"/> is not supported and no
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> was found
+        /// </exception>
+        public void Write(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            var typeName = element.GetType().Name;
+
+            if (!this.writerCache.TryGetValue(typeName, out var writer))
+            {
+                throw new InvalidOperationException($"No writer found for type {typeName}");
+            }
+
+            writer(xmlWriter, element, elementName, writeContext);
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a contained element. When
+        /// the <see cref="IXmiElement"/> is not part of the document that is being written, an href reference element
+        /// is written instead.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public void WriteContainedElement(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (writeContext.IsLocal(element))
+            {
+                this.Write(xmlWriter, element, elementName, writeContext);
+            }
+            else
+            {
+                this.WriteHrefElement(xmlWriter, element, elementName, writeContext);
+            }
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a reference element. When the
+        /// <see cref="IXmiElement"/> is part of the document that is being written an xmi:idref element is written,
+        /// otherwise an href reference element is written.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is referenced
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public void WriteReferenceElement(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (writeContext.IsLocal(element))
+            {
+                xmlWriter.WriteStartElement(elementName);
+                xmlWriter.WriteAttributeString("xmi", "idref", this.xmiWriterSettings.XmiNamespaceUri, element.XmiId);
+                xmlWriter.WriteEndElement();
+            }
+            else
+            {
+                this.WriteHrefElement(xmlWriter, element, elementName, writeContext);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> using the appropriate
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> based on the concrete type of the <see cref="IXmiElement"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// thrown when the concrete type of the <see cref="IXmiElement"/> is not supported and no
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> was found
+        /// </exception>
+        public Task WriteAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            var typeName = element.GetType().Name;
+
+            if (!this.writerAsyncCache.TryGetValue(typeName, out var writer))
+            {
+                throw new InvalidOperationException($"No writer found for type {typeName}");
+            }
+
+            return writer(xmlWriter, element, elementName, writeContext);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a contained element. When
+        /// the <see cref="IXmiElement"/> is not part of the document that is being written, an href reference element
+        /// is written instead.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public Task WriteContainedElementAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (writeContext.IsLocal(element))
+            {
+                return this.WriteAsync(xmlWriter, element, elementName, writeContext);
+            }
+
+            return this.WriteHrefElementAsync(xmlWriter, element, elementName, writeContext);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a reference element. When the
+        /// <see cref="IXmiElement"/> is part of the document that is being written an xmi:idref element is written,
+        /// otherwise an href reference element is written.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is referenced
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task WriteReferenceElementAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (writeContext.IsLocal(element))
+            {
+                await xmlWriter.WriteStartElementAsync(null, elementName, null);
+                await xmlWriter.WriteAttributeStringAsync("xmi", "idref", this.xmiWriterSettings.XmiNamespaceUri, element.XmiId);
+                await xmlWriter.WriteEndElementAsync();
+            }
+            else
+            {
+                await this.WriteHrefElementAsync(xmlWriter, element, elementName, writeContext);
+            }
+        }
+
+        /// <summary>
+        /// Writes an href reference element for the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is referenced
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        private void WriteHrefElement(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            xmlWriter.WriteStartElement(elementName);
+            xmlWriter.WriteAttributeString("xmi", "type", this.xmiWriterSettings.XmiNamespaceUri, $"uml:{element.GetType().Name}");
+            xmlWriter.WriteAttributeString("href", writeContext.QueryHref(element));
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes an href reference element for the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is referenced
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        private async Task WriteHrefElementAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            await xmlWriter.WriteStartElementAsync(null, elementName, null);
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.xmiWriterSettings.XmiNamespaceUri, $"uml:{element.GetType().Name}");
+            await xmlWriter.WriteAttributeStringAsync(null, "href", null, writeContext.QueryHref(element));
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator/Templates/xmi-writer-template.hbs
+++ b/uml4net.CodeGenerator/Templates/xmi-writer-template.hbs
@@ -1,0 +1,218 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="{{this.Name}}Writer.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="{{this.Name}}Writer"/> is to write an instance of <see cref="I{{this.Name}}"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class {{this.Name}}Writer : XmiElementWriter<I{{this.Name}}>, IXmiElementWriter<I{{this.Name}}>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<{{this.Name}}Writer> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="{{this.Name}}Writer"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public {{this.Name}}Writer(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<{{this.Name}}Writer>.Instance : loggerFactory.CreateLogger<{{this.Name}}Writer>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="I{{this.Name}}"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="I{{this.Name}}"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, I{{this.Name}} element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the {{this.Name}} with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:{{this.Name}}");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            {{ #each (Class.QueryAllNonDerivedNonReadOnlyProperties this) as | property | }}
+            {{ #Property.WriteXmlAttributeForXmiWriter property ../ }}
+            {{/each}}
+
+            {{ #each (Class.QueryAllNonDerivedNonReadOnlyProperties this) as | property | }}
+            {{ #Property.WriteXmlElementForXmiWriter property ../ }}
+            {{/each}}
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="I{{this.Name}}"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="I{{this.Name}}"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, I{{this.Name}} element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the {{this.Name}} with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:{{this.Name}}");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            {{ #each (Class.QueryAllNonDerivedNonReadOnlyProperties this) as | property | }}
+            {{ #Property.WriteXmlAttributeForXmiWriter property ../ true }}
+            {{/each}}
+
+            {{ #each (Class.QueryAllNonDerivedNonReadOnlyProperties this) as | property | }}
+            {{ #Property.WriteXmlElementForXmiWriter property ../ true }}
+            {{/each}}
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.CodeGenerator/uml4net.CodeGenerator.csproj
+++ b/uml4net.CodeGenerator/uml4net.CodeGenerator.csproj
@@ -49,6 +49,12 @@
       <None Update="Templates\XmiElementReaderFacade-template.hbs">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
+      <None Update="Templates\xmi-writer-template.hbs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <None Update="Templates\XmiElementWriterFacade-template.hbs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
       <None Update="Templates\extension-core-poco-class-template.hbs">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>

--- a/uml4net.HandleBars.Tests/PropertyHelperTestFixture.cs
+++ b/uml4net.HandleBars.Tests/PropertyHelperTestFixture.cs
@@ -33,6 +33,7 @@ namespace uml4net.HandleBars.Tests
 
     using uml4net.Activities;
     using uml4net.Classification;
+    using uml4net.Extensions;
     using uml4net.StructuredClassifiers;
     using uml4net.xmi;
     using uml4net.xmi.Readers;
@@ -98,6 +99,231 @@ namespace uml4net.HandleBars.Tests
             Assert.That(activityEdgeProperty, Is.EqualTo("public IContainerList<IActivityEdge> Edge { get; set; }" + Environment.NewLine));
 
             Assert.That(() => handlebarsTemplate(new Dependency()), Throws.ArgumentException);
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlAttributeForXmiWriter_writes_bool_property_as_expected()
+        {
+            var template = "{{ #Property.WriteXmlAttributeForXmiWriter this.Property this.Class }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Class");
+
+            var isAbstract = @class.QueryAllProperties().Single(x => x.XmiId == "Class-isAbstract");
+
+            var generatedCode = handlebarsTemplate(new { Property = isAbstract, Class = @class });
+
+            Assert.That(generatedCode, Does.Contain("if (element.IsAbstract)"));
+            Assert.That(generatedCode, Does.Contain("xmlWriter.WriteAttributeString(\"isAbstract\", XmlConvert.ToString(element.IsAbstract));"));
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlAttributeForXmiWriter_writes_string_property_as_expected()
+        {
+            var template = "{{ #Property.WriteXmlAttributeForXmiWriter this.Property this.Class }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Class");
+
+            var name = @class.QueryAllProperties().Single(x => x.XmiId == "NamedElement-name");
+
+            var generatedCode = handlebarsTemplate(new { Property = name, Class = @class });
+
+            Assert.That(generatedCode, Does.Contain("if (!string.IsNullOrEmpty(element.Name))"));
+            Assert.That(generatedCode, Does.Contain("xmlWriter.WriteAttributeString(\"name\", element.Name);"));
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlAttributeForXmiWriter_writes_enum_property_with_default_as_expected()
+        {
+            var template = "{{ #Property.WriteXmlAttributeForXmiWriter this.Property this.Class }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Class");
+
+            var visibility = @class.QueryAllProperties().Single(x => x.XmiId == "PackageableElement-visibility");
+
+            var generatedCode = handlebarsTemplate(new { Property = visibility, Class = @class });
+
+            Assert.That(generatedCode, Does.Contain("if (element.Visibility != VisibilityKind.Public)"));
+            Assert.That(generatedCode, Does.Contain("xmlWriter.WriteAttributeString(\"visibility\", LowerCaseFirstLetter(element.Visibility.ToString()));"));
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlAttributeForXmiWriter_skips_redefined_and_composite_properties()
+        {
+            var template = "{{ #Property.WriteXmlAttributeForXmiWriter this.Property this.Class }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Class");
+
+            var redefinedVisibility = @class.QueryAllProperties().Single(x => x.XmiId == "NamedElement-visibility");
+
+            Assert.That(handlebarsTemplate(new { Property = redefinedVisibility, Class = @class }), Is.Empty);
+
+            var ownedAttribute = @class.QueryAllProperties().Single(x => x.XmiId == "StructuredClassifier-ownedAttribute");
+
+            Assert.That(handlebarsTemplate(new { Property = ownedAttribute, Class = @class }), Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlAttributeForXmiWriter_writes_single_valued_reference_as_expected()
+        {
+            var template = "{{ #Property.WriteXmlAttributeForXmiWriter this.Property this.Class }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Association");
+
+            var owningTemplateParameter = @class.QueryAllProperties().Single(x => x.XmiId == "ParameterableElement-owningTemplateParameter");
+
+            var generatedCode = handlebarsTemplate(new { Property = owningTemplateParameter, Class = @class });
+
+            Assert.That(generatedCode, Does.Contain("if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))"));
+            Assert.That(generatedCode, Does.Contain("xmlWriter.WriteAttributeString(\"owningTemplateParameter\", element.OwningTemplateParameter.XmiId);"));
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlAttributeForXmiWriter_writes_async_variant_as_expected()
+        {
+            var template = "{{ #Property.WriteXmlAttributeForXmiWriter this.Property this.Class true }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Class");
+
+            var name = @class.QueryAllProperties().Single(x => x.XmiId == "NamedElement-name");
+
+            var generatedCode = handlebarsTemplate(new { Property = name, Class = @class });
+
+            Assert.That(generatedCode, Does.Contain("await xmlWriter.WriteAttributeStringAsync(null, \"name\", null, element.Name);"));
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlElementForXmiWriter_writes_contained_property_as_expected()
+        {
+            var template = "{{ #Property.WriteXmlElementForXmiWriter this.Property this.Class }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Class");
+
+            var ownedComment = @class.QueryAllProperties().Single(x => x.XmiId == "Element-ownedComment");
+
+            var generatedCode = handlebarsTemplate(new { Property = ownedComment, Class = @class });
+
+            Assert.That(generatedCode, Does.Contain("foreach (var value in element.OwnedComment)"));
+            Assert.That(generatedCode, Does.Contain("this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, \"ownedComment\", writeContext);"));
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlElementForXmiWriter_writes_composite_with_non_derived_subsets_as_reference()
+        {
+            var template = "{{ #Property.WriteXmlElementForXmiWriter this.Property this.Class }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("Activities", "Activity");
+
+            var postcondition = @class.QueryAllProperties().Single(x => x.XmiId == "Behavior-postcondition");
+
+            var generatedCode = handlebarsTemplate(new { Property = postcondition, Class = @class });
+
+            Assert.That(generatedCode, Does.Contain("foreach (var value in element.Postcondition)"));
+            Assert.That(generatedCode, Does.Contain("this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, \"postcondition\", writeContext);"));
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlElementForXmiWriter_writes_multi_valued_reference_as_expected()
+        {
+            var template = "{{ #Property.WriteXmlElementForXmiWriter this.Property this.Class }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Association");
+
+            var navigableOwnedEnd = @class.QueryAllProperties().Single(x => x.XmiId == "Association-navigableOwnedEnd");
+
+            var generatedCode = handlebarsTemplate(new { Property = navigableOwnedEnd, Class = @class });
+
+            Assert.That(generatedCode, Does.Contain("foreach (var value in element.NavigableOwnedEnd)"));
+            Assert.That(generatedCode, Does.Contain("this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, \"navigableOwnedEnd\", writeContext);"));
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlElementForXmiWriter_writes_single_valued_reference_href_fallback_as_expected()
+        {
+            var template = "{{ #Property.WriteXmlElementForXmiWriter this.Property this.Class }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Association");
+
+            var owningTemplateParameter = @class.QueryAllProperties().Single(x => x.XmiId == "ParameterableElement-owningTemplateParameter");
+
+            var generatedCode = handlebarsTemplate(new { Property = owningTemplateParameter, Class = @class });
+
+            Assert.That(generatedCode, Does.Contain("if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))"));
+            Assert.That(generatedCode, Does.Contain("this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, \"owningTemplateParameter\", writeContext);"));
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlElementForXmiWriter_skips_scalar_primitives_and_enums()
+        {
+            var template = "{{ #Property.WriteXmlElementForXmiWriter this.Property this.Class }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Class");
+
+            var name = @class.QueryAllProperties().Single(x => x.XmiId == "NamedElement-name");
+
+            Assert.That(handlebarsTemplate(new { Property = name, Class = @class }), Is.Empty);
+
+            var visibility = @class.QueryAllProperties().Single(x => x.XmiId == "PackageableElement-visibility");
+
+            Assert.That(handlebarsTemplate(new { Property = visibility, Class = @class }), Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_WriteXmlElementForXmiWriter_writes_async_variant_as_expected()
+        {
+            var template = "{{ #Property.WriteXmlElementForXmiWriter this.Property this.Class true }}";
+
+            var handlebarsTemplate = this.handlebarsContext.Compile(template);
+
+            var @class = this.QueryClass("StructuredClassifiers", "Class");
+
+            var ownedComment = @class.QueryAllProperties().Single(x => x.XmiId == "Element-ownedComment");
+
+            var generatedCode = handlebarsTemplate(new { Property = ownedComment, Class = @class });
+
+            Assert.That(generatedCode, Does.Contain("await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, \"ownedComment\", writeContext);"));
+        }
+
+        /// <summary>
+        /// Queries a <see cref="IClass"/> from the UML metamodel that is used as test input
+        /// </summary>
+        /// <param name="packageName">
+        /// The name of the package that contains the <see cref="IClass"/>
+        /// </param>
+        /// <param name="className">
+        /// The name of the <see cref="IClass"/>
+        /// </param>
+        /// <returns>
+        /// the queried <see cref="IClass"/>
+        /// </returns>
+        private IClass QueryClass(string packageName, string className)
+        {
+            var root = this.xmiReaderResult.QueryRoot(xmiId: "_0", name: "UML");
+
+            var package = root.NestedPackage.Single(x => x.Name == packageName);
+
+            return package.PackagedElement.OfType<IClass>().Single(x => x.Name == className);
         }
     }
 }

--- a/uml4net.HandleBars/PropertyHelper.cs
+++ b/uml4net.HandleBars/PropertyHelper.cs
@@ -40,6 +40,11 @@ namespace uml4net.HandleBars
     public static class PropertyHelper
     {
         /// <summary>
+        /// The message used when the parameters of a helper could not be converted to an <see cref="IProperty"/> and an <see cref="IClass"/>
+        /// </summary>
+        private const string ParametersNotConvertibleToPropertyAndClass = "the parameters could not be converted to a IProperty and IClass";
+
+        /// <summary>
         /// Registers the <see cref="PropertyHelper"/>
         /// </summary>
         /// <param name="handlebars">
@@ -643,7 +648,7 @@ namespace uml4net.HandleBars
 
                 if (property == null || @class == null)
                 {
-                    throw new ArgumentException("the parameters could not be converted to a IProperty and IClass");
+                    throw new ArgumentException(ParametersNotConvertibleToPropertyAndClass);
                 }
 
                 if (property.IsDerived || property.IsDerivedUnion || property.IsReadOnly)
@@ -798,7 +803,7 @@ namespace uml4net.HandleBars
 
                 if (property == null || @class == null)
                 {
-                    throw new ArgumentException("the parameters could not be converted to a IProperty and IClass");
+                    throw new ArgumentException(ParametersNotConvertibleToPropertyAndClass);
                 }
 
                 var isForExtension = false;
@@ -999,7 +1004,7 @@ namespace uml4net.HandleBars
 
                 if (property == null || @class == null)
                 {
-                    throw new ArgumentException("the parameters could not be converted to a IProperty and IClass");
+                    throw new ArgumentException(ParametersNotConvertibleToPropertyAndClass);
                 }
 
                 var isAsync = false;
@@ -1134,7 +1139,7 @@ namespace uml4net.HandleBars
 
                 if (property == null || @class == null)
                 {
-                    throw new ArgumentException("the parameters could not be converted to a IProperty and IClass");
+                    throw new ArgumentException(ParametersNotConvertibleToPropertyAndClass);
                 }
 
                 var isAsync = false;

--- a/uml4net.HandleBars/PropertyHelper.cs
+++ b/uml4net.HandleBars/PropertyHelper.cs
@@ -986,6 +986,301 @@ namespace uml4net.HandleBars
 
                 throw new NotSupportedException($"{@class.Name}.{property.Name}");
             });
+
+            handlebars.RegisterHelper("Property.WriteXmlAttributeForXmiWriter", (writer, context, parameters) =>
+            {
+                if (parameters.Length != 2 && parameters.Length != 3)
+                {
+                    throw new HandlebarsException("{{#Property.WriteXmlAttributeForXmiWriter}} helper must have two or three arguments");
+                }
+
+                var property = parameters[0] as IProperty;
+                var @class = parameters[1] as IClass;
+
+                if (property == null || @class == null)
+                {
+                    throw new ArgumentException("the parameters could not be converted to a IProperty and IClass");
+                }
+
+                var isAsync = false;
+
+                if (parameters.Length == 3)
+                {
+                    isAsync = parameters[2] is bool boolValue ? boolValue : bool.Parse(parameters[2].ToString());
+                }
+
+                if (property.IsDerived || property.IsDerivedUnion || property.IsReadOnly)
+                {
+                    return;
+                }
+
+                var isRedefinedByProperty = property.TryQueryRedefinedByProperty(@class, out _);
+
+                if (isRedefinedByProperty)
+                {
+                    return;
+                }
+
+                if (property.IsComposite)
+                {
+                    // contained objects are only handled as contained XML elements
+                    return;
+                }
+
+                var pocoPropertyName = property.Name.CapitalizeFirstLetter();
+
+                var sb = new StringBuilder();
+
+                if (property.QueryIsReferenceType() && !property.QueryIsEnumerable())
+                {
+                    sb.AppendLine($"if (element.{pocoPropertyName} != null && writeContext.IsLocal(element.{pocoPropertyName}))");
+                    sb.AppendLine("{");
+                    sb.AppendLine(isAsync
+                        ? $"await xmlWriter.WriteAttributeStringAsync(null, \"{property.Name}\", null, element.{pocoPropertyName}.XmiId);"
+                        : $"xmlWriter.WriteAttributeString(\"{property.Name}\", element.{pocoPropertyName}.XmiId);");
+                    sb.AppendLine("}");
+
+                    writer.WriteSafeString(sb + Environment.NewLine);
+                    return;
+                }
+
+                if (property.QueryIsEnumerable())
+                {
+                    // multi-valued references and multi-valued primitives are written as XML elements
+                    return;
+                }
+
+                if (property.QueryIsPrimitiveType())
+                {
+                    var cSharpTypeName = property.QueryCSharpTypeName();
+
+                    switch (cSharpTypeName)
+                    {
+                        case "bool":
+                            var boolDefault = property.QueryIsDefaultValueDifferentThanDefault() ? property.QueryDefaultValueAsString() : "false";
+
+                            sb.AppendLine(boolDefault == "true" ? $"if (!element.{pocoPropertyName})" : $"if (element.{pocoPropertyName})");
+                            sb.AppendLine("{");
+                            sb.AppendLine(isAsync
+                                ? $"await xmlWriter.WriteAttributeStringAsync(null, \"{property.Name}\", null, XmlConvert.ToString(element.{pocoPropertyName}));"
+                                : $"xmlWriter.WriteAttributeString(\"{property.Name}\", XmlConvert.ToString(element.{pocoPropertyName}));");
+                            sb.AppendLine("}");
+                            break;
+                        case "double":
+                        case "int":
+                            var numericDefault = property.QueryIsDefaultValueDifferentThanDefault() ? property.QueryDefaultValueAsString() : "0";
+
+                            sb.AppendLine($"if (element.{pocoPropertyName} != {numericDefault})");
+                            sb.AppendLine("{");
+                            sb.AppendLine(isAsync
+                                ? $"await xmlWriter.WriteAttributeStringAsync(null, \"{property.Name}\", null, XmlConvert.ToString(element.{pocoPropertyName}));"
+                                : $"xmlWriter.WriteAttributeString(\"{property.Name}\", XmlConvert.ToString(element.{pocoPropertyName}));");
+                            sb.AppendLine("}");
+                            break;
+                        case "string":
+                            var condition = $"!string.IsNullOrEmpty(element.{pocoPropertyName})";
+
+                            if (property.QueryIsDefaultValueDifferentThanDefault())
+                            {
+                                condition += $" && element.{pocoPropertyName} != \"{property.QueryDefaultValueAsString()}\"";
+                            }
+
+                            sb.AppendLine($"if ({condition})");
+                            sb.AppendLine("{");
+                            sb.AppendLine(isAsync
+                                ? $"await xmlWriter.WriteAttributeStringAsync(null, \"{property.Name}\", null, element.{pocoPropertyName});"
+                                : $"xmlWriter.WriteAttributeString(\"{property.Name}\", element.{pocoPropertyName});");
+                            sb.AppendLine("}");
+                            break;
+                        default:
+                            throw new NotSupportedException($"{property.Name} has a Primitive Type that is not supported: {cSharpTypeName}");
+                    }
+
+                    writer.WriteSafeString(sb + Environment.NewLine);
+                    return;
+                }
+
+                if (property.QueryIsEnum())
+                {
+                    var typeName = property.QueryTypeName();
+
+                    var enumDefault = property.QueryIsDefaultValueDifferentThanDefault()
+                        ? $"{typeName}.{property.QueryDefaultValueAsString().CapitalizeFirstLetter()}"
+                        : $"default({typeName})";
+
+                    sb.AppendLine($"if (element.{pocoPropertyName} != {enumDefault})");
+                    sb.AppendLine("{");
+                    sb.AppendLine(isAsync
+                        ? $"await xmlWriter.WriteAttributeStringAsync(null, \"{property.Name}\", null, LowerCaseFirstLetter(element.{pocoPropertyName}.ToString()));"
+                        : $"xmlWriter.WriteAttributeString(\"{property.Name}\", LowerCaseFirstLetter(element.{pocoPropertyName}.ToString()));");
+                    sb.AppendLine("}");
+
+                    writer.WriteSafeString(sb + Environment.NewLine);
+                    return;
+                }
+
+                throw new NotSupportedException($"{@class.Name}.{property.Name}");
+            });
+
+            handlebars.RegisterHelper("Property.WriteXmlElementForXmiWriter", (writer, context, parameters) =>
+            {
+                if (parameters.Length != 2 && parameters.Length != 3)
+                {
+                    throw new HandlebarsException("{{#Property.WriteXmlElementForXmiWriter}} helper must have two or three arguments");
+                }
+
+                var property = parameters[0] as IProperty;
+                var @class = parameters[1] as IClass;
+
+                if (property == null || @class == null)
+                {
+                    throw new ArgumentException("the parameters could not be converted to a IProperty and IClass");
+                }
+
+                var isAsync = false;
+
+                if (parameters.Length == 3)
+                {
+                    isAsync = parameters[2] is bool boolValue ? boolValue : bool.Parse(parameters[2].ToString());
+                }
+
+                if (property.IsDerived || property.IsDerivedUnion || property.IsReadOnly)
+                {
+                    return;
+                }
+
+                var isRedefinedByProperty = property.TryQueryRedefinedByProperty(@class, out _);
+
+                if (isRedefinedByProperty)
+                {
+                    return;
+                }
+
+                var pocoPropertyName = property.Name.CapitalizeFirstLetter();
+
+                var sb = new StringBuilder();
+
+                if (property.IsComposite)
+                {
+                    if (property.QueryIsPrimitiveType())
+                    {
+                        // composite primitive values are read as element content strings by the readers
+                        sb.AppendLine($"foreach (var value in element.{pocoPropertyName})");
+                        sb.AppendLine("{");
+                        sb.AppendLine(isAsync
+                            ? $"await xmlWriter.WriteElementStringAsync(null, \"{property.Name}\", null, value);"
+                            : $"xmlWriter.WriteElementString(\"{property.Name}\", value);");
+                        sb.AppendLine("}");
+
+                        writer.WriteSafeString(sb + Environment.NewLine);
+                        return;
+                    }
+
+                    if (property.QueryIsEnum())
+                    {
+                        throw new NotImplementedException("contained enumeration is not yet supported");
+                    }
+
+                    if (property.QueryIsReferenceType() && (property.SubsettedProperty.Count == 0 || property.SubsettedProperty.Any(x => x.IsDerived || x.IsDerivedUnion || x.IsReadOnly)))
+                    {
+                        sb.AppendLine($"foreach (var value in element.{pocoPropertyName})");
+                        sb.AppendLine("{");
+                        sb.AppendLine(isAsync
+                            ? $"await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, \"{property.Name}\", writeContext);"
+                            : $"this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, \"{property.Name}\", writeContext);");
+                        sb.AppendLine("}");
+
+                        writer.WriteSafeString(sb + Environment.NewLine);
+                        return;
+                    }
+
+                    if (property.QueryIsReferenceType() && property.SubsettedProperty.Count > 0)
+                    {
+                        // the readers collect these composite properties as reference identifiers,
+                        // therefore they are written as xmi:idref reference elements
+                        sb.AppendLine($"foreach (var value in element.{pocoPropertyName})");
+                        sb.AppendLine("{");
+                        sb.AppendLine(isAsync
+                            ? $"await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, \"{property.Name}\", writeContext);"
+                            : $"this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, \"{property.Name}\", writeContext);");
+                        sb.AppendLine("}");
+
+                        writer.WriteSafeString(sb + Environment.NewLine);
+                        return;
+                    }
+                }
+                else
+                {
+                    if (property.QueryIsPrimitiveType() && property.QueryIsEnumerable())
+                    {
+                        var cSharpTypeName = property.QueryCSharpTypeName();
+
+                        switch (cSharpTypeName)
+                        {
+                            case "bool":
+                            case "double":
+                            case "int":
+                                sb.AppendLine($"foreach (var value in element.{pocoPropertyName})");
+                                sb.AppendLine("{");
+                                sb.AppendLine(isAsync
+                                    ? $"await xmlWriter.WriteElementStringAsync(null, \"{property.Name}\", null, XmlConvert.ToString(value));"
+                                    : $"xmlWriter.WriteElementString(\"{property.Name}\", XmlConvert.ToString(value));");
+                                sb.AppendLine("}");
+                                break;
+                            case "string":
+                                sb.AppendLine($"foreach (var value in element.{pocoPropertyName})");
+                                sb.AppendLine("{");
+                                sb.AppendLine(isAsync
+                                    ? $"await xmlWriter.WriteElementStringAsync(null, \"{property.Name}\", null, value);"
+                                    : $"xmlWriter.WriteElementString(\"{property.Name}\", value);");
+                                sb.AppendLine("}");
+                                break;
+                            default:
+                                throw new NotSupportedException($"{property.Name} has a Primitive Type that is not supported: {cSharpTypeName}");
+                        }
+
+                        writer.WriteSafeString(sb + Environment.NewLine);
+                        return;
+                    }
+
+                    if (property.QueryIsPrimitiveType() || property.QueryIsEnum())
+                    {
+                        // scalar primitives and enumerations are written as XML attributes
+                        return;
+                    }
+
+                    if (property.QueryIsReferenceType() && !property.QueryIsEnumerable())
+                    {
+                        // local references are written as XML attributes, external references as href elements
+                        sb.AppendLine($"if (element.{pocoPropertyName} != null && !writeContext.IsLocal(element.{pocoPropertyName}))");
+                        sb.AppendLine("{");
+                        sb.AppendLine(isAsync
+                            ? $"await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.{pocoPropertyName}, \"{property.Name}\", writeContext);"
+                            : $"this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.{pocoPropertyName}, \"{property.Name}\", writeContext);");
+                        sb.AppendLine("}");
+
+                        writer.WriteSafeString(sb + Environment.NewLine);
+                        return;
+                    }
+
+                    if (property.QueryIsReferenceType() && property.QueryIsEnumerable())
+                    {
+                        sb.AppendLine($"foreach (var value in element.{pocoPropertyName})");
+                        sb.AppendLine("{");
+                        sb.AppendLine(isAsync
+                            ? $"await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, \"{property.Name}\", writeContext);"
+                            : $"this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, \"{property.Name}\", writeContext);");
+                        sb.AppendLine("}");
+
+                        writer.WriteSafeString(sb + Environment.NewLine);
+                        return;
+                    }
+
+                    throw new NotSupportedException($"{@class.Name}.{property.Name}");
+                }
+
+                throw new NotSupportedException($"{@class.Name}.{property.Name}");
+            });
         }
     }
 }

--- a/uml4net.xmi.Tests/Writers/ReferenceClosureCalculatorTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/ReferenceClosureCalculatorTestFixture.cs
@@ -1,0 +1,168 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="ReferenceClosureCalculatorTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Tests.Writers
+{
+    using System.Linq;
+
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using NUnit.Framework;
+
+    using uml4net.Classification;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StructuredClassifiers;
+    using uml4net.xmi.Settings;
+    using uml4net.xmi.Writers;
+
+    [TestFixture]
+    public class ReferenceClosureCalculatorTestFixture
+    {
+        private ReferenceClosureCalculator referenceClosureCalculator;
+
+        private Package packageA;
+
+        private Class classA;
+
+        private Property property;
+
+        private Package packageB;
+
+        private PrimitiveType primitiveType;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.referenceClosureCalculator = new ReferenceClosureCalculator(NullLogger<ReferenceClosureCalculator>.Instance);
+
+            this.packageB = new Package { XmiId = "PackageB", DocumentName = "b.xmi", Name = "PackageB" };
+            this.primitiveType = new PrimitiveType { XmiId = "String", DocumentName = "b.xmi", Name = "String" };
+            this.packageB.PackagedElement.Add(this.primitiveType);
+
+            this.packageA = new Package { XmiId = "PackageA", DocumentName = "a.xmi", Name = "PackageA" };
+            this.classA = new Class { XmiId = "ClassA", DocumentName = "a.xmi", Name = "ClassA" };
+            this.property = new Property { XmiId = "Property1", DocumentName = "a.xmi", Name = "property1" };
+            this.property.Type = this.primitiveType;
+            this.classA.OwnedAttribute.Add(this.property);
+            this.packageA.PackagedElement.Add(this.classA);
+        }
+
+        [Test]
+        public void Verify_that_CalculateWritePlan_throws_when_arguments_are_null()
+        {
+            Assert.That(() => this.referenceClosureCalculator.CalculateWritePlan(null, ExternalReferenceResolutionKind.Href, "a.xmi"),
+                Throws.ArgumentNullException);
+
+            Assert.That(() => this.referenceClosureCalculator.CalculateWritePlan(this.packageA, ExternalReferenceResolutionKind.Href, null),
+                Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_Href_plan_contains_selected_package_only()
+        {
+            var plan = this.referenceClosureCalculator.CalculateWritePlan(this.packageA, ExternalReferenceResolutionKind.Href, "a.xmi");
+
+            Assert.That(plan.RootPackages, Is.EqualTo(new[] { this.packageA }));
+
+            Assert.That(plan.LocalIdentifiers, Does.Contain(this.packageA.FullyQualifiedIdentifier));
+            Assert.That(plan.LocalIdentifiers, Does.Contain(this.classA.FullyQualifiedIdentifier));
+            Assert.That(plan.LocalIdentifiers, Does.Contain(this.property.FullyQualifiedIdentifier));
+
+            Assert.That(plan.LocalIdentifiers, Does.Not.Contain(this.primitiveType.FullyQualifiedIdentifier));
+            Assert.That(plan.LocalIdentifiers, Does.Not.Contain(this.packageB.FullyQualifiedIdentifier));
+
+            Assert.That(plan.ElementsMissingXmiId, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_Include_plan_pulls_in_referenced_root_package()
+        {
+            var plan = this.referenceClosureCalculator.CalculateWritePlan(this.packageA, ExternalReferenceResolutionKind.Include, "a.xmi");
+
+            Assert.That(plan.RootPackages, Is.EqualTo(new IPackage[] { this.packageA, this.packageB }));
+
+            Assert.That(plan.LocalIdentifiers, Does.Contain(this.primitiveType.FullyQualifiedIdentifier));
+            Assert.That(plan.LocalIdentifiers, Does.Contain(this.packageB.FullyQualifiedIdentifier));
+
+            Assert.That(plan.ElementsMissingXmiId, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_Include_plan_pulls_in_transitively_referenced_root_packages()
+        {
+            var packageC = new Package { XmiId = "PackageC", DocumentName = "c.xmi", Name = "PackageC" };
+            var dataType = new DataType { XmiId = "DataType1", DocumentName = "c.xmi", Name = "DataType1" };
+            packageC.PackagedElement.Add(dataType);
+
+            var propertyB = new Property { XmiId = "PropertyB", DocumentName = "b.xmi", Name = "propertyB" };
+            propertyB.Type = dataType;
+            var classB = new Class { XmiId = "ClassB", DocumentName = "b.xmi", Name = "ClassB" };
+            classB.OwnedAttribute.Add(propertyB);
+            this.packageB.PackagedElement.Add(classB);
+
+            var plan = this.referenceClosureCalculator.CalculateWritePlan(this.packageA, ExternalReferenceResolutionKind.Include, "a.xmi");
+
+            Assert.That(plan.RootPackages, Is.EqualTo(new IPackage[] { this.packageA, this.packageB, packageC }));
+
+            Assert.That(plan.LocalIdentifiers, Does.Contain(dataType.FullyQualifiedIdentifier));
+        }
+
+        [Test]
+        public void Verify_that_Include_plan_orders_included_packages_by_name()
+        {
+            var packageC = new Package { XmiId = "PackageC", DocumentName = "c.xmi", Name = "APackageC" };
+            var dataType = new DataType { XmiId = "DataType1", DocumentName = "c.xmi", Name = "DataType1" };
+            packageC.PackagedElement.Add(dataType);
+
+            var otherProperty = new Property { XmiId = "Property2", DocumentName = "a.xmi", Name = "property2" };
+            otherProperty.Type = dataType;
+            this.classA.OwnedAttribute.Add(otherProperty);
+
+            var plan = this.referenceClosureCalculator.CalculateWritePlan(this.packageA, ExternalReferenceResolutionKind.Include, "a.xmi");
+
+            Assert.That(plan.RootPackages.First(), Is.EqualTo(this.packageA));
+            Assert.That(plan.RootPackages.Skip(1).Select(x => x.Name), Is.EqualTo(new[] { "APackageC", "PackageB" }));
+        }
+
+        [Test]
+        public void Verify_that_Include_plan_skips_referenced_elements_that_are_not_contained_by_a_root_package()
+        {
+            var freeFloatingType = new Class { XmiId = "FreeFloating", DocumentName = "free.xmi", Name = "FreeFloating" };
+            this.property.Type = freeFloatingType;
+
+            var plan = this.referenceClosureCalculator.CalculateWritePlan(this.packageA, ExternalReferenceResolutionKind.Include, "a.xmi");
+
+            Assert.That(plan.RootPackages, Is.EqualTo(new[] { this.packageA }));
+            Assert.That(plan.LocalIdentifiers, Does.Not.Contain(freeFloatingType.FullyQualifiedIdentifier));
+        }
+
+        [Test]
+        public void Verify_that_elements_without_XmiId_are_reported()
+        {
+            var invalidClass = new Class { DocumentName = "a.xmi", Name = "Invalid" };
+            this.packageA.PackagedElement.Add(invalidClass);
+
+            var plan = this.referenceClosureCalculator.CalculateWritePlan(this.packageA, ExternalReferenceResolutionKind.Href, "a.xmi");
+
+            Assert.That(plan.ElementsMissingXmiId, Is.EqualTo(new[] { invalidClass }));
+        }
+    }
+}

--- a/uml4net.xmi.Tests/Writers/XmiRoundTripTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/XmiRoundTripTestFixture.cs
@@ -1,0 +1,312 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiRoundTripTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Tests.Writers
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using NUnit.Framework;
+
+    using Serilog;
+
+    using uml4net.CommonStructure;
+    using uml4net.Packages;
+    using uml4net.StructuredClassifiers;
+    using uml4net.xmi;
+    using uml4net.xmi.Readers;
+    using uml4net.xmi.Settings;
+    using uml4net.xmi.Writers;
+
+    [TestFixture]
+    public class XmiRoundTripTestFixture
+    {
+        private string rootPath;
+
+        private ReferenceClosureCalculator referenceClosureCalculator;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Information()
+                .WriteTo.Console()
+                .CreateLogger();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.rootPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData");
+
+            this.referenceClosureCalculator = new ReferenceClosureCalculator(NullLogger<ReferenceClosureCalculator>.Instance);
+        }
+
+        [Test]
+        public void Verify_that_the_UML_model_round_trips_with_href_references()
+        {
+            var originalRoot = this.ReadUmlModel().QueryRoot("_0", "UML");
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(this.CreateLoggerFactory())
+                .Build();
+
+            writer.Write(originalRoot, stream, "UML.xmi");
+
+            stream.Position = 0;
+
+            var rereadRoot = this.ReadUmlModel(stream).QueryRoot("_0", "UML");
+
+            this.AssertContainmentTreesAreEquivalent(originalRoot, rereadRoot, "UML.xmi");
+
+            var activity = rereadRoot.NestedPackage.Single(x => x.Name == "Activities")
+                .PackagedElement.OfType<IClass>().Single(x => x.Name == "Activity");
+
+            Assert.That(activity.IsAbstract, Is.False);
+            Assert.That(activity.Visibility, Is.EqualTo(VisibilityKind.Public));
+            Assert.That(activity.Generalization.Single().General.Name, Is.EqualTo("Behavior"));
+            Assert.That(activity.OwnedRule, Is.Not.Empty);
+
+            var classifier = rereadRoot.NestedPackage.Single(x => x.Name == "Classification")
+                .PackagedElement.OfType<IClass>().Single(x => x.Name == "Classifier");
+
+            Assert.That(classifier.IsAbstract, Is.True);
+
+            var isAbstract = classifier.OwnedAttribute.Single(x => x.Name == "isAbstract");
+
+            Assert.That(isAbstract.Type.Name, Is.EqualTo("Boolean"));
+            Assert.That(isAbstract.Type.DocumentName, Does.EndWith("PrimitiveTypes.xmi"),
+                "the href reference to the PrimitiveTypes document was expected to be resolved from the written document");
+        }
+
+        [Test]
+        public async Task Verify_that_the_UML_model_round_trips_asynchronously()
+        {
+            var originalRoot = this.ReadUmlModel().QueryRoot("_0", "UML");
+
+            using var syncStream = new MemoryStream();
+            using var asyncStream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(this.CreateLoggerFactory())
+                .Build();
+
+            writer.Write(originalRoot, syncStream, "UML.xmi");
+
+            await writer.WriteAsync(originalRoot, asyncStream, "UML.xmi");
+
+            Assert.That(asyncStream.ToArray(), Is.EqualTo(syncStream.ToArray()),
+                "the synchronous and asynchronous write are expected to produce identical documents");
+        }
+
+        [Test]
+        public void Verify_that_the_UML_model_round_trips_with_include_mode()
+        {
+            var originalRoot = this.ReadUmlModel().QueryRoot("_0", "UML");
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .UsingSettings(x => x.ExternalReferenceResolution = ExternalReferenceResolutionKind.Include)
+                .WithLogger(this.CreateLoggerFactory())
+                .Build();
+
+            writer.Write(originalRoot, stream, "UML-include.xmi");
+
+            stream.Position = 0;
+
+            var reader = XmiReaderBuilder.Create()
+                .WithLogger(this.CreateLoggerFactory())
+                .Build();
+
+            var rereadResult = reader.Read(stream, "UML-include.xmi");
+
+            Assert.That(rereadResult.Packages, Has.Count.EqualTo(2),
+                "the written document is expected to contain the UML package and the included PrimitiveTypes package");
+
+            var rereadRoot = rereadResult.QueryRoot("_0", "UML");
+
+            var classifier = rereadRoot.NestedPackage.Single(x => x.Name == "Classification")
+                .PackagedElement.OfType<IClass>().Single(x => x.Name == "Classifier");
+
+            var isAbstract = classifier.OwnedAttribute.Single(x => x.Name == "isAbstract");
+
+            Assert.That(isAbstract.Type, Is.Not.Null);
+            Assert.That(isAbstract.Type.Name, Is.EqualTo("Boolean"));
+            Assert.That(isAbstract.Type.DocumentName, Is.EqualTo("UML-include.xmi"),
+                "the PrimitiveTypes package was expected to be included in the written document");
+        }
+
+        [Test]
+        public void Verify_that_a_mutated_model_round_trips()
+        {
+            var originalRoot = this.ReadUmlModel().QueryRoot("_0", "UML");
+
+            var activity = originalRoot.NestedPackage.Single(x => x.Name == "Activities")
+                .PackagedElement.OfType<IClass>().Single(x => x.Name == "Activity");
+
+            activity.Name = "RenamedActivity";
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(this.CreateLoggerFactory())
+                .Build();
+
+            writer.Write(originalRoot, stream, "UML.xmi");
+
+            stream.Position = 0;
+
+            var rereadRoot = this.ReadUmlModel(stream).QueryRoot("_0", "UML");
+
+            var renamedActivity = rereadRoot.NestedPackage.Single(x => x.Name == "Activities")
+                .PackagedElement.OfType<IClass>().Single(x => x.XmiId == activity.XmiId);
+
+            Assert.That(renamedActivity.Name, Is.EqualTo("RenamedActivity"));
+        }
+
+        [Test]
+        public void Verify_that_the_SysML_model_round_trips()
+        {
+            var pathMaps = new Dictionary<string, string>
+            {
+                ["pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml"] = Path.Combine("TestData", "PrimitiveTypes.xmi")
+            };
+
+            var reader = XmiReaderBuilder.Create()
+                .UsingSettings(x =>
+                {
+                    x.LocalReferenceBasePath = this.rootPath;
+                    x.PathMaps = pathMaps;
+                })
+                .WithLogger(this.CreateLoggerFactory())
+                .Build();
+
+            var originalResult = reader.Read(Path.Combine(this.rootPath, "SysML.uml"));
+
+            var originalRoot = originalResult.Packages.First();
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(this.CreateLoggerFactory())
+                .Build();
+
+            writer.Write(originalRoot, stream, "SysML.uml");
+
+            stream.Position = 0;
+
+            var rereadReader = XmiReaderBuilder.Create()
+                .UsingSettings(x =>
+                {
+                    x.LocalReferenceBasePath = this.rootPath;
+                    x.PathMaps = pathMaps;
+                })
+                .WithLogger(this.CreateLoggerFactory())
+                .Build();
+
+            var rereadResult = rereadReader.Read(stream, "SysML.uml");
+
+            var rereadRoot = rereadResult.Packages.First();
+
+            this.AssertContainmentTreesAreEquivalent(originalRoot, rereadRoot, "SysML.uml");
+        }
+
+        /// <summary>
+        /// Asserts that the containment trees of the provided packages contain the same elements by
+        /// comparing the <see cref="IXmiElement.FullyQualifiedIdentifier"/>s of the calculated write plans
+        /// </summary>
+        /// <param name="originalRoot">
+        /// The root <see cref="IPackage"/> of the original model
+        /// </param>
+        /// <param name="rereadRoot">
+        /// The root <see cref="IPackage"/> of the model that was read from the written document
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that was written
+        /// </param>
+        private void AssertContainmentTreesAreEquivalent(IPackage originalRoot, IPackage rereadRoot, string documentName)
+        {
+            var originalPlan = this.referenceClosureCalculator.CalculateWritePlan(originalRoot, ExternalReferenceResolutionKind.Href, documentName);
+            var rereadPlan = this.referenceClosureCalculator.CalculateWritePlan(rereadRoot, ExternalReferenceResolutionKind.Href, documentName);
+
+            var missing = originalPlan.LocalIdentifiers.Except(rereadPlan.LocalIdentifiers).Take(10).ToList();
+            var extra = rereadPlan.LocalIdentifiers.Except(originalPlan.LocalIdentifiers).Take(10).ToList();
+
+            Assert.That(rereadPlan.LocalIdentifiers.SetEquals(originalPlan.LocalIdentifiers), Is.True,
+                $"the containment trees are not equivalent; missing: [{string.Join(", ", missing)}]; extra: [{string.Join(", ", extra)}]");
+        }
+
+        /// <summary>
+        /// Reads the UML model from the TestData directory
+        /// </summary>
+        /// <returns>
+        /// The <see cref="XmiReaderResult"/>
+        /// </returns>
+        private XmiReaderResult ReadUmlModel()
+        {
+            var reader = XmiReaderBuilder.Create()
+                .UsingSettings(x => x.LocalReferenceBasePath = this.rootPath)
+                .WithLogger(this.CreateLoggerFactory())
+                .Build();
+
+            return reader.Read(Path.Combine(this.rootPath, "UML.xmi"));
+        }
+
+        /// <summary>
+        /// Reads a UML model from the provided <see cref="Stream"/>, resolving external references
+        /// from the TestData directory
+        /// </summary>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> that contains the XMI content
+        /// </param>
+        /// <returns>
+        /// The <see cref="XmiReaderResult"/>
+        /// </returns>
+        private XmiReaderResult ReadUmlModel(Stream stream)
+        {
+            var reader = XmiReaderBuilder.Create()
+                .UsingSettings(x => x.LocalReferenceBasePath = this.rootPath)
+                .WithLogger(this.CreateLoggerFactory())
+                .Build();
+
+            return reader.Read(stream, "UML.xmi");
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ILoggerFactory"/>. Each reader, writer and scope receives its own
+        /// instance since disposing a scope also disposes the registered <see cref="ILoggerFactory"/>
+        /// </summary>
+        /// <returns>
+        /// The created <see cref="ILoggerFactory"/>
+        /// </returns>
+        private ILoggerFactory CreateLoggerFactory()
+        {
+            return LoggerFactory.Create(builder => builder.AddSerilog());
+        }
+    }
+}

--- a/uml4net.xmi.Tests/Writers/XmiWriteContextTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/XmiWriteContextTestFixture.cs
@@ -1,0 +1,96 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiWriteContextTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Tests.Writers
+{
+    using System.Collections.Generic;
+
+    using NUnit.Framework;
+
+    using uml4net.StructuredClassifiers;
+    using uml4net.xmi.Writers;
+
+    [TestFixture]
+    public class XmiWriteContextTestFixture
+    {
+        [Test]
+        public void Verify_that_constructor_throws_when_arguments_are_null()
+        {
+            Assert.That(() => new XmiWriteContext(null, []), Throws.ArgumentNullException);
+            Assert.That(() => new XmiWriteContext("UML.xmi", null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_DocumentName_is_set()
+        {
+            var context = new XmiWriteContext("UML.xmi", []);
+
+            Assert.That(context.DocumentName, Is.EqualTo("UML.xmi"));
+        }
+
+        [Test]
+        public void Verify_that_IsLocal_returns_expected_result()
+        {
+            var localClass = new Class { XmiId = "Class-1", DocumentName = "UML.xmi" };
+            var externalClass = new Class { XmiId = "Class-2", DocumentName = "PrimitiveTypes.xmi" };
+
+            var context = new XmiWriteContext("UML.xmi", [localClass.FullyQualifiedIdentifier]);
+
+            Assert.That(context.IsLocal(localClass), Is.True);
+            Assert.That(context.IsLocal(externalClass), Is.False);
+        }
+
+        [Test]
+        public void Verify_that_IsLocal_supports_empty_document_name()
+        {
+            var localClass = new Class { XmiId = "Class-1" };
+
+            var context = new XmiWriteContext("UML.xmi", [localClass.FullyQualifiedIdentifier]);
+
+            Assert.That(context.IsLocal(localClass), Is.True);
+        }
+
+        [Test]
+        public void Verify_that_IsLocal_throws_when_element_is_null()
+        {
+            var context = new XmiWriteContext("UML.xmi", []);
+
+            Assert.That(() => context.IsLocal(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_QueryHref_returns_expected_result()
+        {
+            var externalClass = new Class { XmiId = "Boolean", DocumentName = "PrimitiveTypes.xmi" };
+
+            var context = new XmiWriteContext("UML.xmi", []);
+
+            Assert.That(context.QueryHref(externalClass), Is.EqualTo("PrimitiveTypes.xmi#Boolean"));
+        }
+
+        [Test]
+        public void Verify_that_QueryHref_throws_when_element_is_null()
+        {
+            var context = new XmiWriteContext("UML.xmi", []);
+
+            Assert.That(() => context.QueryHref(null), Throws.ArgumentNullException);
+        }
+    }
+}

--- a/uml4net.xmi.Tests/Writers/XmiWriterBuilderTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/XmiWriterBuilderTestFixture.cs
@@ -1,0 +1,110 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiWriterBuilderTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Tests.Writers
+{
+    using Microsoft.Extensions.Logging;
+
+    using NUnit.Framework;
+
+    using Serilog;
+
+    using uml4net.xmi;
+    using uml4net.xmi.Settings;
+    using uml4net.xmi.Writers;
+
+    [TestFixture]
+    public class XmiWriterBuilderTestFixture
+    {
+        private ILoggerFactory loggerFactory;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.Console()
+                .CreateLogger();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.loggerFactory = LoggerFactory.Create(builder => builder.AddSerilog());
+        }
+
+        [Test]
+        public void Verify_that_Build_returns_an_XmiWriter()
+        {
+            using var writer = XmiWriterBuilder.Create()
+                .WithLogger(this.loggerFactory)
+                .Build();
+
+            Assert.That(writer, Is.InstanceOf<IXmiWriter>());
+        }
+
+        [Test]
+        public void Verify_that_UsingSettings_delegate_configures_the_settings()
+        {
+            var scope = XmiWriterBuilder.Create()
+                .UsingSettings(x => x.ExternalReferenceResolution = ExternalReferenceResolutionKind.Include)
+                .WithLogger(this.loggerFactory);
+
+            using var writer = scope.Build();
+
+            Assert.That(writer, Is.InstanceOf<IXmiWriter>());
+        }
+
+        [Test]
+        public void Verify_that_UsingSettings_instance_configures_the_settings()
+        {
+            var settings = new DefaultWriterSettings
+            {
+                Indent = false
+            };
+
+            using var writer = XmiWriterBuilder.Create()
+                .UsingSettings(settings)
+                .WithLogger(this.loggerFactory)
+                .Build();
+
+            Assert.That(writer, Is.InstanceOf<IXmiWriter>());
+        }
+
+        [Test]
+        public void Verify_that_scope_can_be_disposed()
+        {
+            var scope = XmiWriterBuilder.Create().WithLogger(this.loggerFactory);
+            var writer = scope.Build();
+
+            Assert.That(() => scope.Dispose(), Throws.Nothing);
+        }
+
+        [Test]
+        public void Verify_that_disposing_the_writer_disposes_the_scope()
+        {
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(this.loggerFactory)
+                .Build();
+
+            Assert.That(() => writer.Dispose(), Throws.Nothing);
+        }
+    }
+}

--- a/uml4net.xmi.Tests/Writers/XmiWriterTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/XmiWriterTestFixture.cs
@@ -1,0 +1,192 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiWriterTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Tests.Writers
+{
+    using System.IO;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+
+    using NUnit.Framework;
+
+    using uml4net.Packages;
+    using uml4net.StructuredClassifiers;
+    using uml4net.xmi;
+    using uml4net.xmi.Writers;
+
+    [TestFixture]
+    public class XmiWriterTestFixture
+    {
+        private ILoggerFactory loggerFactory;
+
+        private IXmiWriter xmiWriter;
+
+        private Package package;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.loggerFactory = LoggerFactory.Create(builder => { });
+
+            this.xmiWriter = XmiWriterBuilder.Create()
+                .WithLogger(this.loggerFactory)
+                .Build();
+
+            this.package = new Package { XmiId = "Package-1", Name = "package" };
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.xmiWriter.Dispose();
+        }
+
+        [Test]
+        public void Verify_that_Write_throws_when_fileUri_is_null_or_empty()
+        {
+            Assert.That(() => this.xmiWriter.Write(this.package, (string)null), Throws.ArgumentException);
+            Assert.That(() => this.xmiWriter.Write(this.package, string.Empty), Throws.ArgumentException);
+        }
+
+        [Test]
+        public void Verify_that_Write_throws_when_arguments_are_null_or_empty()
+        {
+            using var stream = new MemoryStream();
+
+            Assert.That(() => this.xmiWriter.Write(null, stream, "output.xmi"), Throws.ArgumentNullException);
+            Assert.That(() => this.xmiWriter.Write(this.package, null, "output.xmi"), Throws.ArgumentNullException);
+            Assert.That(() => this.xmiWriter.Write(this.package, stream, null), Throws.ArgumentException);
+            Assert.That(() => this.xmiWriter.Write(this.package, stream, string.Empty), Throws.ArgumentException);
+        }
+
+        [Test]
+        public void Verify_that_WriteAsync_throws_when_fileUri_is_null_or_empty()
+        {
+            Assert.That(() => this.xmiWriter.WriteAsync(this.package, (string)null), Throws.ArgumentException);
+            Assert.That(() => this.xmiWriter.WriteAsync(this.package, string.Empty), Throws.ArgumentException);
+        }
+
+        [Test]
+        public void Verify_that_WriteAsync_throws_when_arguments_are_null_or_empty()
+        {
+            using var stream = new MemoryStream();
+
+            Assert.That(() => this.xmiWriter.WriteAsync(null, stream, "output.xmi"), Throws.ArgumentNullException);
+            Assert.That(() => this.xmiWriter.WriteAsync(this.package, null, "output.xmi"), Throws.ArgumentNullException);
+            Assert.That(() => this.xmiWriter.WriteAsync(this.package, stream, null), Throws.ArgumentException);
+            Assert.That(() => this.xmiWriter.WriteAsync(this.package, stream, string.Empty), Throws.ArgumentException);
+        }
+
+        [Test]
+        public void Verify_that_Write_throws_when_an_element_has_no_XmiId()
+        {
+            var invalidPackage = new Package { Name = "invalid" };
+
+            using var stream = new MemoryStream();
+
+            Assert.That(() => this.xmiWriter.Write(invalidPackage, stream, "output.xmi"),
+                Throws.InvalidOperationException.With.Message.Contains("do not have an XmiId"));
+        }
+
+        [Test]
+        public void Verify_that_a_simple_package_is_written_as_expected()
+        {
+            var @class = new Class { XmiId = "Class-1", Name = "class" };
+            this.package.PackagedElement.Add(@class);
+
+            using var stream = new MemoryStream();
+
+            this.xmiWriter.Write(this.package, stream, "output.xmi");
+
+            var xmlDocument = new XmlDocument();
+            stream.Position = 0;
+            xmlDocument.Load(stream);
+
+            var root = xmlDocument.DocumentElement;
+
+            Assert.That(root.Name, Is.EqualTo("xmi:XMI"));
+            Assert.That(root.GetAttribute("xmlns:uml"), Is.EqualTo("http://www.omg.org/spec/UML/20131001"));
+            Assert.That(root.GetAttribute("xmlns:xmi"), Is.EqualTo("http://www.omg.org/spec/XMI/20131001"));
+
+            var packageElement = (XmlElement)root.FirstChild;
+
+            Assert.That(packageElement.Name, Is.EqualTo("uml:Package"));
+            Assert.That(packageElement.GetAttribute("xmi:type"), Is.EqualTo("uml:Package"));
+            Assert.That(packageElement.GetAttribute("xmi:id"), Is.EqualTo("Package-1"));
+            Assert.That(packageElement.GetAttribute("name"), Is.EqualTo("package"));
+
+            var classElement = (XmlElement)packageElement.FirstChild;
+
+            Assert.That(classElement.Name, Is.EqualTo("packagedElement"));
+            Assert.That(classElement.GetAttribute("xmi:type"), Is.EqualTo("uml:Class"));
+            Assert.That(classElement.GetAttribute("xmi:id"), Is.EqualTo("Class-1"));
+            Assert.That(classElement.GetAttribute("name"), Is.EqualTo("class"));
+        }
+
+        [Test]
+        public void Verify_that_a_model_is_written_with_a_uml_Model_root_element()
+        {
+            var model = new Model { XmiId = "Model-1", Name = "model" };
+
+            using var stream = new MemoryStream();
+
+            this.xmiWriter.Write(model, stream, "output.xmi");
+
+            var xmlDocument = new XmlDocument();
+            stream.Position = 0;
+            xmlDocument.Load(stream);
+
+            var modelElement = (XmlElement)xmlDocument.DocumentElement.FirstChild;
+
+            Assert.That(modelElement.Name, Is.EqualTo("uml:Model"));
+            Assert.That(modelElement.GetAttribute("xmi:type"), Is.EqualTo("uml:Model"));
+        }
+
+        [Test]
+        public void Verify_that_Write_to_a_file_creates_the_file()
+        {
+            var fileUri = Path.Combine(TestContext.CurrentContext.WorkDirectory, "xmi-writer-test-output.xmi");
+
+            this.xmiWriter.Write(this.package, fileUri);
+
+            Assert.That(File.Exists(fileUri), Is.True);
+
+            var content = File.ReadAllText(fileUri);
+
+            Assert.That(content, Does.Contain("uml:Package"));
+        }
+
+        [Test]
+        public async Task Verify_that_WriteAsync_to_a_file_creates_the_file()
+        {
+            var fileUri = Path.Combine(TestContext.CurrentContext.WorkDirectory, "xmi-writer-test-output-async.xmi");
+
+            await this.xmiWriter.WriteAsync(this.package, fileUri);
+
+            Assert.That(File.Exists(fileUri), Is.True);
+
+            var content = await File.ReadAllTextAsync(fileUri);
+
+            Assert.That(content, Does.Contain("uml:Package"));
+        }
+    }
+}

--- a/uml4net.xmi/AutoGenXmiWriters/AbstractionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AbstractionWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AbstractionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="AbstractionWriter"/> is to write an instance of <see cref="IAbstraction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class AbstractionWriter : XmiElementWriter<IAbstraction>, IXmiElementWriter<IAbstraction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<AbstractionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbstractionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public AbstractionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<AbstractionWriter>.Instance : loggerFactory.CreateLogger<AbstractionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IAbstraction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAbstraction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IAbstraction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Abstraction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Abstraction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IAbstraction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAbstraction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IAbstraction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Abstraction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Abstraction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/AcceptCallActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AcceptCallActionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AcceptCallActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="AcceptCallActionWriter"/> is to write an instance of <see cref="IAcceptCallAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class AcceptCallActionWriter : XmiElementWriter<IAcceptCallAction>, IXmiElementWriter<IAcceptCallAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<AcceptCallActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AcceptCallActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public AcceptCallActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<AcceptCallActionWriter>.Instance : loggerFactory.CreateLogger<AcceptCallActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IAcceptCallAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAcceptCallAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IAcceptCallAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AcceptCallAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AcceptCallAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsUnmarshall)
+            {
+                xmlWriter.WriteAttributeString("isUnmarshall", XmlConvert.ToString(element.IsUnmarshall));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.ReturnInformation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "returnInformation", writeContext);
+            }
+
+            foreach (var value in element.Trigger)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "trigger", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IAcceptCallAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAcceptCallAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IAcceptCallAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AcceptCallAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AcceptCallAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsUnmarshall)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnmarshall", null, XmlConvert.ToString(element.IsUnmarshall));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.ReturnInformation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "returnInformation", writeContext);
+            }
+
+            foreach (var value in element.Trigger)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/AcceptEventActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AcceptEventActionWriter.cs
@@ -1,0 +1,416 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AcceptEventActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="AcceptEventActionWriter"/> is to write an instance of <see cref="IAcceptEventAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class AcceptEventActionWriter : XmiElementWriter<IAcceptEventAction>, IXmiElementWriter<IAcceptEventAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<AcceptEventActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AcceptEventActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public AcceptEventActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<AcceptEventActionWriter>.Instance : loggerFactory.CreateLogger<AcceptEventActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IAcceptEventAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAcceptEventAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IAcceptEventAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AcceptEventAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AcceptEventAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsUnmarshall)
+            {
+                xmlWriter.WriteAttributeString("isUnmarshall", XmlConvert.ToString(element.IsUnmarshall));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.Trigger)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "trigger", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IAcceptEventAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAcceptEventAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IAcceptEventAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AcceptEventAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AcceptEventAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsUnmarshall)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnmarshall", null, XmlConvert.ToString(element.IsUnmarshall));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.Trigger)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ActionExecutionSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActionExecutionSpecificationWriter.cs
@@ -1,0 +1,366 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActionExecutionSpecificationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ActionExecutionSpecificationWriter"/> is to write an instance of <see cref="IActionExecutionSpecification"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ActionExecutionSpecificationWriter : XmiElementWriter<IActionExecutionSpecification>, IXmiElementWriter<IActionExecutionSpecification>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ActionExecutionSpecificationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActionExecutionSpecificationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ActionExecutionSpecificationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ActionExecutionSpecificationWriter>.Instance : loggerFactory.CreateLogger<ActionExecutionSpecificationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IActionExecutionSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActionExecutionSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IActionExecutionSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ActionExecutionSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActionExecutionSpecification");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Action != null && writeContext.IsLocal(element.Action))
+            {
+                xmlWriter.WriteAttributeString("action", element.Action.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (element.Finish != null && writeContext.IsLocal(element.Finish))
+            {
+                xmlWriter.WriteAttributeString("finish", element.Finish.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Start != null && writeContext.IsLocal(element.Start))
+            {
+                xmlWriter.WriteAttributeString("start", element.Start.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Action != null && !writeContext.IsLocal(element.Action))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Action, "action", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            if (element.Finish != null && !writeContext.IsLocal(element.Finish))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Finish, "finish", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Start != null && !writeContext.IsLocal(element.Start))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Start, "start", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IActionExecutionSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActionExecutionSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IActionExecutionSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ActionExecutionSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActionExecutionSpecification");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Action != null && writeContext.IsLocal(element.Action))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "action", null, element.Action.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (element.Finish != null && writeContext.IsLocal(element.Finish))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "finish", null, element.Finish.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Start != null && writeContext.IsLocal(element.Start))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "start", null, element.Start.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Action != null && !writeContext.IsLocal(element.Action))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Action, "action", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            if (element.Finish != null && !writeContext.IsLocal(element.Finish))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Finish, "finish", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Start != null && !writeContext.IsLocal(element.Start))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Start, "start", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ActionInputPinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActionInputPinWriter.cs
@@ -1,0 +1,486 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActionInputPinWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ActionInputPinWriter"/> is to write an instance of <see cref="IActionInputPin"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ActionInputPinWriter : XmiElementWriter<IActionInputPin>, IXmiElementWriter<IActionInputPin>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ActionInputPinWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActionInputPinWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ActionInputPinWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ActionInputPinWriter>.Instance : loggerFactory.CreateLogger<ActionInputPinWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IActionInputPin"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActionInputPin"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IActionInputPin element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ActionInputPin with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActionInputPin");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControl)
+            {
+                xmlWriter.WriteAttributeString("isControl", XmlConvert.ToString(element.IsControl));
+            }
+
+            if (element.IsControlType)
+            {
+                xmlWriter.WriteAttributeString("isControlType", XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                xmlWriter.WriteAttributeString("ordering", LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                xmlWriter.WriteAttributeString("selection", element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.FromAction)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "fromAction", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperBound", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IActionInputPin"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActionInputPin"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IActionInputPin element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ActionInputPin with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActionInputPin");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControl)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControl", null, XmlConvert.ToString(element.IsControl));
+            }
+
+            if (element.IsControlType)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControlType", null, XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "ordering", null, LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "selection", null, element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.FromAction)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "fromAction", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityFinalNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityFinalNodeWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActivityFinalNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ActivityFinalNodeWriter"/> is to write an instance of <see cref="IActivityFinalNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ActivityFinalNodeWriter : XmiElementWriter<IActivityFinalNode>, IXmiElementWriter<IActivityFinalNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ActivityFinalNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityFinalNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ActivityFinalNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ActivityFinalNodeWriter>.Instance : loggerFactory.CreateLogger<ActivityFinalNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IActivityFinalNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActivityFinalNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IActivityFinalNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ActivityFinalNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityFinalNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IActivityFinalNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActivityFinalNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IActivityFinalNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ActivityFinalNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityFinalNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityParameterNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityParameterNodeWriter.cs
@@ -1,0 +1,446 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActivityParameterNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ActivityParameterNodeWriter"/> is to write an instance of <see cref="IActivityParameterNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ActivityParameterNodeWriter : XmiElementWriter<IActivityParameterNode>, IXmiElementWriter<IActivityParameterNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ActivityParameterNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityParameterNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ActivityParameterNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ActivityParameterNodeWriter>.Instance : loggerFactory.CreateLogger<ActivityParameterNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IActivityParameterNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActivityParameterNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IActivityParameterNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ActivityParameterNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityParameterNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControlType)
+            {
+                xmlWriter.WriteAttributeString("isControlType", XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                xmlWriter.WriteAttributeString("ordering", LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Parameter != null && writeContext.IsLocal(element.Parameter))
+            {
+                xmlWriter.WriteAttributeString("parameter", element.Parameter.XmiId);
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                xmlWriter.WriteAttributeString("selection", element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Parameter != null && !writeContext.IsLocal(element.Parameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Parameter, "parameter", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperBound", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IActivityParameterNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActivityParameterNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IActivityParameterNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ActivityParameterNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityParameterNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControlType)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControlType", null, XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "ordering", null, LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Parameter != null && writeContext.IsLocal(element.Parameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "parameter", null, element.Parameter.XmiId);
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "selection", null, element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Parameter != null && !writeContext.IsLocal(element.Parameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Parameter, "parameter", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityPartitionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityPartitionWriter.cs
@@ -1,0 +1,356 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActivityPartitionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ActivityPartitionWriter"/> is to write an instance of <see cref="IActivityPartition"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ActivityPartitionWriter : XmiElementWriter<IActivityPartition>, IXmiElementWriter<IActivityPartition>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ActivityPartitionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityPartitionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ActivityPartitionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ActivityPartitionWriter>.Instance : loggerFactory.CreateLogger<ActivityPartitionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IActivityPartition"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActivityPartition"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IActivityPartition element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ActivityPartition with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityPartition");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.InActivity != null && writeContext.IsLocal(element.InActivity))
+            {
+                xmlWriter.WriteAttributeString("inActivity", element.InActivity.XmiId);
+            }
+
+            if (element.IsDimension)
+            {
+                xmlWriter.WriteAttributeString("isDimension", XmlConvert.ToString(element.IsDimension));
+            }
+
+            if (element.IsExternal)
+            {
+                xmlWriter.WriteAttributeString("isExternal", XmlConvert.ToString(element.IsExternal));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Represents != null && writeContext.IsLocal(element.Represents))
+            {
+                xmlWriter.WriteAttributeString("represents", element.Represents.XmiId);
+            }
+
+            if (element.SuperPartition != null && writeContext.IsLocal(element.SuperPartition))
+            {
+                xmlWriter.WriteAttributeString("superPartition", element.SuperPartition.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Edge)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "edge", writeContext);
+            }
+
+            if (element.InActivity != null && !writeContext.IsLocal(element.InActivity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InActivity, "inActivity", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Represents != null && !writeContext.IsLocal(element.Represents))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Represents, "represents", writeContext);
+            }
+
+            foreach (var value in element.Subpartition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "subpartition", writeContext);
+            }
+
+            if (element.SuperPartition != null && !writeContext.IsLocal(element.SuperPartition))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.SuperPartition, "superPartition", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IActivityPartition"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActivityPartition"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IActivityPartition element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ActivityPartition with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityPartition");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.InActivity != null && writeContext.IsLocal(element.InActivity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inActivity", null, element.InActivity.XmiId);
+            }
+
+            if (element.IsDimension)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDimension", null, XmlConvert.ToString(element.IsDimension));
+            }
+
+            if (element.IsExternal)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isExternal", null, XmlConvert.ToString(element.IsExternal));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Represents != null && writeContext.IsLocal(element.Represents))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "represents", null, element.Represents.XmiId);
+            }
+
+            if (element.SuperPartition != null && writeContext.IsLocal(element.SuperPartition))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "superPartition", null, element.SuperPartition.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Edge)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "edge", writeContext);
+            }
+
+            if (element.InActivity != null && !writeContext.IsLocal(element.InActivity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InActivity, "inActivity", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Represents != null && !writeContext.IsLocal(element.Represents))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Represents, "represents", writeContext);
+            }
+
+            foreach (var value in element.Subpartition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "subpartition", writeContext);
+            }
+
+            if (element.SuperPartition != null && !writeContext.IsLocal(element.SuperPartition))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.SuperPartition, "superPartition", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityWriter.cs
@@ -1,0 +1,736 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActivityWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ActivityWriter"/> is to write an instance of <see cref="IActivity"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ActivityWriter : XmiElementWriter<IActivity>, IXmiElementWriter<IActivity>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ActivityWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ActivityWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ActivityWriter>.Instance : loggerFactory.CreateLogger<ActivityWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IActivity"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActivity"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IActivity element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Activity with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Activity");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsReadOnly)
+            {
+                xmlWriter.WriteAttributeString("isReadOnly", XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (!element.IsReentrant)
+            {
+                xmlWriter.WriteAttributeString("isReentrant", XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (element.IsSingleExecution)
+            {
+                xmlWriter.WriteAttributeString("isSingleExecution", XmlConvert.ToString(element.IsSingleExecution));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                xmlWriter.WriteAttributeString("specification", element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Group)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "group", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Partition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "partition", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedBehavior", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.StructuredNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "structuredNode", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IActivity"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActivity"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IActivity element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Activity with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Activity");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsReadOnly)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReadOnly", null, XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (!element.IsReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReentrant", null, XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (element.IsSingleExecution)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isSingleExecution", null, XmlConvert.ToString(element.IsSingleExecution));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specification", null, element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Group)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "group", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Partition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "partition", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedBehavior", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.StructuredNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "structuredNode", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ActorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActorWriter.cs
@@ -1,0 +1,516 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ActorWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ActorWriter"/> is to write an instance of <see cref="IActor"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ActorWriter : XmiElementWriter<IActor>, IXmiElementWriter<IActor>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ActorWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ActorWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ActorWriter>.Instance : loggerFactory.CreateLogger<ActorWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IActor"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActor"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IActor element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Actor with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Actor");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IActor"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IActor"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IActor element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Actor with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Actor");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/AddStructuralFeatureValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AddStructuralFeatureValueActionWriter.cs
@@ -1,0 +1,456 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AddStructuralFeatureValueActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="AddStructuralFeatureValueActionWriter"/> is to write an instance of <see cref="IAddStructuralFeatureValueAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class AddStructuralFeatureValueActionWriter : XmiElementWriter<IAddStructuralFeatureValueAction>, IXmiElementWriter<IAddStructuralFeatureValueAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<AddStructuralFeatureValueActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddStructuralFeatureValueActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public AddStructuralFeatureValueActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<AddStructuralFeatureValueActionWriter>.Instance : loggerFactory.CreateLogger<AddStructuralFeatureValueActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IAddStructuralFeatureValueAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAddStructuralFeatureValueAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IAddStructuralFeatureValueAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AddStructuralFeatureValueAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AddStructuralFeatureValueAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsReplaceAll)
+            {
+                xmlWriter.WriteAttributeString("isReplaceAll", XmlConvert.ToString(element.IsReplaceAll));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.StructuralFeature != null && writeContext.IsLocal(element.StructuralFeature))
+            {
+                xmlWriter.WriteAttributeString("structuralFeature", element.StructuralFeature.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InsertAt)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "insertAt", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.StructuralFeature != null && !writeContext.IsLocal(element.StructuralFeature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "value", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IAddStructuralFeatureValueAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAddStructuralFeatureValueAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IAddStructuralFeatureValueAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AddStructuralFeatureValueAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AddStructuralFeatureValueAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsReplaceAll)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReplaceAll", null, XmlConvert.ToString(element.IsReplaceAll));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.StructuralFeature != null && writeContext.IsLocal(element.StructuralFeature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "structuralFeature", null, element.StructuralFeature.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InsertAt)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "insertAt", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.StructuralFeature != null && !writeContext.IsLocal(element.StructuralFeature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/AddVariableValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AddVariableValueActionWriter.cs
@@ -1,0 +1,436 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AddVariableValueActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="AddVariableValueActionWriter"/> is to write an instance of <see cref="IAddVariableValueAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class AddVariableValueActionWriter : XmiElementWriter<IAddVariableValueAction>, IXmiElementWriter<IAddVariableValueAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<AddVariableValueActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddVariableValueActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public AddVariableValueActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<AddVariableValueActionWriter>.Instance : loggerFactory.CreateLogger<AddVariableValueActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IAddVariableValueAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAddVariableValueAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IAddVariableValueAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AddVariableValueAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AddVariableValueAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsReplaceAll)
+            {
+                xmlWriter.WriteAttributeString("isReplaceAll", XmlConvert.ToString(element.IsReplaceAll));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Variable != null && writeContext.IsLocal(element.Variable))
+            {
+                xmlWriter.WriteAttributeString("variable", element.Variable.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InsertAt)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "insertAt", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "value", writeContext);
+            }
+
+            if (element.Variable != null && !writeContext.IsLocal(element.Variable))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Variable, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IAddVariableValueAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAddVariableValueAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IAddVariableValueAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AddVariableValueAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AddVariableValueAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsReplaceAll)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReplaceAll", null, XmlConvert.ToString(element.IsReplaceAll));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Variable != null && writeContext.IsLocal(element.Variable))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "variable", null, element.Variable.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InsertAt)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "insertAt", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
+            }
+
+            if (element.Variable != null && !writeContext.IsLocal(element.Variable))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/AnyReceiveEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AnyReceiveEventWriter.cs
@@ -1,0 +1,286 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AnyReceiveEventWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="AnyReceiveEventWriter"/> is to write an instance of <see cref="IAnyReceiveEvent"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class AnyReceiveEventWriter : XmiElementWriter<IAnyReceiveEvent>, IXmiElementWriter<IAnyReceiveEvent>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<AnyReceiveEventWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AnyReceiveEventWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public AnyReceiveEventWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<AnyReceiveEventWriter>.Instance : loggerFactory.CreateLogger<AnyReceiveEventWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IAnyReceiveEvent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAnyReceiveEvent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IAnyReceiveEvent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AnyReceiveEvent with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AnyReceiveEvent");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IAnyReceiveEvent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAnyReceiveEvent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IAnyReceiveEvent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AnyReceiveEvent with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AnyReceiveEvent");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ArtifactWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ArtifactWriter.cs
@@ -1,0 +1,526 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ArtifactWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ArtifactWriter"/> is to write an instance of <see cref="IArtifact"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ArtifactWriter : XmiElementWriter<IArtifact>, IXmiElementWriter<IArtifact>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ArtifactWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArtifactWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ArtifactWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ArtifactWriter>.Instance : loggerFactory.CreateLogger<ArtifactWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IArtifact"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IArtifact"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IArtifact element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Artifact with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Artifact");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.FileName))
+            {
+                xmlWriter.WriteAttributeString("fileName", element.FileName);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Manifestation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "manifestation", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedArtifact)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedArtifact", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IArtifact"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IArtifact"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IArtifact element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Artifact with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Artifact");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.FileName))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "fileName", null, element.FileName);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Manifestation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "manifestation", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedArtifact)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedArtifact", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/AssociationClassWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AssociationClassWriter.cs
@@ -1,0 +1,616 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AssociationClassWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="AssociationClassWriter"/> is to write an instance of <see cref="IAssociationClass"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class AssociationClassWriter : XmiElementWriter<IAssociationClass>, IXmiElementWriter<IAssociationClass>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<AssociationClassWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssociationClassWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public AssociationClassWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<AssociationClassWriter>.Instance : loggerFactory.CreateLogger<AssociationClassWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IAssociationClass"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAssociationClass"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IAssociationClass element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AssociationClass with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AssociationClass");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsDerived)
+            {
+                xmlWriter.WriteAttributeString("isDerived", XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.MemberEnd)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "memberEnd", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NavigableOwnedEnd)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "navigableOwnedEnd", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedEnd)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IAssociationClass"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAssociationClass"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IAssociationClass element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the AssociationClass with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AssociationClass");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsDerived)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerived", null, XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.MemberEnd)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "memberEnd", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NavigableOwnedEnd)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "navigableOwnedEnd", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedEnd)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/AssociationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AssociationWriter.cs
@@ -1,0 +1,516 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AssociationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="AssociationWriter"/> is to write an instance of <see cref="IAssociation"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class AssociationWriter : XmiElementWriter<IAssociation>, IXmiElementWriter<IAssociation>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<AssociationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssociationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public AssociationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<AssociationWriter>.Instance : loggerFactory.CreateLogger<AssociationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IAssociation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAssociation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IAssociation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Association with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Association");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsDerived)
+            {
+                xmlWriter.WriteAttributeString("isDerived", XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.MemberEnd)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "memberEnd", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NavigableOwnedEnd)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "navigableOwnedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedEnd)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IAssociation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IAssociation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IAssociation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Association with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Association");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsDerived)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerived", null, XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.MemberEnd)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "memberEnd", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NavigableOwnedEnd)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "navigableOwnedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedEnd)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/BehaviorExecutionSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/BehaviorExecutionSpecificationWriter.cs
@@ -1,0 +1,366 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="BehaviorExecutionSpecificationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="BehaviorExecutionSpecificationWriter"/> is to write an instance of <see cref="IBehaviorExecutionSpecification"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class BehaviorExecutionSpecificationWriter : XmiElementWriter<IBehaviorExecutionSpecification>, IXmiElementWriter<IBehaviorExecutionSpecification>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<BehaviorExecutionSpecificationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BehaviorExecutionSpecificationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public BehaviorExecutionSpecificationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<BehaviorExecutionSpecificationWriter>.Instance : loggerFactory.CreateLogger<BehaviorExecutionSpecificationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IBehaviorExecutionSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IBehaviorExecutionSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IBehaviorExecutionSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the BehaviorExecutionSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:BehaviorExecutionSpecification");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Behavior != null && writeContext.IsLocal(element.Behavior))
+            {
+                xmlWriter.WriteAttributeString("behavior", element.Behavior.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (element.Finish != null && writeContext.IsLocal(element.Finish))
+            {
+                xmlWriter.WriteAttributeString("finish", element.Finish.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Start != null && writeContext.IsLocal(element.Start))
+            {
+                xmlWriter.WriteAttributeString("start", element.Start.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Behavior != null && !writeContext.IsLocal(element.Behavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Behavior, "behavior", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            if (element.Finish != null && !writeContext.IsLocal(element.Finish))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Finish, "finish", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Start != null && !writeContext.IsLocal(element.Start))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Start, "start", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IBehaviorExecutionSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IBehaviorExecutionSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IBehaviorExecutionSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the BehaviorExecutionSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:BehaviorExecutionSpecification");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Behavior != null && writeContext.IsLocal(element.Behavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "behavior", null, element.Behavior.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (element.Finish != null && writeContext.IsLocal(element.Finish))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "finish", null, element.Finish.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Start != null && writeContext.IsLocal(element.Start))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "start", null, element.Start.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Behavior != null && !writeContext.IsLocal(element.Behavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Behavior, "behavior", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            if (element.Finish != null && !writeContext.IsLocal(element.Finish))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Finish, "finish", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Start != null && !writeContext.IsLocal(element.Start))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Start, "start", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/BroadcastSignalActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/BroadcastSignalActionWriter.cs
@@ -1,0 +1,436 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="BroadcastSignalActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="BroadcastSignalActionWriter"/> is to write an instance of <see cref="IBroadcastSignalAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class BroadcastSignalActionWriter : XmiElementWriter<IBroadcastSignalAction>, IXmiElementWriter<IBroadcastSignalAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<BroadcastSignalActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BroadcastSignalActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public BroadcastSignalActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<BroadcastSignalActionWriter>.Instance : loggerFactory.CreateLogger<BroadcastSignalActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IBroadcastSignalAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IBroadcastSignalAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IBroadcastSignalAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the BroadcastSignalAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:BroadcastSignalAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                xmlWriter.WriteAttributeString("onPort", element.OnPort.XmiId);
+            }
+
+            if (element.Signal != null && writeContext.IsLocal(element.Signal))
+            {
+                xmlWriter.WriteAttributeString("signal", element.Signal.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Signal != null && !writeContext.IsLocal(element.Signal))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signal, "signal", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IBroadcastSignalAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IBroadcastSignalAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IBroadcastSignalAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the BroadcastSignalAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:BroadcastSignalAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "onPort", null, element.OnPort.XmiId);
+            }
+
+            if (element.Signal != null && writeContext.IsLocal(element.Signal))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "signal", null, element.Signal.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Signal != null && !writeContext.IsLocal(element.Signal))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signal, "signal", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CallBehaviorActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CallBehaviorActionWriter.cs
@@ -1,0 +1,456 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CallBehaviorActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CallBehaviorActionWriter"/> is to write an instance of <see cref="ICallBehaviorAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CallBehaviorActionWriter : XmiElementWriter<ICallBehaviorAction>, IXmiElementWriter<ICallBehaviorAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CallBehaviorActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallBehaviorActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CallBehaviorActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CallBehaviorActionWriter>.Instance : loggerFactory.CreateLogger<CallBehaviorActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICallBehaviorAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICallBehaviorAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICallBehaviorAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CallBehaviorAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallBehaviorAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.Behavior != null && writeContext.IsLocal(element.Behavior))
+            {
+                xmlWriter.WriteAttributeString("behavior", element.Behavior.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!element.IsSynchronous)
+            {
+                xmlWriter.WriteAttributeString("isSynchronous", XmlConvert.ToString(element.IsSynchronous));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                xmlWriter.WriteAttributeString("onPort", element.OnPort.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "argument", writeContext);
+            }
+
+            if (element.Behavior != null && !writeContext.IsLocal(element.Behavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Behavior, "behavior", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICallBehaviorAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICallBehaviorAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICallBehaviorAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CallBehaviorAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallBehaviorAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.Behavior != null && writeContext.IsLocal(element.Behavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "behavior", null, element.Behavior.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!element.IsSynchronous)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isSynchronous", null, XmlConvert.ToString(element.IsSynchronous));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "onPort", null, element.OnPort.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "argument", writeContext);
+            }
+
+            if (element.Behavior != null && !writeContext.IsLocal(element.Behavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Behavior, "behavior", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CallEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CallEventWriter.cs
@@ -1,0 +1,306 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CallEventWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CallEventWriter"/> is to write an instance of <see cref="ICallEvent"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CallEventWriter : XmiElementWriter<ICallEvent>, IXmiElementWriter<ICallEvent>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CallEventWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallEventWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CallEventWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CallEventWriter>.Instance : loggerFactory.CreateLogger<CallEventWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICallEvent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICallEvent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICallEvent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CallEvent with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallEvent");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Operation != null && writeContext.IsLocal(element.Operation))
+            {
+                xmlWriter.WriteAttributeString("operation", element.Operation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.Operation != null && !writeContext.IsLocal(element.Operation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Operation, "operation", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICallEvent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICallEvent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICallEvent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CallEvent with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallEvent");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Operation != null && writeContext.IsLocal(element.Operation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "operation", null, element.Operation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.Operation != null && !writeContext.IsLocal(element.Operation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Operation, "operation", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CallOperationActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CallOperationActionWriter.cs
@@ -1,0 +1,466 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CallOperationActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CallOperationActionWriter"/> is to write an instance of <see cref="ICallOperationAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CallOperationActionWriter : XmiElementWriter<ICallOperationAction>, IXmiElementWriter<ICallOperationAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CallOperationActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallOperationActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CallOperationActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CallOperationActionWriter>.Instance : loggerFactory.CreateLogger<CallOperationActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICallOperationAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICallOperationAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICallOperationAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CallOperationAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallOperationAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!element.IsSynchronous)
+            {
+                xmlWriter.WriteAttributeString("isSynchronous", XmlConvert.ToString(element.IsSynchronous));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                xmlWriter.WriteAttributeString("onPort", element.OnPort.XmiId);
+            }
+
+            if (element.Operation != null && writeContext.IsLocal(element.Operation))
+            {
+                xmlWriter.WriteAttributeString("operation", element.Operation.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            if (element.Operation != null && !writeContext.IsLocal(element.Operation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Operation, "operation", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.Target)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "target", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICallOperationAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICallOperationAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICallOperationAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CallOperationAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallOperationAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!element.IsSynchronous)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isSynchronous", null, XmlConvert.ToString(element.IsSynchronous));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "onPort", null, element.OnPort.XmiId);
+            }
+
+            if (element.Operation != null && writeContext.IsLocal(element.Operation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "operation", null, element.Operation.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            if (element.Operation != null && !writeContext.IsLocal(element.Operation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Operation, "operation", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.Target)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CentralBufferNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CentralBufferNodeWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CentralBufferNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CentralBufferNodeWriter"/> is to write an instance of <see cref="ICentralBufferNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CentralBufferNodeWriter : XmiElementWriter<ICentralBufferNode>, IXmiElementWriter<ICentralBufferNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CentralBufferNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CentralBufferNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CentralBufferNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CentralBufferNodeWriter>.Instance : loggerFactory.CreateLogger<CentralBufferNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICentralBufferNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICentralBufferNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICentralBufferNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CentralBufferNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CentralBufferNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControlType)
+            {
+                xmlWriter.WriteAttributeString("isControlType", XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                xmlWriter.WriteAttributeString("ordering", LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                xmlWriter.WriteAttributeString("selection", element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperBound", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICentralBufferNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICentralBufferNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICentralBufferNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CentralBufferNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CentralBufferNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControlType)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControlType", null, XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "ordering", null, LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "selection", null, element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ChangeEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ChangeEventWriter.cs
@@ -1,0 +1,296 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ChangeEventWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ChangeEventWriter"/> is to write an instance of <see cref="IChangeEvent"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ChangeEventWriter : XmiElementWriter<IChangeEvent>, IXmiElementWriter<IChangeEvent>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ChangeEventWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangeEventWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ChangeEventWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ChangeEventWriter>.Instance : loggerFactory.CreateLogger<ChangeEventWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IChangeEvent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IChangeEvent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IChangeEvent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ChangeEvent with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ChangeEvent");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ChangeExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "changeExpression", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IChangeEvent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IChangeEvent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IChangeEvent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ChangeEvent with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ChangeEvent");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ChangeExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "changeExpression", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ClassWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClassWriter.cs
@@ -1,0 +1,576 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ClassWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ClassWriter"/> is to write an instance of <see cref="IClass"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ClassWriter : XmiElementWriter<IClass>, IXmiElementWriter<IClass>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ClassWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClassWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ClassWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ClassWriter>.Instance : loggerFactory.CreateLogger<ClassWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IClass"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClass"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IClass element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Class with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Class");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IClass"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClass"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IClass element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Class with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Class");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ClassifierTemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClassifierTemplateParameterWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ClassifierTemplateParameterWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ClassifierTemplateParameterWriter"/> is to write an instance of <see cref="IClassifierTemplateParameter"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ClassifierTemplateParameterWriter : XmiElementWriter<IClassifierTemplateParameter>, IXmiElementWriter<IClassifierTemplateParameter>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ClassifierTemplateParameterWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClassifierTemplateParameterWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ClassifierTemplateParameterWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ClassifierTemplateParameterWriter>.Instance : loggerFactory.CreateLogger<ClassifierTemplateParameterWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IClassifierTemplateParameter"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClassifierTemplateParameter"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IClassifierTemplateParameter element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ClassifierTemplateParameter with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClassifierTemplateParameter");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!element.AllowSubstitutable)
+            {
+                xmlWriter.WriteAttributeString("allowSubstitutable", XmlConvert.ToString(element.AllowSubstitutable));
+            }
+
+            if (element.Default != null && writeContext.IsLocal(element.Default))
+            {
+                xmlWriter.WriteAttributeString("default", element.Default.XmiId);
+            }
+
+            if (element.ParameteredElement != null && writeContext.IsLocal(element.ParameteredElement))
+            {
+                xmlWriter.WriteAttributeString("parameteredElement", element.ParameteredElement.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                xmlWriter.WriteAttributeString("signature", element.Signature.XmiId);
+            }
+
+
+            foreach (var value in element.ConstrainingClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "constrainingClassifier", writeContext);
+            }
+
+            if (element.Default != null && !writeContext.IsLocal(element.Default))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Default, "default", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedDefault)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedDefault", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameteredElement)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameteredElement", writeContext);
+            }
+
+            if (element.ParameteredElement != null && !writeContext.IsLocal(element.ParameteredElement))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ParameteredElement, "parameteredElement", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IClassifierTemplateParameter"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClassifierTemplateParameter"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IClassifierTemplateParameter element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ClassifierTemplateParameter with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClassifierTemplateParameter");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!element.AllowSubstitutable)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "allowSubstitutable", null, XmlConvert.ToString(element.AllowSubstitutable));
+            }
+
+            if (element.Default != null && writeContext.IsLocal(element.Default))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "default", null, element.Default.XmiId);
+            }
+
+            if (element.ParameteredElement != null && writeContext.IsLocal(element.ParameteredElement))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "parameteredElement", null, element.ParameteredElement.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "signature", null, element.Signature.XmiId);
+            }
+
+
+            foreach (var value in element.ConstrainingClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "constrainingClassifier", writeContext);
+            }
+
+            if (element.Default != null && !writeContext.IsLocal(element.Default))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Default, "default", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedDefault)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedDefault", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameteredElement)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameteredElement", writeContext);
+            }
+
+            if (element.ParameteredElement != null && !writeContext.IsLocal(element.ParameteredElement))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ParameteredElement, "parameteredElement", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ClauseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClauseWriter.cs
@@ -1,0 +1,286 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ClauseWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ClauseWriter"/> is to write an instance of <see cref="IClause"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ClauseWriter : XmiElementWriter<IClause>, IXmiElementWriter<IClause>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ClauseWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClauseWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ClauseWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ClauseWriter>.Instance : loggerFactory.CreateLogger<ClauseWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IClause"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClause"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IClause element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Clause with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Clause");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Decider != null && writeContext.IsLocal(element.Decider))
+            {
+                xmlWriter.WriteAttributeString("decider", element.Decider.XmiId);
+            }
+
+
+            foreach (var value in element.Body)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "body", writeContext);
+            }
+
+            foreach (var value in element.BodyOutput)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "bodyOutput", writeContext);
+            }
+
+            if (element.Decider != null && !writeContext.IsLocal(element.Decider))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Decider, "decider", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.PredecessorClause)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "predecessorClause", writeContext);
+            }
+
+            foreach (var value in element.SuccessorClause)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "successorClause", writeContext);
+            }
+
+            foreach (var value in element.Test)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "test", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IClause"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClause"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IClause element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Clause with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Clause");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Decider != null && writeContext.IsLocal(element.Decider))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "decider", null, element.Decider.XmiId);
+            }
+
+
+            foreach (var value in element.Body)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "body", writeContext);
+            }
+
+            foreach (var value in element.BodyOutput)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "bodyOutput", writeContext);
+            }
+
+            if (element.Decider != null && !writeContext.IsLocal(element.Decider))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Decider, "decider", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.PredecessorClause)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "predecessorClause", writeContext);
+            }
+
+            foreach (var value in element.SuccessorClause)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "successorClause", writeContext);
+            }
+
+            foreach (var value in element.Test)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "test", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ClearAssociationActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClearAssociationActionWriter.cs
@@ -1,0 +1,416 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ClearAssociationActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ClearAssociationActionWriter"/> is to write an instance of <see cref="IClearAssociationAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ClearAssociationActionWriter : XmiElementWriter<IClearAssociationAction>, IXmiElementWriter<IClearAssociationAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ClearAssociationActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClearAssociationActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ClearAssociationActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ClearAssociationActionWriter>.Instance : loggerFactory.CreateLogger<ClearAssociationActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IClearAssociationAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClearAssociationAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IClearAssociationAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ClearAssociationAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearAssociationAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.Association != null && writeContext.IsLocal(element.Association))
+            {
+                xmlWriter.WriteAttributeString("association", element.Association.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.Association != null && !writeContext.IsLocal(element.Association))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Association, "association", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IClearAssociationAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClearAssociationAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IClearAssociationAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ClearAssociationAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearAssociationAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.Association != null && writeContext.IsLocal(element.Association))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "association", null, element.Association.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.Association != null && !writeContext.IsLocal(element.Association))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Association, "association", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ClearStructuralFeatureActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClearStructuralFeatureActionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ClearStructuralFeatureActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ClearStructuralFeatureActionWriter"/> is to write an instance of <see cref="IClearStructuralFeatureAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ClearStructuralFeatureActionWriter : XmiElementWriter<IClearStructuralFeatureAction>, IXmiElementWriter<IClearStructuralFeatureAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ClearStructuralFeatureActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClearStructuralFeatureActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ClearStructuralFeatureActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ClearStructuralFeatureActionWriter>.Instance : loggerFactory.CreateLogger<ClearStructuralFeatureActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IClearStructuralFeatureAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClearStructuralFeatureAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IClearStructuralFeatureAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ClearStructuralFeatureAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearStructuralFeatureAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.StructuralFeature != null && writeContext.IsLocal(element.StructuralFeature))
+            {
+                xmlWriter.WriteAttributeString("structuralFeature", element.StructuralFeature.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.StructuralFeature != null && !writeContext.IsLocal(element.StructuralFeature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IClearStructuralFeatureAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClearStructuralFeatureAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IClearStructuralFeatureAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ClearStructuralFeatureAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearStructuralFeatureAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.StructuralFeature != null && writeContext.IsLocal(element.StructuralFeature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "structuralFeature", null, element.StructuralFeature.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.StructuralFeature != null && !writeContext.IsLocal(element.StructuralFeature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ClearVariableActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClearVariableActionWriter.cs
@@ -1,0 +1,406 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ClearVariableActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ClearVariableActionWriter"/> is to write an instance of <see cref="IClearVariableAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ClearVariableActionWriter : XmiElementWriter<IClearVariableAction>, IXmiElementWriter<IClearVariableAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ClearVariableActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClearVariableActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ClearVariableActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ClearVariableActionWriter>.Instance : loggerFactory.CreateLogger<ClearVariableActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IClearVariableAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClearVariableAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IClearVariableAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ClearVariableAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearVariableAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Variable != null && writeContext.IsLocal(element.Variable))
+            {
+                xmlWriter.WriteAttributeString("variable", element.Variable.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Variable != null && !writeContext.IsLocal(element.Variable))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Variable, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IClearVariableAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IClearVariableAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IClearVariableAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ClearVariableAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearVariableAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Variable != null && writeContext.IsLocal(element.Variable))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "variable", null, element.Variable.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Variable != null && !writeContext.IsLocal(element.Variable))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CollaborationUseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CollaborationUseWriter.cs
@@ -1,0 +1,276 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CollaborationUseWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CollaborationUseWriter"/> is to write an instance of <see cref="ICollaborationUse"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CollaborationUseWriter : XmiElementWriter<ICollaborationUse>, IXmiElementWriter<ICollaborationUse>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CollaborationUseWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollaborationUseWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CollaborationUseWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CollaborationUseWriter>.Instance : loggerFactory.CreateLogger<CollaborationUseWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICollaborationUse"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICollaborationUse"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICollaborationUse element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CollaborationUse with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CollaborationUse");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RoleBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "roleBinding", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICollaborationUse"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICollaborationUse"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICollaborationUse element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CollaborationUse with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CollaborationUse");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RoleBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "roleBinding", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CollaborationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CollaborationWriter.cs
@@ -1,0 +1,546 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CollaborationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CollaborationWriter"/> is to write an instance of <see cref="ICollaboration"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CollaborationWriter : XmiElementWriter<ICollaboration>, IXmiElementWriter<ICollaboration>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CollaborationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollaborationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CollaborationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CollaborationWriter>.Instance : loggerFactory.CreateLogger<CollaborationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICollaboration"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICollaboration"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICollaboration element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Collaboration with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Collaboration");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationRole)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "collaborationRole", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICollaboration"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICollaboration"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICollaboration element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Collaboration with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Collaboration");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationRole)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "collaborationRole", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CombinedFragmentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CombinedFragmentWriter.cs
@@ -1,0 +1,336 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CombinedFragmentWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CombinedFragmentWriter"/> is to write an instance of <see cref="ICombinedFragment"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CombinedFragmentWriter : XmiElementWriter<ICombinedFragment>, IXmiElementWriter<ICombinedFragment>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CombinedFragmentWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CombinedFragmentWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CombinedFragmentWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CombinedFragmentWriter>.Instance : loggerFactory.CreateLogger<CombinedFragmentWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICombinedFragment"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICombinedFragment"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICombinedFragment element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CombinedFragment with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CombinedFragment");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (element.InteractionOperator != InteractionOperatorKind.Seq)
+            {
+                xmlWriter.WriteAttributeString("interactionOperator", LowerCaseFirstLetter(element.InteractionOperator.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CfragmentGate)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "cfragmentGate", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Operand)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "operand", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICombinedFragment"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICombinedFragment"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICombinedFragment element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CombinedFragment with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CombinedFragment");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (element.InteractionOperator != InteractionOperatorKind.Seq)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interactionOperator", null, LowerCaseFirstLetter(element.InteractionOperator.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CfragmentGate)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "cfragmentGate", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Operand)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "operand", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CommentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CommentWriter.cs
@@ -1,0 +1,236 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CommentWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CommentWriter"/> is to write an instance of <see cref="IComment"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CommentWriter : XmiElementWriter<IComment>, IXmiElementWriter<IComment>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CommentWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommentWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CommentWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CommentWriter>.Instance : loggerFactory.CreateLogger<CommentWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IComment"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IComment"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IComment element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Comment with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Comment");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Body))
+            {
+                xmlWriter.WriteAttributeString("body", element.Body);
+            }
+
+
+            foreach (var value in element.AnnotatedElement)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "annotatedElement", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IComment"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IComment"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IComment element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Comment with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Comment");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Body))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "body", null, element.Body);
+            }
+
+
+            foreach (var value in element.AnnotatedElement)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "annotatedElement", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CommunicationPathWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CommunicationPathWriter.cs
@@ -1,0 +1,516 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CommunicationPathWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CommunicationPathWriter"/> is to write an instance of <see cref="ICommunicationPath"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CommunicationPathWriter : XmiElementWriter<ICommunicationPath>, IXmiElementWriter<ICommunicationPath>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CommunicationPathWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommunicationPathWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CommunicationPathWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CommunicationPathWriter>.Instance : loggerFactory.CreateLogger<CommunicationPathWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICommunicationPath"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICommunicationPath"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICommunicationPath element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CommunicationPath with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CommunicationPath");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsDerived)
+            {
+                xmlWriter.WriteAttributeString("isDerived", XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.MemberEnd)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "memberEnd", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NavigableOwnedEnd)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "navigableOwnedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedEnd)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICommunicationPath"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICommunicationPath"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICommunicationPath element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CommunicationPath with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CommunicationPath");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsDerived)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerived", null, XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.MemberEnd)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "memberEnd", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NavigableOwnedEnd)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "navigableOwnedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedEnd)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ComponentRealizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ComponentRealizationWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ComponentRealizationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ComponentRealizationWriter"/> is to write an instance of <see cref="IComponentRealization"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ComponentRealizationWriter : XmiElementWriter<IComponentRealization>, IXmiElementWriter<IComponentRealization>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ComponentRealizationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComponentRealizationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ComponentRealizationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ComponentRealizationWriter>.Instance : loggerFactory.CreateLogger<ComponentRealizationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IComponentRealization"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IComponentRealization"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IComponentRealization element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ComponentRealization with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ComponentRealization");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Abstraction != null && writeContext.IsLocal(element.Abstraction))
+            {
+                xmlWriter.WriteAttributeString("abstraction", element.Abstraction.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Abstraction != null && !writeContext.IsLocal(element.Abstraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Abstraction, "abstraction", writeContext);
+            }
+
+            foreach (var value in element.Client)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.RealizingClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "realizingClassifier", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IComponentRealization"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IComponentRealization"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IComponentRealization element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ComponentRealization with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ComponentRealization");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Abstraction != null && writeContext.IsLocal(element.Abstraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "abstraction", null, element.Abstraction.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Abstraction != null && !writeContext.IsLocal(element.Abstraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Abstraction, "abstraction", writeContext);
+            }
+
+            foreach (var value in element.Client)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.RealizingClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "realizingClassifier", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ComponentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ComponentWriter.cs
@@ -1,0 +1,606 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ComponentWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ComponentWriter"/> is to write an instance of <see cref="IComponent"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ComponentWriter : XmiElementWriter<IComponent>, IXmiElementWriter<IComponent>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ComponentWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComponentWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ComponentWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ComponentWriter>.Instance : loggerFactory.CreateLogger<ComponentWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IComponent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IComponent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IComponent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Component with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Component");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (!element.IsIndirectlyInstantiated)
+            {
+                xmlWriter.WriteAttributeString("isIndirectlyInstantiated", XmlConvert.ToString(element.IsIndirectlyInstantiated));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackagedElement)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packagedElement", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Realization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "realization", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IComponent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IComponent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IComponent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Component with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Component");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (!element.IsIndirectlyInstantiated)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isIndirectlyInstantiated", null, XmlConvert.ToString(element.IsIndirectlyInstantiated));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackagedElement)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packagedElement", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Realization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "realization", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ConditionalNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConditionalNodeWriter.cs
@@ -1,0 +1,506 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConditionalNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ConditionalNodeWriter"/> is to write an instance of <see cref="IConditionalNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ConditionalNodeWriter : XmiElementWriter<IConditionalNode>, IXmiElementWriter<IConditionalNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ConditionalNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConditionalNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ConditionalNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ConditionalNodeWriter>.Instance : loggerFactory.CreateLogger<ConditionalNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IConditionalNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConditionalNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IConditionalNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ConditionalNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConditionalNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsAssured)
+            {
+                xmlWriter.WriteAttributeString("isAssured", XmlConvert.ToString(element.IsAssured));
+            }
+
+            if (element.IsDeterminate)
+            {
+                xmlWriter.WriteAttributeString("isDeterminate", XmlConvert.ToString(element.IsDeterminate));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.MustIsolate)
+            {
+                xmlWriter.WriteAttributeString("mustIsolate", XmlConvert.ToString(element.MustIsolate));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Clause)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "clause", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeInput)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "structuredNodeInput", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IConditionalNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConditionalNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IConditionalNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ConditionalNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConditionalNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsAssured)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAssured", null, XmlConvert.ToString(element.IsAssured));
+            }
+
+            if (element.IsDeterminate)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDeterminate", null, XmlConvert.ToString(element.IsDeterminate));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.MustIsolate)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "mustIsolate", null, XmlConvert.ToString(element.MustIsolate));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Clause)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "clause", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeInput)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "structuredNodeInput", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectableElementTemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectableElementTemplateParameterWriter.cs
@@ -1,0 +1,296 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConnectableElementTemplateParameterWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ConnectableElementTemplateParameterWriter"/> is to write an instance of <see cref="IConnectableElementTemplateParameter"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ConnectableElementTemplateParameterWriter : XmiElementWriter<IConnectableElementTemplateParameter>, IXmiElementWriter<IConnectableElementTemplateParameter>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ConnectableElementTemplateParameterWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectableElementTemplateParameterWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ConnectableElementTemplateParameterWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ConnectableElementTemplateParameterWriter>.Instance : loggerFactory.CreateLogger<ConnectableElementTemplateParameterWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IConnectableElementTemplateParameter"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConnectableElementTemplateParameter"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IConnectableElementTemplateParameter element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ConnectableElementTemplateParameter with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectableElementTemplateParameter");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Default != null && writeContext.IsLocal(element.Default))
+            {
+                xmlWriter.WriteAttributeString("default", element.Default.XmiId);
+            }
+
+            if (element.ParameteredElement != null && writeContext.IsLocal(element.ParameteredElement))
+            {
+                xmlWriter.WriteAttributeString("parameteredElement", element.ParameteredElement.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                xmlWriter.WriteAttributeString("signature", element.Signature.XmiId);
+            }
+
+
+            if (element.Default != null && !writeContext.IsLocal(element.Default))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Default, "default", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedDefault)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedDefault", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameteredElement)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameteredElement", writeContext);
+            }
+
+            if (element.ParameteredElement != null && !writeContext.IsLocal(element.ParameteredElement))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ParameteredElement, "parameteredElement", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IConnectableElementTemplateParameter"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConnectableElementTemplateParameter"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IConnectableElementTemplateParameter element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ConnectableElementTemplateParameter with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectableElementTemplateParameter");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Default != null && writeContext.IsLocal(element.Default))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "default", null, element.Default.XmiId);
+            }
+
+            if (element.ParameteredElement != null && writeContext.IsLocal(element.ParameteredElement))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "parameteredElement", null, element.ParameteredElement.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "signature", null, element.Signature.XmiId);
+            }
+
+
+            if (element.Default != null && !writeContext.IsLocal(element.Default))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Default, "default", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedDefault)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedDefault", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameteredElement)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameteredElement", writeContext);
+            }
+
+            if (element.ParameteredElement != null && !writeContext.IsLocal(element.ParameteredElement))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ParameteredElement, "parameteredElement", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectionPointReferenceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectionPointReferenceWriter.cs
@@ -1,0 +1,336 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConnectionPointReferenceWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ConnectionPointReferenceWriter"/> is to write an instance of <see cref="IConnectionPointReference"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ConnectionPointReferenceWriter : XmiElementWriter<IConnectionPointReference>, IXmiElementWriter<IConnectionPointReference>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ConnectionPointReferenceWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionPointReferenceWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ConnectionPointReferenceWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ConnectionPointReferenceWriter>.Instance : loggerFactory.CreateLogger<ConnectionPointReferenceWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IConnectionPointReference"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConnectionPointReference"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IConnectionPointReference element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ConnectionPointReference with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectionPointReference");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                xmlWriter.WriteAttributeString("container", element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.RedefinedVertex != null && writeContext.IsLocal(element.RedefinedVertex))
+            {
+                xmlWriter.WriteAttributeString("redefinedVertex", element.RedefinedVertex.XmiId);
+            }
+
+            if (element.State != null && writeContext.IsLocal(element.State))
+            {
+                xmlWriter.WriteAttributeString("state", element.State.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.Entry)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "entry", writeContext);
+            }
+
+            foreach (var value in element.Exit)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "exit", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.RedefinedVertex != null && !writeContext.IsLocal(element.RedefinedVertex))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.RedefinedVertex, "redefinedVertex", writeContext);
+            }
+
+            if (element.State != null && !writeContext.IsLocal(element.State))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.State, "state", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IConnectionPointReference"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConnectionPointReference"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IConnectionPointReference element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ConnectionPointReference with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectionPointReference");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "container", null, element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.RedefinedVertex != null && writeContext.IsLocal(element.RedefinedVertex))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "redefinedVertex", null, element.RedefinedVertex.XmiId);
+            }
+
+            if (element.State != null && writeContext.IsLocal(element.State))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "state", null, element.State.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.Entry)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "entry", writeContext);
+            }
+
+            foreach (var value in element.Exit)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "exit", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.RedefinedVertex != null && !writeContext.IsLocal(element.RedefinedVertex))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.RedefinedVertex, "redefinedVertex", writeContext);
+            }
+
+            if (element.State != null && !writeContext.IsLocal(element.State))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.State, "state", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectorEndWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectorEndWriter.cs
@@ -1,0 +1,296 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConnectorEndWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ConnectorEndWriter"/> is to write an instance of <see cref="IConnectorEnd"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ConnectorEndWriter : XmiElementWriter<IConnectorEnd>, IXmiElementWriter<IConnectorEnd>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ConnectorEndWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectorEndWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ConnectorEndWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ConnectorEndWriter>.Instance : loggerFactory.CreateLogger<ConnectorEndWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IConnectorEnd"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConnectorEnd"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IConnectorEnd element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ConnectorEnd with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectorEnd");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (element.PartWithPort != null && writeContext.IsLocal(element.PartWithPort))
+            {
+                xmlWriter.WriteAttributeString("partWithPort", element.PartWithPort.XmiId);
+            }
+
+            if (element.Role != null && writeContext.IsLocal(element.Role))
+            {
+                xmlWriter.WriteAttributeString("role", element.Role.XmiId);
+            }
+
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.PartWithPort != null && !writeContext.IsLocal(element.PartWithPort))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.PartWithPort, "partWithPort", writeContext);
+            }
+
+            if (element.Role != null && !writeContext.IsLocal(element.Role))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Role, "role", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IConnectorEnd"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConnectorEnd"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IConnectorEnd element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ConnectorEnd with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectorEnd");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (element.PartWithPort != null && writeContext.IsLocal(element.PartWithPort))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "partWithPort", null, element.PartWithPort.XmiId);
+            }
+
+            if (element.Role != null && writeContext.IsLocal(element.Role))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "role", null, element.Role.XmiId);
+            }
+
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.PartWithPort != null && !writeContext.IsLocal(element.PartWithPort))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.PartWithPort, "partWithPort", writeContext);
+            }
+
+            if (element.Role != null && !writeContext.IsLocal(element.Role))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Role, "role", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectorWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConnectorWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ConnectorWriter"/> is to write an instance of <see cref="IConnector"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ConnectorWriter : XmiElementWriter<IConnector>, IXmiElementWriter<IConnector>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ConnectorWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectorWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ConnectorWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ConnectorWriter>.Instance : loggerFactory.CreateLogger<ConnectorWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IConnector"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConnector"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IConnector element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Connector with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Connector");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsStatic)
+            {
+                xmlWriter.WriteAttributeString("isStatic", XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Contract)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "contract", writeContext);
+            }
+
+            foreach (var value in element.End)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "end", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedConnector)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedConnector", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IConnector"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConnector"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IConnector element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Connector with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Connector");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsStatic)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isStatic", null, XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Contract)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "contract", writeContext);
+            }
+
+            foreach (var value in element.End)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "end", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedConnector", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ConsiderIgnoreFragmentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConsiderIgnoreFragmentWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConsiderIgnoreFragmentWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ConsiderIgnoreFragmentWriter"/> is to write an instance of <see cref="IConsiderIgnoreFragment"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ConsiderIgnoreFragmentWriter : XmiElementWriter<IConsiderIgnoreFragment>, IXmiElementWriter<IConsiderIgnoreFragment>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ConsiderIgnoreFragmentWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsiderIgnoreFragmentWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ConsiderIgnoreFragmentWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ConsiderIgnoreFragmentWriter>.Instance : loggerFactory.CreateLogger<ConsiderIgnoreFragmentWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IConsiderIgnoreFragment"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConsiderIgnoreFragment"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IConsiderIgnoreFragment element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ConsiderIgnoreFragment with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConsiderIgnoreFragment");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (element.InteractionOperator != InteractionOperatorKind.Seq)
+            {
+                xmlWriter.WriteAttributeString("interactionOperator", LowerCaseFirstLetter(element.InteractionOperator.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CfragmentGate)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "cfragmentGate", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.Message)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "message", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Operand)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "operand", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IConsiderIgnoreFragment"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConsiderIgnoreFragment"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IConsiderIgnoreFragment element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ConsiderIgnoreFragment with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConsiderIgnoreFragment");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (element.InteractionOperator != InteractionOperatorKind.Seq)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interactionOperator", null, LowerCaseFirstLetter(element.InteractionOperator.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CfragmentGate)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "cfragmentGate", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.Message)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "message", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Operand)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "operand", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConstraintWriter.cs
@@ -1,0 +1,326 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ConstraintWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ConstraintWriter"/> is to write an instance of <see cref="IConstraint"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ConstraintWriter : XmiElementWriter<IConstraint>, IXmiElementWriter<IConstraint>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ConstraintWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConstraintWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ConstraintWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ConstraintWriter>.Instance : loggerFactory.CreateLogger<ConstraintWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Constraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Constraint");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                xmlWriter.WriteAttributeString("context", element.Context.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Constraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Constraint");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "context", null, element.Context.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ContinuationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ContinuationWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ContinuationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ContinuationWriter"/> is to write an instance of <see cref="IContinuation"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ContinuationWriter : XmiElementWriter<IContinuation>, IXmiElementWriter<IContinuation>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ContinuationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContinuationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ContinuationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ContinuationWriter>.Instance : loggerFactory.CreateLogger<ContinuationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IContinuation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IContinuation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IContinuation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Continuation with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Continuation");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (!element.Setting)
+            {
+                xmlWriter.WriteAttributeString("setting", XmlConvert.ToString(element.Setting));
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Covered)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IContinuation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IContinuation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IContinuation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Continuation with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Continuation");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (!element.Setting)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "setting", null, XmlConvert.ToString(element.Setting));
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Covered)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ControlFlowWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ControlFlowWriter.cs
@@ -1,0 +1,396 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ControlFlowWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ControlFlowWriter"/> is to write an instance of <see cref="IControlFlow"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ControlFlowWriter : XmiElementWriter<IControlFlow>, IXmiElementWriter<IControlFlow>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ControlFlowWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ControlFlowWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ControlFlowWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ControlFlowWriter>.Instance : loggerFactory.CreateLogger<ControlFlowWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IControlFlow"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IControlFlow"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IControlFlow element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ControlFlow with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ControlFlow");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.Interrupts != null && writeContext.IsLocal(element.Interrupts))
+            {
+                xmlWriter.WriteAttributeString("interrupts", element.Interrupts.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Source != null && writeContext.IsLocal(element.Source))
+            {
+                xmlWriter.WriteAttributeString("source", element.Source.XmiId);
+            }
+
+            if (element.Target != null && writeContext.IsLocal(element.Target))
+            {
+                xmlWriter.WriteAttributeString("target", element.Target.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Guard)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "guard", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            if (element.Interrupts != null && !writeContext.IsLocal(element.Interrupts))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Interrupts, "interrupts", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedEdge)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedEdge", writeContext);
+            }
+
+            if (element.Source != null && !writeContext.IsLocal(element.Source))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Source, "source", writeContext);
+            }
+
+            if (element.Target != null && !writeContext.IsLocal(element.Target))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Target, "target", writeContext);
+            }
+
+            foreach (var value in element.Weight)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "weight", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IControlFlow"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IControlFlow"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IControlFlow element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ControlFlow with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ControlFlow");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.Interrupts != null && writeContext.IsLocal(element.Interrupts))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interrupts", null, element.Interrupts.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Source != null && writeContext.IsLocal(element.Source))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "source", null, element.Source.XmiId);
+            }
+
+            if (element.Target != null && writeContext.IsLocal(element.Target))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "target", null, element.Target.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Guard)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "guard", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            if (element.Interrupts != null && !writeContext.IsLocal(element.Interrupts))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Interrupts, "interrupts", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedEdge)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedEdge", writeContext);
+            }
+
+            if (element.Source != null && !writeContext.IsLocal(element.Source))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Source, "source", writeContext);
+            }
+
+            if (element.Target != null && !writeContext.IsLocal(element.Target))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Target, "target", writeContext);
+            }
+
+            foreach (var value in element.Weight)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "weight", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CreateLinkActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CreateLinkActionWriter.cs
@@ -1,0 +1,406 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CreateLinkActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CreateLinkActionWriter"/> is to write an instance of <see cref="ICreateLinkAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CreateLinkActionWriter : XmiElementWriter<ICreateLinkAction>, IXmiElementWriter<ICreateLinkAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CreateLinkActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateLinkActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CreateLinkActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CreateLinkActionWriter>.Instance : loggerFactory.CreateLogger<CreateLinkActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICreateLinkAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICreateLinkAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICreateLinkAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CreateLinkAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateLinkAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.EndData)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "endData", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "inputValue", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICreateLinkAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICreateLinkAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICreateLinkAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CreateLinkAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateLinkAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.EndData)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "endData", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "inputValue", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CreateLinkObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CreateLinkObjectActionWriter.cs
@@ -1,0 +1,416 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CreateLinkObjectActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CreateLinkObjectActionWriter"/> is to write an instance of <see cref="ICreateLinkObjectAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CreateLinkObjectActionWriter : XmiElementWriter<ICreateLinkObjectAction>, IXmiElementWriter<ICreateLinkObjectAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CreateLinkObjectActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateLinkObjectActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CreateLinkObjectActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CreateLinkObjectActionWriter>.Instance : loggerFactory.CreateLogger<CreateLinkObjectActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICreateLinkObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICreateLinkObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICreateLinkObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CreateLinkObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateLinkObjectAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.EndData)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "endData", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "inputValue", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICreateLinkObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICreateLinkObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICreateLinkObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CreateLinkObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateLinkObjectAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.EndData)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "endData", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "inputValue", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/CreateObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CreateObjectActionWriter.cs
@@ -1,0 +1,416 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="CreateObjectActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="CreateObjectActionWriter"/> is to write an instance of <see cref="ICreateObjectAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class CreateObjectActionWriter : XmiElementWriter<ICreateObjectAction>, IXmiElementWriter<ICreateObjectAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<CreateObjectActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateObjectActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public CreateObjectActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<CreateObjectActionWriter>.Instance : loggerFactory.CreateLogger<CreateObjectActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ICreateObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICreateObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ICreateObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CreateObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateObjectAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.Classifier != null && writeContext.IsLocal(element.Classifier))
+            {
+                xmlWriter.WriteAttributeString("classifier", element.Classifier.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.Classifier != null && !writeContext.IsLocal(element.Classifier))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Classifier, "classifier", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ICreateObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ICreateObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ICreateObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the CreateObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateObjectAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.Classifier != null && writeContext.IsLocal(element.Classifier))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifier", null, element.Classifier.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.Classifier != null && !writeContext.IsLocal(element.Classifier))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Classifier, "classifier", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DataStoreNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DataStoreNodeWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DataStoreNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DataStoreNodeWriter"/> is to write an instance of <see cref="IDataStoreNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DataStoreNodeWriter : XmiElementWriter<IDataStoreNode>, IXmiElementWriter<IDataStoreNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DataStoreNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataStoreNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DataStoreNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DataStoreNodeWriter>.Instance : loggerFactory.CreateLogger<DataStoreNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDataStoreNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDataStoreNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDataStoreNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DataStoreNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DataStoreNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControlType)
+            {
+                xmlWriter.WriteAttributeString("isControlType", XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                xmlWriter.WriteAttributeString("ordering", LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                xmlWriter.WriteAttributeString("selection", element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperBound", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDataStoreNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDataStoreNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDataStoreNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DataStoreNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DataStoreNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControlType)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControlType", null, XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "ordering", null, LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "selection", null, element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DataTypeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DataTypeWriter.cs
@@ -1,0 +1,496 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DataTypeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DataTypeWriter"/> is to write an instance of <see cref="IDataType"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DataTypeWriter : XmiElementWriter<IDataType>, IXmiElementWriter<IDataType>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DataTypeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataTypeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DataTypeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DataTypeWriter>.Instance : loggerFactory.CreateLogger<DataTypeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDataType"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDataType"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDataType element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DataType with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DataType");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDataType"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDataType"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDataType element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DataType with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DataType");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DecisionNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DecisionNodeWriter.cs
@@ -1,0 +1,386 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DecisionNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DecisionNodeWriter"/> is to write an instance of <see cref="IDecisionNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DecisionNodeWriter : XmiElementWriter<IDecisionNode>, IXmiElementWriter<IDecisionNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DecisionNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DecisionNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DecisionNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DecisionNodeWriter>.Instance : loggerFactory.CreateLogger<DecisionNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDecisionNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDecisionNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDecisionNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DecisionNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DecisionNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.DecisionInput != null && writeContext.IsLocal(element.DecisionInput))
+            {
+                xmlWriter.WriteAttributeString("decisionInput", element.DecisionInput.XmiId);
+            }
+
+            if (element.DecisionInputFlow != null && writeContext.IsLocal(element.DecisionInputFlow))
+            {
+                xmlWriter.WriteAttributeString("decisionInputFlow", element.DecisionInputFlow.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.DecisionInput != null && !writeContext.IsLocal(element.DecisionInput))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.DecisionInput, "decisionInput", writeContext);
+            }
+
+            if (element.DecisionInputFlow != null && !writeContext.IsLocal(element.DecisionInputFlow))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.DecisionInputFlow, "decisionInputFlow", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDecisionNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDecisionNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDecisionNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DecisionNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DecisionNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.DecisionInput != null && writeContext.IsLocal(element.DecisionInput))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "decisionInput", null, element.DecisionInput.XmiId);
+            }
+
+            if (element.DecisionInputFlow != null && writeContext.IsLocal(element.DecisionInputFlow))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "decisionInputFlow", null, element.DecisionInputFlow.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.DecisionInput != null && !writeContext.IsLocal(element.DecisionInput))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.DecisionInput, "decisionInput", writeContext);
+            }
+
+            if (element.DecisionInputFlow != null && !writeContext.IsLocal(element.DecisionInputFlow))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.DecisionInputFlow, "decisionInputFlow", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DependencyWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DependencyWriter.cs
@@ -1,0 +1,306 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DependencyWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DependencyWriter"/> is to write an instance of <see cref="IDependency"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DependencyWriter : XmiElementWriter<IDependency>, IXmiElementWriter<IDependency>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DependencyWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DependencyWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DependencyWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DependencyWriter>.Instance : loggerFactory.CreateLogger<DependencyWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDependency"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDependency"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDependency element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Dependency with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Dependency");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDependency"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDependency"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDependency element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Dependency with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Dependency");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DeploymentSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DeploymentSpecificationWriter.cs
@@ -1,0 +1,566 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DeploymentSpecificationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DeploymentSpecificationWriter"/> is to write an instance of <see cref="IDeploymentSpecification"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DeploymentSpecificationWriter : XmiElementWriter<IDeploymentSpecification>, IXmiElementWriter<IDeploymentSpecification>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DeploymentSpecificationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeploymentSpecificationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DeploymentSpecificationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DeploymentSpecificationWriter>.Instance : loggerFactory.CreateLogger<DeploymentSpecificationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDeploymentSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDeploymentSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDeploymentSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DeploymentSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DeploymentSpecification");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Deployment != null && writeContext.IsLocal(element.Deployment))
+            {
+                xmlWriter.WriteAttributeString("deployment", element.Deployment.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.DeploymentLocation))
+            {
+                xmlWriter.WriteAttributeString("deploymentLocation", element.DeploymentLocation);
+            }
+
+            if (!string.IsNullOrEmpty(element.ExecutionLocation))
+            {
+                xmlWriter.WriteAttributeString("executionLocation", element.ExecutionLocation);
+            }
+
+            if (!string.IsNullOrEmpty(element.FileName))
+            {
+                xmlWriter.WriteAttributeString("fileName", element.FileName);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            if (element.Deployment != null && !writeContext.IsLocal(element.Deployment))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Deployment, "deployment", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Manifestation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "manifestation", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedArtifact)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedArtifact", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDeploymentSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDeploymentSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDeploymentSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DeploymentSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DeploymentSpecification");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Deployment != null && writeContext.IsLocal(element.Deployment))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "deployment", null, element.Deployment.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.DeploymentLocation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "deploymentLocation", null, element.DeploymentLocation);
+            }
+
+            if (!string.IsNullOrEmpty(element.ExecutionLocation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "executionLocation", null, element.ExecutionLocation);
+            }
+
+            if (!string.IsNullOrEmpty(element.FileName))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "fileName", null, element.FileName);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            if (element.Deployment != null && !writeContext.IsLocal(element.Deployment))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Deployment, "deployment", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Manifestation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "manifestation", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedArtifact)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedArtifact", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DeploymentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DeploymentWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DeploymentWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DeploymentWriter"/> is to write an instance of <see cref="IDeployment"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DeploymentWriter : XmiElementWriter<IDeployment>, IXmiElementWriter<IDeployment>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DeploymentWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeploymentWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DeploymentWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DeploymentWriter>.Instance : loggerFactory.CreateLogger<DeploymentWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDeployment"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDeployment"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDeployment element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Deployment with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Deployment");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Location != null && writeContext.IsLocal(element.Location))
+            {
+                xmlWriter.WriteAttributeString("location", element.Location.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.Configuration)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "configuration", writeContext);
+            }
+
+            foreach (var value in element.DeployedArtifact)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "deployedArtifact", writeContext);
+            }
+
+            if (element.Location != null && !writeContext.IsLocal(element.Location))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Location, "location", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDeployment"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDeployment"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDeployment element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Deployment with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Deployment");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Location != null && writeContext.IsLocal(element.Location))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "location", null, element.Location.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.Configuration)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "configuration", writeContext);
+            }
+
+            foreach (var value in element.DeployedArtifact)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "deployedArtifact", writeContext);
+            }
+
+            if (element.Location != null && !writeContext.IsLocal(element.Location))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Location, "location", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DestroyLinkActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DestroyLinkActionWriter.cs
@@ -1,0 +1,406 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DestroyLinkActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DestroyLinkActionWriter"/> is to write an instance of <see cref="IDestroyLinkAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DestroyLinkActionWriter : XmiElementWriter<IDestroyLinkAction>, IXmiElementWriter<IDestroyLinkAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DestroyLinkActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DestroyLinkActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DestroyLinkActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DestroyLinkActionWriter>.Instance : loggerFactory.CreateLogger<DestroyLinkActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDestroyLinkAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDestroyLinkAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDestroyLinkAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DestroyLinkAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestroyLinkAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.EndData)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "endData", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "inputValue", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDestroyLinkAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDestroyLinkAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDestroyLinkAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DestroyLinkAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestroyLinkAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.EndData)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "endData", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "inputValue", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DestroyObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DestroyObjectActionWriter.cs
@@ -1,0 +1,416 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DestroyObjectActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DestroyObjectActionWriter"/> is to write an instance of <see cref="IDestroyObjectAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DestroyObjectActionWriter : XmiElementWriter<IDestroyObjectAction>, IXmiElementWriter<IDestroyObjectAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DestroyObjectActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DestroyObjectActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DestroyObjectActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DestroyObjectActionWriter>.Instance : loggerFactory.CreateLogger<DestroyObjectActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDestroyObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDestroyObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDestroyObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DestroyObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestroyObjectAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsDestroyLinks)
+            {
+                xmlWriter.WriteAttributeString("isDestroyLinks", XmlConvert.ToString(element.IsDestroyLinks));
+            }
+
+            if (element.IsDestroyOwnedObjects)
+            {
+                xmlWriter.WriteAttributeString("isDestroyOwnedObjects", XmlConvert.ToString(element.IsDestroyOwnedObjects));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Target)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "target", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDestroyObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDestroyObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDestroyObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DestroyObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestroyObjectAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsDestroyLinks)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDestroyLinks", null, XmlConvert.ToString(element.IsDestroyLinks));
+            }
+
+            if (element.IsDestroyOwnedObjects)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDestroyOwnedObjects", null, XmlConvert.ToString(element.IsDestroyOwnedObjects));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Target)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DestructionOccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DestructionOccurrenceSpecificationWriter.cs
@@ -1,0 +1,356 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DestructionOccurrenceSpecificationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DestructionOccurrenceSpecificationWriter"/> is to write an instance of <see cref="IDestructionOccurrenceSpecification"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DestructionOccurrenceSpecificationWriter : XmiElementWriter<IDestructionOccurrenceSpecification>, IXmiElementWriter<IDestructionOccurrenceSpecification>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DestructionOccurrenceSpecificationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DestructionOccurrenceSpecificationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DestructionOccurrenceSpecificationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DestructionOccurrenceSpecificationWriter>.Instance : loggerFactory.CreateLogger<DestructionOccurrenceSpecificationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDestructionOccurrenceSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDestructionOccurrenceSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDestructionOccurrenceSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DestructionOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestructionOccurrenceSpecification");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Covered != null && writeContext.IsLocal(element.Covered))
+            {
+                xmlWriter.WriteAttributeString("covered", element.Covered.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (element.Message != null && writeContext.IsLocal(element.Message))
+            {
+                xmlWriter.WriteAttributeString("message", element.Message.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Covered != null && !writeContext.IsLocal(element.Covered))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Covered, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            if (element.Message != null && !writeContext.IsLocal(element.Message))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Message, "message", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.ToAfter)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "toAfter", writeContext);
+            }
+
+            foreach (var value in element.ToBefore)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "toBefore", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDestructionOccurrenceSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDestructionOccurrenceSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDestructionOccurrenceSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DestructionOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestructionOccurrenceSpecification");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Covered != null && writeContext.IsLocal(element.Covered))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "covered", null, element.Covered.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (element.Message != null && writeContext.IsLocal(element.Message))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "message", null, element.Message.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Covered != null && !writeContext.IsLocal(element.Covered))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Covered, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            if (element.Message != null && !writeContext.IsLocal(element.Message))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Message, "message", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.ToAfter)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toAfter", writeContext);
+            }
+
+            foreach (var value in element.ToBefore)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DeviceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DeviceWriter.cs
@@ -1,0 +1,596 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DeviceWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DeviceWriter"/> is to write an instance of <see cref="IDevice"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DeviceWriter : XmiElementWriter<IDevice>, IXmiElementWriter<IDevice>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DeviceWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DeviceWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DeviceWriter>.Instance : loggerFactory.CreateLogger<DeviceWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDevice"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDevice"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDevice element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Device with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Device");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deployment", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.NestedNode)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedNode", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDevice"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDevice"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDevice element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Device with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Device");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deployment", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.NestedNode)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedNode", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DurationConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationConstraintWriter.cs
@@ -1,0 +1,336 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DurationConstraintWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DurationConstraintWriter"/> is to write an instance of <see cref="IDurationConstraint"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DurationConstraintWriter : XmiElementWriter<IDurationConstraint>, IXmiElementWriter<IDurationConstraint>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DurationConstraintWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurationConstraintWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DurationConstraintWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DurationConstraintWriter>.Instance : loggerFactory.CreateLogger<DurationConstraintWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDurationConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDurationConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDurationConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DurationConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationConstraint");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                xmlWriter.WriteAttributeString("context", element.Context.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.FirstEvent)
+            {
+                xmlWriter.WriteElementString("firstEvent", XmlConvert.ToString(value));
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDurationConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDurationConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDurationConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DurationConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationConstraint");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "context", null, element.Context.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.FirstEvent)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "firstEvent", null, XmlConvert.ToString(value));
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DurationIntervalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationIntervalWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DurationIntervalWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DurationIntervalWriter"/> is to write an instance of <see cref="IDurationInterval"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DurationIntervalWriter : XmiElementWriter<IDurationInterval>, IXmiElementWriter<IDurationInterval>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DurationIntervalWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurationIntervalWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DurationIntervalWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DurationIntervalWriter>.Instance : loggerFactory.CreateLogger<DurationIntervalWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDurationInterval"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDurationInterval"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDurationInterval element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DurationInterval with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationInterval");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Max != null && writeContext.IsLocal(element.Max))
+            {
+                xmlWriter.WriteAttributeString("max", element.Max.XmiId);
+            }
+
+            if (element.Min != null && writeContext.IsLocal(element.Min))
+            {
+                xmlWriter.WriteAttributeString("min", element.Min.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Max != null && !writeContext.IsLocal(element.Max))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Max, "max", writeContext);
+            }
+
+            if (element.Min != null && !writeContext.IsLocal(element.Min))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Min, "min", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDurationInterval"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDurationInterval"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDurationInterval element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DurationInterval with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationInterval");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Max != null && writeContext.IsLocal(element.Max))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "max", null, element.Max.XmiId);
+            }
+
+            if (element.Min != null && writeContext.IsLocal(element.Min))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "min", null, element.Min.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Max != null && !writeContext.IsLocal(element.Max))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Max, "max", writeContext);
+            }
+
+            if (element.Min != null && !writeContext.IsLocal(element.Min))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Min, "min", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DurationObservationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationObservationWriter.cs
@@ -1,0 +1,306 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DurationObservationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DurationObservationWriter"/> is to write an instance of <see cref="IDurationObservation"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DurationObservationWriter : XmiElementWriter<IDurationObservation>, IXmiElementWriter<IDurationObservation>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DurationObservationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurationObservationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DurationObservationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DurationObservationWriter>.Instance : loggerFactory.CreateLogger<DurationObservationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDurationObservation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDurationObservation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDurationObservation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DurationObservation with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationObservation");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Event)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "event", writeContext);
+            }
+
+            foreach (var value in element.FirstEvent)
+            {
+                xmlWriter.WriteElementString("firstEvent", XmlConvert.ToString(value));
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDurationObservation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDurationObservation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDurationObservation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the DurationObservation with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationObservation");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Event)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "event", writeContext);
+            }
+
+            foreach (var value in element.FirstEvent)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "firstEvent", null, XmlConvert.ToString(value));
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/DurationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationWriter.cs
@@ -1,0 +1,326 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DurationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="DurationWriter"/> is to write an instance of <see cref="IDuration"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class DurationWriter : XmiElementWriter<IDuration>, IXmiElementWriter<IDuration>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DurationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DurationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DurationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<DurationWriter>.Instance : loggerFactory.CreateLogger<DurationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IDuration"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDuration"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IDuration element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Duration with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Duration");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Expr)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "expr", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Observation)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "observation", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IDuration"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IDuration"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IDuration element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Duration with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Duration");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Expr)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "expr", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Observation)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "observation", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ElementImportWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ElementImportWriter.cs
@@ -1,0 +1,276 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ElementImportWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ElementImportWriter"/> is to write an instance of <see cref="IElementImport"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ElementImportWriter : XmiElementWriter<IElementImport>, IXmiElementWriter<IElementImport>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ElementImportWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ElementImportWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ElementImportWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ElementImportWriter>.Instance : loggerFactory.CreateLogger<ElementImportWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IElementImport"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IElementImport"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IElementImport element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ElementImport with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ElementImport");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Alias))
+            {
+                xmlWriter.WriteAttributeString("alias", element.Alias);
+            }
+
+            if (element.ImportedElement != null && writeContext.IsLocal(element.ImportedElement))
+            {
+                xmlWriter.WriteAttributeString("importedElement", element.ImportedElement.XmiId);
+            }
+
+            if (element.ImportingNamespace != null && writeContext.IsLocal(element.ImportingNamespace))
+            {
+                xmlWriter.WriteAttributeString("importingNamespace", element.ImportingNamespace.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ImportedElement != null && !writeContext.IsLocal(element.ImportedElement))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ImportedElement, "importedElement", writeContext);
+            }
+
+            if (element.ImportingNamespace != null && !writeContext.IsLocal(element.ImportingNamespace))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ImportingNamespace, "importingNamespace", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IElementImport"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IElementImport"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IElementImport element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ElementImport with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ElementImport");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Alias))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "alias", null, element.Alias);
+            }
+
+            if (element.ImportedElement != null && writeContext.IsLocal(element.ImportedElement))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "importedElement", null, element.ImportedElement.XmiId);
+            }
+
+            if (element.ImportingNamespace != null && writeContext.IsLocal(element.ImportingNamespace))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "importingNamespace", null, element.ImportingNamespace.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ImportedElement != null && !writeContext.IsLocal(element.ImportedElement))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ImportedElement, "importedElement", writeContext);
+            }
+
+            if (element.ImportingNamespace != null && !writeContext.IsLocal(element.ImportingNamespace))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ImportingNamespace, "importingNamespace", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/EnumerationLiteralWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/EnumerationLiteralWriter.cs
@@ -1,0 +1,336 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="EnumerationLiteralWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="EnumerationLiteralWriter"/> is to write an instance of <see cref="IEnumerationLiteral"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class EnumerationLiteralWriter : XmiElementWriter<IEnumerationLiteral>, IXmiElementWriter<IEnumerationLiteral>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<EnumerationLiteralWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerationLiteralWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public EnumerationLiteralWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<EnumerationLiteralWriter>.Instance : loggerFactory.CreateLogger<EnumerationLiteralWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IEnumerationLiteral"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IEnumerationLiteral"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IEnumerationLiteral element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the EnumerationLiteral with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:EnumerationLiteral");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Enumeration != null && writeContext.IsLocal(element.Enumeration))
+            {
+                xmlWriter.WriteAttributeString("enumeration", element.Enumeration.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Deployment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deployment", writeContext);
+            }
+
+            if (element.Enumeration != null && !writeContext.IsLocal(element.Enumeration))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Enumeration, "enumeration", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Slot)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "slot", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IEnumerationLiteral"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IEnumerationLiteral"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IEnumerationLiteral element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the EnumerationLiteral with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:EnumerationLiteral");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Enumeration != null && writeContext.IsLocal(element.Enumeration))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enumeration", null, element.Enumeration.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Deployment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deployment", writeContext);
+            }
+
+            if (element.Enumeration != null && !writeContext.IsLocal(element.Enumeration))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Enumeration, "enumeration", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Slot)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "slot", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/EnumerationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/EnumerationWriter.cs
@@ -1,0 +1,506 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="EnumerationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="EnumerationWriter"/> is to write an instance of <see cref="IEnumeration"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class EnumerationWriter : XmiElementWriter<IEnumeration>, IXmiElementWriter<IEnumeration>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<EnumerationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public EnumerationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<EnumerationWriter>.Instance : loggerFactory.CreateLogger<EnumerationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IEnumeration"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IEnumeration"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IEnumeration element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Enumeration with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Enumeration");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedLiteral)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedLiteral", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IEnumeration"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IEnumeration"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IEnumeration element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Enumeration with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Enumeration");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedLiteral)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedLiteral", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ExceptionHandlerWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExceptionHandlerWriter.cs
@@ -1,0 +1,286 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExceptionHandlerWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExceptionHandlerWriter"/> is to write an instance of <see cref="IExceptionHandler"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExceptionHandlerWriter : XmiElementWriter<IExceptionHandler>, IXmiElementWriter<IExceptionHandler>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExceptionHandlerWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExceptionHandlerWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExceptionHandlerWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExceptionHandlerWriter>.Instance : loggerFactory.CreateLogger<ExceptionHandlerWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExceptionHandler"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExceptionHandler"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExceptionHandler element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExceptionHandler with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExceptionHandler");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ExceptionInput != null && writeContext.IsLocal(element.ExceptionInput))
+            {
+                xmlWriter.WriteAttributeString("exceptionInput", element.ExceptionInput.XmiId);
+            }
+
+            if (element.HandlerBody != null && writeContext.IsLocal(element.HandlerBody))
+            {
+                xmlWriter.WriteAttributeString("handlerBody", element.HandlerBody.XmiId);
+            }
+
+            if (element.ProtectedNode != null && writeContext.IsLocal(element.ProtectedNode))
+            {
+                xmlWriter.WriteAttributeString("protectedNode", element.ProtectedNode.XmiId);
+            }
+
+
+            if (element.ExceptionInput != null && !writeContext.IsLocal(element.ExceptionInput))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ExceptionInput, "exceptionInput", writeContext);
+            }
+
+            foreach (var value in element.ExceptionType)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "exceptionType", writeContext);
+            }
+
+            if (element.HandlerBody != null && !writeContext.IsLocal(element.HandlerBody))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.HandlerBody, "handlerBody", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.ProtectedNode != null && !writeContext.IsLocal(element.ProtectedNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ProtectedNode, "protectedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExceptionHandler"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExceptionHandler"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExceptionHandler element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExceptionHandler with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExceptionHandler");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ExceptionInput != null && writeContext.IsLocal(element.ExceptionInput))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "exceptionInput", null, element.ExceptionInput.XmiId);
+            }
+
+            if (element.HandlerBody != null && writeContext.IsLocal(element.HandlerBody))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "handlerBody", null, element.HandlerBody.XmiId);
+            }
+
+            if (element.ProtectedNode != null && writeContext.IsLocal(element.ProtectedNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "protectedNode", null, element.ProtectedNode.XmiId);
+            }
+
+
+            if (element.ExceptionInput != null && !writeContext.IsLocal(element.ExceptionInput))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ExceptionInput, "exceptionInput", writeContext);
+            }
+
+            foreach (var value in element.ExceptionType)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "exceptionType", writeContext);
+            }
+
+            if (element.HandlerBody != null && !writeContext.IsLocal(element.HandlerBody))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.HandlerBody, "handlerBody", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.ProtectedNode != null && !writeContext.IsLocal(element.ProtectedNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ProtectedNode, "protectedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ExecutionEnvironmentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExecutionEnvironmentWriter.cs
@@ -1,0 +1,596 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExecutionEnvironmentWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExecutionEnvironmentWriter"/> is to write an instance of <see cref="IExecutionEnvironment"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExecutionEnvironmentWriter : XmiElementWriter<IExecutionEnvironment>, IXmiElementWriter<IExecutionEnvironment>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExecutionEnvironmentWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExecutionEnvironmentWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExecutionEnvironmentWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExecutionEnvironmentWriter>.Instance : loggerFactory.CreateLogger<ExecutionEnvironmentWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExecutionEnvironment"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExecutionEnvironment"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExecutionEnvironment element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExecutionEnvironment with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExecutionEnvironment");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deployment", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.NestedNode)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedNode", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExecutionEnvironment"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExecutionEnvironment"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExecutionEnvironment element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExecutionEnvironment with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExecutionEnvironment");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deployment", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.NestedNode)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedNode", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ExecutionOccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExecutionOccurrenceSpecificationWriter.cs
@@ -1,0 +1,356 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExecutionOccurrenceSpecificationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExecutionOccurrenceSpecificationWriter"/> is to write an instance of <see cref="IExecutionOccurrenceSpecification"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExecutionOccurrenceSpecificationWriter : XmiElementWriter<IExecutionOccurrenceSpecification>, IXmiElementWriter<IExecutionOccurrenceSpecification>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExecutionOccurrenceSpecificationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExecutionOccurrenceSpecificationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExecutionOccurrenceSpecificationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExecutionOccurrenceSpecificationWriter>.Instance : loggerFactory.CreateLogger<ExecutionOccurrenceSpecificationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExecutionOccurrenceSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExecutionOccurrenceSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExecutionOccurrenceSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExecutionOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExecutionOccurrenceSpecification");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Covered != null && writeContext.IsLocal(element.Covered))
+            {
+                xmlWriter.WriteAttributeString("covered", element.Covered.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (element.Execution != null && writeContext.IsLocal(element.Execution))
+            {
+                xmlWriter.WriteAttributeString("execution", element.Execution.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Covered != null && !writeContext.IsLocal(element.Covered))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Covered, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            if (element.Execution != null && !writeContext.IsLocal(element.Execution))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Execution, "execution", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.ToAfter)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "toAfter", writeContext);
+            }
+
+            foreach (var value in element.ToBefore)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "toBefore", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExecutionOccurrenceSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExecutionOccurrenceSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExecutionOccurrenceSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExecutionOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExecutionOccurrenceSpecification");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Covered != null && writeContext.IsLocal(element.Covered))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "covered", null, element.Covered.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (element.Execution != null && writeContext.IsLocal(element.Execution))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "execution", null, element.Execution.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Covered != null && !writeContext.IsLocal(element.Covered))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Covered, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            if (element.Execution != null && !writeContext.IsLocal(element.Execution))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Execution, "execution", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.ToAfter)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toAfter", writeContext);
+            }
+
+            foreach (var value in element.ToBefore)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ExpansionNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExpansionNodeWriter.cs
@@ -1,0 +1,466 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExpansionNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExpansionNodeWriter"/> is to write an instance of <see cref="IExpansionNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExpansionNodeWriter : XmiElementWriter<IExpansionNode>, IXmiElementWriter<IExpansionNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExpansionNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpansionNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExpansionNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExpansionNodeWriter>.Instance : loggerFactory.CreateLogger<ExpansionNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExpansionNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExpansionNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExpansionNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExpansionNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExpansionNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControlType)
+            {
+                xmlWriter.WriteAttributeString("isControlType", XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                xmlWriter.WriteAttributeString("ordering", LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.RegionAsInput != null && writeContext.IsLocal(element.RegionAsInput))
+            {
+                xmlWriter.WriteAttributeString("regionAsInput", element.RegionAsInput.XmiId);
+            }
+
+            if (element.RegionAsOutput != null && writeContext.IsLocal(element.RegionAsOutput))
+            {
+                xmlWriter.WriteAttributeString("regionAsOutput", element.RegionAsOutput.XmiId);
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                xmlWriter.WriteAttributeString("selection", element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.RegionAsInput != null && !writeContext.IsLocal(element.RegionAsInput))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.RegionAsInput, "regionAsInput", writeContext);
+            }
+
+            if (element.RegionAsOutput != null && !writeContext.IsLocal(element.RegionAsOutput))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.RegionAsOutput, "regionAsOutput", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperBound", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExpansionNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExpansionNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExpansionNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExpansionNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExpansionNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControlType)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControlType", null, XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "ordering", null, LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.RegionAsInput != null && writeContext.IsLocal(element.RegionAsInput))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "regionAsInput", null, element.RegionAsInput.XmiId);
+            }
+
+            if (element.RegionAsOutput != null && writeContext.IsLocal(element.RegionAsOutput))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "regionAsOutput", null, element.RegionAsOutput.XmiId);
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "selection", null, element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.RegionAsInput != null && !writeContext.IsLocal(element.RegionAsInput))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.RegionAsInput, "regionAsInput", writeContext);
+            }
+
+            if (element.RegionAsOutput != null && !writeContext.IsLocal(element.RegionAsOutput))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.RegionAsOutput, "regionAsOutput", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ExpansionRegionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExpansionRegionWriter.cs
@@ -1,0 +1,506 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExpansionRegionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExpansionRegionWriter"/> is to write an instance of <see cref="IExpansionRegion"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExpansionRegionWriter : XmiElementWriter<IExpansionRegion>, IXmiElementWriter<IExpansionRegion>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExpansionRegionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpansionRegionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExpansionRegionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExpansionRegionWriter>.Instance : loggerFactory.CreateLogger<ExpansionRegionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExpansionRegion"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExpansionRegion"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExpansionRegion element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExpansionRegion with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExpansionRegion");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.Mode != ExpansionKind.Iterative)
+            {
+                xmlWriter.WriteAttributeString("mode", LowerCaseFirstLetter(element.Mode.ToString()));
+            }
+
+            if (element.MustIsolate)
+            {
+                xmlWriter.WriteAttributeString("mustIsolate", XmlConvert.ToString(element.MustIsolate));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputElement)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inputElement", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OutputElement)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outputElement", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeInput)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "structuredNodeInput", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeOutput)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "structuredNodeOutput", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExpansionRegion"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExpansionRegion"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExpansionRegion element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExpansionRegion with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExpansionRegion");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.Mode != ExpansionKind.Iterative)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "mode", null, LowerCaseFirstLetter(element.Mode.ToString()));
+            }
+
+            if (element.MustIsolate)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "mustIsolate", null, XmlConvert.ToString(element.MustIsolate));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputElement)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inputElement", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OutputElement)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outputElement", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeInput)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "structuredNodeInput", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeOutput)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "structuredNodeOutput", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExpressionWriter.cs
@@ -1,0 +1,326 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExpressionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExpressionWriter"/> is to write an instance of <see cref="IExpression"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExpressionWriter : XmiElementWriter<IExpression>, IXmiElementWriter<IExpression>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExpressionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpressionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExpressionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExpressionWriter>.Instance : loggerFactory.CreateLogger<ExpressionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Expression with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Expression");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Symbol))
+            {
+                xmlWriter.WriteAttributeString("symbol", element.Symbol);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Operand)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "operand", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Expression with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Expression");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Symbol))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "symbol", null, element.Symbol);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Operand)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "operand", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ExtendWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtendWriter.cs
@@ -1,0 +1,306 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExtendWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExtendWriter"/> is to write an instance of <see cref="IExtend"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExtendWriter : XmiElementWriter<IExtend>, IXmiElementWriter<IExtend>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExtendWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtendWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExtendWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExtendWriter>.Instance : loggerFactory.CreateLogger<ExtendWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExtend"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExtend"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExtend element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Extend with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Extend");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ExtendedCase != null && writeContext.IsLocal(element.ExtendedCase))
+            {
+                xmlWriter.WriteAttributeString("extendedCase", element.ExtendedCase.XmiId);
+            }
+
+            if (element.Extension != null && writeContext.IsLocal(element.Extension))
+            {
+                xmlWriter.WriteAttributeString("extension", element.Extension.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Condition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "condition", writeContext);
+            }
+
+            if (element.ExtendedCase != null && !writeContext.IsLocal(element.ExtendedCase))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ExtendedCase, "extendedCase", writeContext);
+            }
+
+            if (element.Extension != null && !writeContext.IsLocal(element.Extension))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Extension, "extension", writeContext);
+            }
+
+            foreach (var value in element.ExtensionLocation)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "extensionLocation", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExtend"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExtend"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExtend element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Extend with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Extend");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ExtendedCase != null && writeContext.IsLocal(element.ExtendedCase))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "extendedCase", null, element.ExtendedCase.XmiId);
+            }
+
+            if (element.Extension != null && writeContext.IsLocal(element.Extension))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "extension", null, element.Extension.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Condition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "condition", writeContext);
+            }
+
+            if (element.ExtendedCase != null && !writeContext.IsLocal(element.ExtendedCase))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ExtendedCase, "extendedCase", writeContext);
+            }
+
+            if (element.Extension != null && !writeContext.IsLocal(element.Extension))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Extension, "extension", writeContext);
+            }
+
+            foreach (var value in element.ExtensionLocation)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "extensionLocation", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ExtensionEndWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtensionEndWriter.cs
@@ -1,0 +1,586 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExtensionEndWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExtensionEndWriter"/> is to write an instance of <see cref="IExtensionEnd"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExtensionEndWriter : XmiElementWriter<IExtensionEnd>, IXmiElementWriter<IExtensionEnd>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExtensionEndWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtensionEndWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExtensionEndWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExtensionEndWriter>.Instance : loggerFactory.CreateLogger<ExtensionEndWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExtensionEnd"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExtensionEnd"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExtensionEnd element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExtensionEnd with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExtensionEnd");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Aggregation != AggregationKind.None)
+            {
+                xmlWriter.WriteAttributeString("aggregation", LowerCaseFirstLetter(element.Aggregation.ToString()));
+            }
+
+            if (element.Association != null && writeContext.IsLocal(element.Association))
+            {
+                xmlWriter.WriteAttributeString("association", element.Association.XmiId);
+            }
+
+            if (element.AssociationEnd != null && writeContext.IsLocal(element.AssociationEnd))
+            {
+                xmlWriter.WriteAttributeString("associationEnd", element.AssociationEnd.XmiId);
+            }
+
+            if (element.Class != null && writeContext.IsLocal(element.Class))
+            {
+                xmlWriter.WriteAttributeString("class", element.Class.XmiId);
+            }
+
+            if (element.Datatype != null && writeContext.IsLocal(element.Datatype))
+            {
+                xmlWriter.WriteAttributeString("datatype", element.Datatype.XmiId);
+            }
+
+            if (element.Interface != null && writeContext.IsLocal(element.Interface))
+            {
+                xmlWriter.WriteAttributeString("interface", element.Interface.XmiId);
+            }
+
+            if (element.IsDerived)
+            {
+                xmlWriter.WriteAttributeString("isDerived", XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsDerivedUnion)
+            {
+                xmlWriter.WriteAttributeString("isDerivedUnion", XmlConvert.ToString(element.IsDerivedUnion));
+            }
+
+            if (element.IsID)
+            {
+                xmlWriter.WriteAttributeString("isID", XmlConvert.ToString(element.IsID));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (element.IsReadOnly)
+            {
+                xmlWriter.WriteAttributeString("isReadOnly", XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (element.IsStatic)
+            {
+                xmlWriter.WriteAttributeString("isStatic", XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningAssociation != null && writeContext.IsLocal(element.OwningAssociation))
+            {
+                xmlWriter.WriteAttributeString("owningAssociation", element.OwningAssociation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Association != null && !writeContext.IsLocal(element.Association))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Association, "association", writeContext);
+            }
+
+            if (element.AssociationEnd != null && !writeContext.IsLocal(element.AssociationEnd))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.AssociationEnd, "associationEnd", writeContext);
+            }
+
+            if (element.Class != null && !writeContext.IsLocal(element.Class))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Class, "class", writeContext);
+            }
+
+            if (element.Datatype != null && !writeContext.IsLocal(element.Datatype))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Datatype, "datatype", writeContext);
+            }
+
+            foreach (var value in element.DefaultValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "defaultValue", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deployment", writeContext);
+            }
+
+            if (element.Interface != null && !writeContext.IsLocal(element.Interface))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Interface, "interface", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningAssociation != null && !writeContext.IsLocal(element.OwningAssociation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningAssociation, "owningAssociation", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedProperty)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedProperty", writeContext);
+            }
+
+            foreach (var value in element.SubsettedProperty)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "subsettedProperty", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExtensionEnd"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExtensionEnd"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExtensionEnd element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExtensionEnd with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExtensionEnd");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Aggregation != AggregationKind.None)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "aggregation", null, LowerCaseFirstLetter(element.Aggregation.ToString()));
+            }
+
+            if (element.Association != null && writeContext.IsLocal(element.Association))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "association", null, element.Association.XmiId);
+            }
+
+            if (element.AssociationEnd != null && writeContext.IsLocal(element.AssociationEnd))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "associationEnd", null, element.AssociationEnd.XmiId);
+            }
+
+            if (element.Class != null && writeContext.IsLocal(element.Class))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "class", null, element.Class.XmiId);
+            }
+
+            if (element.Datatype != null && writeContext.IsLocal(element.Datatype))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "datatype", null, element.Datatype.XmiId);
+            }
+
+            if (element.Interface != null && writeContext.IsLocal(element.Interface))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interface", null, element.Interface.XmiId);
+            }
+
+            if (element.IsDerived)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerived", null, XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsDerivedUnion)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerivedUnion", null, XmlConvert.ToString(element.IsDerivedUnion));
+            }
+
+            if (element.IsID)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isID", null, XmlConvert.ToString(element.IsID));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (element.IsReadOnly)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReadOnly", null, XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (element.IsStatic)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isStatic", null, XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningAssociation != null && writeContext.IsLocal(element.OwningAssociation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningAssociation", null, element.OwningAssociation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Association != null && !writeContext.IsLocal(element.Association))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Association, "association", writeContext);
+            }
+
+            if (element.AssociationEnd != null && !writeContext.IsLocal(element.AssociationEnd))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.AssociationEnd, "associationEnd", writeContext);
+            }
+
+            if (element.Class != null && !writeContext.IsLocal(element.Class))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Class, "class", writeContext);
+            }
+
+            if (element.Datatype != null && !writeContext.IsLocal(element.Datatype))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Datatype, "datatype", writeContext);
+            }
+
+            foreach (var value in element.DefaultValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "defaultValue", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deployment", writeContext);
+            }
+
+            if (element.Interface != null && !writeContext.IsLocal(element.Interface))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Interface, "interface", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningAssociation != null && !writeContext.IsLocal(element.OwningAssociation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningAssociation, "owningAssociation", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedProperty)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedProperty", writeContext);
+            }
+
+            foreach (var value in element.SubsettedProperty)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "subsettedProperty", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ExtensionPointWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtensionPointWriter.cs
@@ -1,0 +1,276 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExtensionPointWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExtensionPointWriter"/> is to write an instance of <see cref="IExtensionPoint"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExtensionPointWriter : XmiElementWriter<IExtensionPoint>, IXmiElementWriter<IExtensionPoint>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExtensionPointWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtensionPointWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExtensionPointWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExtensionPointWriter>.Instance : loggerFactory.CreateLogger<ExtensionPointWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExtensionPoint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExtensionPoint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExtensionPoint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExtensionPoint with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExtensionPoint");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.UseCase != null && writeContext.IsLocal(element.UseCase))
+            {
+                xmlWriter.WriteAttributeString("useCase", element.UseCase.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.UseCase != null && !writeContext.IsLocal(element.UseCase))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.UseCase, "useCase", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExtensionPoint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExtensionPoint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExtensionPoint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ExtensionPoint with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExtensionPoint");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.UseCase != null && writeContext.IsLocal(element.UseCase))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "useCase", null, element.UseCase.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.UseCase != null && !writeContext.IsLocal(element.UseCase))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.UseCase, "useCase", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ExtensionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtensionWriter.cs
@@ -1,0 +1,516 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExtensionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ExtensionWriter"/> is to write an instance of <see cref="IExtension"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ExtensionWriter : XmiElementWriter<IExtension>, IXmiElementWriter<IExtension>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ExtensionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtensionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ExtensionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ExtensionWriter>.Instance : loggerFactory.CreateLogger<ExtensionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IExtension"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExtension"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IExtension element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Extension with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Extension");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsDerived)
+            {
+                xmlWriter.WriteAttributeString("isDerived", XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.MemberEnd)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "memberEnd", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NavigableOwnedEnd)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "navigableOwnedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedEnd)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IExtension"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IExtension"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IExtension element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Extension with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Extension");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsDerived)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerived", null, XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.MemberEnd)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "memberEnd", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NavigableOwnedEnd)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "navigableOwnedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedEnd)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedEnd", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/FinalStateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/FinalStateWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FinalStateWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="FinalStateWriter"/> is to write an instance of <see cref="IFinalState"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class FinalStateWriter : XmiElementWriter<IFinalState>, IXmiElementWriter<IFinalState>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<FinalStateWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FinalStateWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public FinalStateWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<FinalStateWriter>.Instance : loggerFactory.CreateLogger<FinalStateWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IFinalState"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IFinalState"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IFinalState element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the FinalState with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FinalState");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                xmlWriter.WriteAttributeString("container", element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.RedefinedVertex != null && writeContext.IsLocal(element.RedefinedVertex))
+            {
+                xmlWriter.WriteAttributeString("redefinedVertex", element.RedefinedVertex.XmiId);
+            }
+
+            if (element.Submachine != null && writeContext.IsLocal(element.Submachine))
+            {
+                xmlWriter.WriteAttributeString("submachine", element.Submachine.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Connection)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "connection", writeContext);
+            }
+
+            foreach (var value in element.ConnectionPoint)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "connectionPoint", writeContext);
+            }
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.DeferrableTrigger)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deferrableTrigger", writeContext);
+            }
+
+            foreach (var value in element.DoActivity)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "doActivity", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Entry)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "entry", writeContext);
+            }
+
+            foreach (var value in element.Exit)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "exit", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            if (element.RedefinedVertex != null && !writeContext.IsLocal(element.RedefinedVertex))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.RedefinedVertex, "redefinedVertex", writeContext);
+            }
+
+            foreach (var value in element.Region)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "region", writeContext);
+            }
+
+            foreach (var value in element.StateInvariant)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "stateInvariant", writeContext);
+            }
+
+            if (element.Submachine != null && !writeContext.IsLocal(element.Submachine))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Submachine, "submachine", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IFinalState"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IFinalState"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IFinalState element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the FinalState with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FinalState");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "container", null, element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.RedefinedVertex != null && writeContext.IsLocal(element.RedefinedVertex))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "redefinedVertex", null, element.RedefinedVertex.XmiId);
+            }
+
+            if (element.Submachine != null && writeContext.IsLocal(element.Submachine))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "submachine", null, element.Submachine.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Connection)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "connection", writeContext);
+            }
+
+            foreach (var value in element.ConnectionPoint)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "connectionPoint", writeContext);
+            }
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.DeferrableTrigger)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deferrableTrigger", writeContext);
+            }
+
+            foreach (var value in element.DoActivity)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "doActivity", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Entry)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "entry", writeContext);
+            }
+
+            foreach (var value in element.Exit)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "exit", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            if (element.RedefinedVertex != null && !writeContext.IsLocal(element.RedefinedVertex))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.RedefinedVertex, "redefinedVertex", writeContext);
+            }
+
+            foreach (var value in element.Region)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "region", writeContext);
+            }
+
+            foreach (var value in element.StateInvariant)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "stateInvariant", writeContext);
+            }
+
+            if (element.Submachine != null && !writeContext.IsLocal(element.Submachine))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Submachine, "submachine", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/FlowFinalNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/FlowFinalNodeWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FlowFinalNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="FlowFinalNodeWriter"/> is to write an instance of <see cref="IFlowFinalNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class FlowFinalNodeWriter : XmiElementWriter<IFlowFinalNode>, IXmiElementWriter<IFlowFinalNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<FlowFinalNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FlowFinalNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public FlowFinalNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<FlowFinalNodeWriter>.Instance : loggerFactory.CreateLogger<FlowFinalNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IFlowFinalNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IFlowFinalNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IFlowFinalNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the FlowFinalNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FlowFinalNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IFlowFinalNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IFlowFinalNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IFlowFinalNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the FlowFinalNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FlowFinalNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ForkNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ForkNodeWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ForkNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ForkNodeWriter"/> is to write an instance of <see cref="IForkNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ForkNodeWriter : XmiElementWriter<IForkNode>, IXmiElementWriter<IForkNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ForkNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ForkNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ForkNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ForkNodeWriter>.Instance : loggerFactory.CreateLogger<ForkNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IForkNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IForkNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IForkNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ForkNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ForkNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IForkNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IForkNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IForkNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ForkNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ForkNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/FunctionBehaviorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/FunctionBehaviorWriter.cs
@@ -1,0 +1,676 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FunctionBehaviorWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="FunctionBehaviorWriter"/> is to write an instance of <see cref="IFunctionBehavior"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class FunctionBehaviorWriter : XmiElementWriter<IFunctionBehavior>, IXmiElementWriter<IFunctionBehavior>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<FunctionBehaviorWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FunctionBehaviorWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public FunctionBehaviorWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<FunctionBehaviorWriter>.Instance : loggerFactory.CreateLogger<FunctionBehaviorWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IFunctionBehavior"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IFunctionBehavior"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IFunctionBehavior element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the FunctionBehavior with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FunctionBehavior");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                xmlWriter.WriteAttributeString("isReentrant", XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                xmlWriter.WriteAttributeString("specification", element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Body)
+            {
+                xmlWriter.WriteElementString("body", value);
+            }
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.Language)
+            {
+                xmlWriter.WriteElementString("language", value);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedBehavior", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IFunctionBehavior"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IFunctionBehavior"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IFunctionBehavior element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the FunctionBehavior with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FunctionBehavior");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReentrant", null, XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specification", null, element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Body)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "body", null, value);
+            }
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.Language)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "language", null, value);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedBehavior", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/GateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GateWriter.cs
@@ -1,0 +1,266 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="GateWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="GateWriter"/> is to write an instance of <see cref="IGate"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class GateWriter : XmiElementWriter<IGate>, IXmiElementWriter<IGate>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<GateWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GateWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public GateWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<GateWriter>.Instance : loggerFactory.CreateLogger<GateWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IGate"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IGate"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IGate element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Gate with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Gate");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Message != null && writeContext.IsLocal(element.Message))
+            {
+                xmlWriter.WriteAttributeString("message", element.Message.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Message != null && !writeContext.IsLocal(element.Message))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Message, "message", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IGate"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IGate"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IGate element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Gate with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Gate");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Message != null && writeContext.IsLocal(element.Message))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "message", null, element.Message.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Message != null && !writeContext.IsLocal(element.Message))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Message, "message", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/GeneralOrderingWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GeneralOrderingWriter.cs
@@ -1,0 +1,286 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="GeneralOrderingWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="GeneralOrderingWriter"/> is to write an instance of <see cref="IGeneralOrdering"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class GeneralOrderingWriter : XmiElementWriter<IGeneralOrdering>, IXmiElementWriter<IGeneralOrdering>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<GeneralOrderingWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GeneralOrderingWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public GeneralOrderingWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<GeneralOrderingWriter>.Instance : loggerFactory.CreateLogger<GeneralOrderingWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IGeneralOrdering"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IGeneralOrdering"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IGeneralOrdering element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the GeneralOrdering with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:GeneralOrdering");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.After != null && writeContext.IsLocal(element.After))
+            {
+                xmlWriter.WriteAttributeString("after", element.After.XmiId);
+            }
+
+            if (element.Before != null && writeContext.IsLocal(element.Before))
+            {
+                xmlWriter.WriteAttributeString("before", element.Before.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.After != null && !writeContext.IsLocal(element.After))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.After, "after", writeContext);
+            }
+
+            if (element.Before != null && !writeContext.IsLocal(element.Before))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Before, "before", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IGeneralOrdering"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IGeneralOrdering"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IGeneralOrdering element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the GeneralOrdering with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:GeneralOrdering");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.After != null && writeContext.IsLocal(element.After))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "after", null, element.After.XmiId);
+            }
+
+            if (element.Before != null && writeContext.IsLocal(element.Before))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "before", null, element.Before.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.After != null && !writeContext.IsLocal(element.After))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.After, "after", writeContext);
+            }
+
+            if (element.Before != null && !writeContext.IsLocal(element.Before))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Before, "before", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/GeneralizationSetWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GeneralizationSetWriter.cs
@@ -1,0 +1,336 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="GeneralizationSetWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="GeneralizationSetWriter"/> is to write an instance of <see cref="IGeneralizationSet"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class GeneralizationSetWriter : XmiElementWriter<IGeneralizationSet>, IXmiElementWriter<IGeneralizationSet>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<GeneralizationSetWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GeneralizationSetWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public GeneralizationSetWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<GeneralizationSetWriter>.Instance : loggerFactory.CreateLogger<GeneralizationSetWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IGeneralizationSet"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IGeneralizationSet"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IGeneralizationSet element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the GeneralizationSet with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:GeneralizationSet");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsCovering)
+            {
+                xmlWriter.WriteAttributeString("isCovering", XmlConvert.ToString(element.IsCovering));
+            }
+
+            if (element.IsDisjoint)
+            {
+                xmlWriter.WriteAttributeString("isDisjoint", XmlConvert.ToString(element.IsDisjoint));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Powertype != null && writeContext.IsLocal(element.Powertype))
+            {
+                xmlWriter.WriteAttributeString("powertype", element.Powertype.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Powertype != null && !writeContext.IsLocal(element.Powertype))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Powertype, "powertype", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IGeneralizationSet"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IGeneralizationSet"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IGeneralizationSet element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the GeneralizationSet with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:GeneralizationSet");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsCovering)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isCovering", null, XmlConvert.ToString(element.IsCovering));
+            }
+
+            if (element.IsDisjoint)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDisjoint", null, XmlConvert.ToString(element.IsDisjoint));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Powertype != null && writeContext.IsLocal(element.Powertype))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "powertype", null, element.Powertype.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Powertype != null && !writeContext.IsLocal(element.Powertype))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Powertype, "powertype", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/GeneralizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GeneralizationWriter.cs
@@ -1,0 +1,276 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="GeneralizationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="GeneralizationWriter"/> is to write an instance of <see cref="IGeneralization"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class GeneralizationWriter : XmiElementWriter<IGeneralization>, IXmiElementWriter<IGeneralization>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<GeneralizationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GeneralizationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public GeneralizationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<GeneralizationWriter>.Instance : loggerFactory.CreateLogger<GeneralizationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IGeneralization"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IGeneralization"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IGeneralization element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Generalization with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Generalization");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.General != null && writeContext.IsLocal(element.General))
+            {
+                xmlWriter.WriteAttributeString("general", element.General.XmiId);
+            }
+
+            if (!element.IsSubstitutable)
+            {
+                xmlWriter.WriteAttributeString("isSubstitutable", XmlConvert.ToString(element.IsSubstitutable));
+            }
+
+            if (element.Specific != null && writeContext.IsLocal(element.Specific))
+            {
+                xmlWriter.WriteAttributeString("specific", element.Specific.XmiId);
+            }
+
+
+            if (element.General != null && !writeContext.IsLocal(element.General))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.General, "general", writeContext);
+            }
+
+            foreach (var value in element.GeneralizationSet)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "generalizationSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Specific != null && !writeContext.IsLocal(element.Specific))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specific, "specific", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IGeneralization"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IGeneralization"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IGeneralization element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Generalization with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Generalization");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.General != null && writeContext.IsLocal(element.General))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "general", null, element.General.XmiId);
+            }
+
+            if (!element.IsSubstitutable)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isSubstitutable", null, XmlConvert.ToString(element.IsSubstitutable));
+            }
+
+            if (element.Specific != null && writeContext.IsLocal(element.Specific))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specific", null, element.Specific.XmiId);
+            }
+
+
+            if (element.General != null && !writeContext.IsLocal(element.General))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.General, "general", writeContext);
+            }
+
+            foreach (var value in element.GeneralizationSet)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "generalizationSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Specific != null && !writeContext.IsLocal(element.Specific))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specific, "specific", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ImageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ImageWriter.cs
@@ -1,0 +1,246 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ImageWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ImageWriter"/> is to write an instance of <see cref="IImage"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ImageWriter : XmiElementWriter<IImage>, IXmiElementWriter<IImage>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ImageWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImageWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ImageWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ImageWriter>.Instance : loggerFactory.CreateLogger<ImageWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IImage"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IImage"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IImage element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Image with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Image");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Content))
+            {
+                xmlWriter.WriteAttributeString("content", element.Content);
+            }
+
+            if (!string.IsNullOrEmpty(element.Format))
+            {
+                xmlWriter.WriteAttributeString("format", element.Format);
+            }
+
+            if (!string.IsNullOrEmpty(element.Location))
+            {
+                xmlWriter.WriteAttributeString("location", element.Location);
+            }
+
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IImage"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IImage"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IImage element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Image with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Image");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Content))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "content", null, element.Content);
+            }
+
+            if (!string.IsNullOrEmpty(element.Format))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "format", null, element.Format);
+            }
+
+            if (!string.IsNullOrEmpty(element.Location))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "location", null, element.Location);
+            }
+
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/IncludeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/IncludeWriter.cs
@@ -1,0 +1,286 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="IncludeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="IncludeWriter"/> is to write an instance of <see cref="IInclude"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class IncludeWriter : XmiElementWriter<IInclude>, IXmiElementWriter<IInclude>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<IncludeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IncludeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public IncludeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<IncludeWriter>.Instance : loggerFactory.CreateLogger<IncludeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInclude"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInclude"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInclude element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Include with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Include");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Addition != null && writeContext.IsLocal(element.Addition))
+            {
+                xmlWriter.WriteAttributeString("addition", element.Addition.XmiId);
+            }
+
+            if (element.IncludingCase != null && writeContext.IsLocal(element.IncludingCase))
+            {
+                xmlWriter.WriteAttributeString("includingCase", element.IncludingCase.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Addition != null && !writeContext.IsLocal(element.Addition))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Addition, "addition", writeContext);
+            }
+
+            if (element.IncludingCase != null && !writeContext.IsLocal(element.IncludingCase))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.IncludingCase, "includingCase", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInclude"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInclude"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInclude element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Include with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Include");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Addition != null && writeContext.IsLocal(element.Addition))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "addition", null, element.Addition.XmiId);
+            }
+
+            if (element.IncludingCase != null && writeContext.IsLocal(element.IncludingCase))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "includingCase", null, element.IncludingCase.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Addition != null && !writeContext.IsLocal(element.Addition))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Addition, "addition", writeContext);
+            }
+
+            if (element.IncludingCase != null && !writeContext.IsLocal(element.IncludingCase))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.IncludingCase, "includingCase", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InformationFlowWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InformationFlowWriter.cs
@@ -1,0 +1,356 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InformationFlowWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InformationFlowWriter"/> is to write an instance of <see cref="IInformationFlow"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InformationFlowWriter : XmiElementWriter<IInformationFlow>, IXmiElementWriter<IInformationFlow>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InformationFlowWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InformationFlowWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InformationFlowWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InformationFlowWriter>.Instance : loggerFactory.CreateLogger<InformationFlowWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInformationFlow"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInformationFlow"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInformationFlow element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InformationFlow with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InformationFlow");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Conveyed)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "conveyed", writeContext);
+            }
+
+            foreach (var value in element.InformationSource)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "informationSource", writeContext);
+            }
+
+            foreach (var value in element.InformationTarget)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "informationTarget", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Realization)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "realization", writeContext);
+            }
+
+            foreach (var value in element.RealizingActivityEdge)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "realizingActivityEdge", writeContext);
+            }
+
+            foreach (var value in element.RealizingConnector)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "realizingConnector", writeContext);
+            }
+
+            foreach (var value in element.RealizingMessage)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "realizingMessage", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInformationFlow"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInformationFlow"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInformationFlow element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InformationFlow with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InformationFlow");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Conveyed)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "conveyed", writeContext);
+            }
+
+            foreach (var value in element.InformationSource)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "informationSource", writeContext);
+            }
+
+            foreach (var value in element.InformationTarget)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "informationTarget", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Realization)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "realization", writeContext);
+            }
+
+            foreach (var value in element.RealizingActivityEdge)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "realizingActivityEdge", writeContext);
+            }
+
+            foreach (var value in element.RealizingConnector)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "realizingConnector", writeContext);
+            }
+
+            foreach (var value in element.RealizingMessage)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "realizingMessage", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InformationItemWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InformationItemWriter.cs
@@ -1,0 +1,486 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InformationItemWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InformationItemWriter"/> is to write an instance of <see cref="IInformationItem"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InformationItemWriter : XmiElementWriter<IInformationItem>, IXmiElementWriter<IInformationItem>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InformationItemWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InformationItemWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InformationItemWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InformationItemWriter>.Instance : loggerFactory.CreateLogger<InformationItemWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInformationItem"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInformationItem"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInformationItem element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InformationItem with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InformationItem");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Represented)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "represented", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInformationItem"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInformationItem"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInformationItem element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InformationItem with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InformationItem");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Represented)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "represented", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InitialNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InitialNodeWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InitialNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InitialNodeWriter"/> is to write an instance of <see cref="IInitialNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InitialNodeWriter : XmiElementWriter<IInitialNode>, IXmiElementWriter<IInitialNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InitialNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InitialNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InitialNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InitialNodeWriter>.Instance : loggerFactory.CreateLogger<InitialNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInitialNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInitialNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInitialNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InitialNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InitialNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInitialNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInitialNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInitialNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InitialNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InitialNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InputPinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InputPinWriter.cs
@@ -1,0 +1,476 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InputPinWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InputPinWriter"/> is to write an instance of <see cref="IInputPin"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InputPinWriter : XmiElementWriter<IInputPin>, IXmiElementWriter<IInputPin>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InputPinWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InputPinWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InputPinWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InputPinWriter>.Instance : loggerFactory.CreateLogger<InputPinWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInputPin"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInputPin"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInputPin element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InputPin with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InputPin");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControl)
+            {
+                xmlWriter.WriteAttributeString("isControl", XmlConvert.ToString(element.IsControl));
+            }
+
+            if (element.IsControlType)
+            {
+                xmlWriter.WriteAttributeString("isControlType", XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                xmlWriter.WriteAttributeString("ordering", LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                xmlWriter.WriteAttributeString("selection", element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperBound", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInputPin"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInputPin"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInputPin element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InputPin with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InputPin");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControl)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControl", null, XmlConvert.ToString(element.IsControl));
+            }
+
+            if (element.IsControlType)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControlType", null, XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "ordering", null, LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "selection", null, element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InstanceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InstanceSpecificationWriter.cs
@@ -1,0 +1,326 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InstanceSpecificationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InstanceSpecificationWriter"/> is to write an instance of <see cref="IInstanceSpecification"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InstanceSpecificationWriter : XmiElementWriter<IInstanceSpecification>, IXmiElementWriter<IInstanceSpecification>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InstanceSpecificationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstanceSpecificationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InstanceSpecificationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InstanceSpecificationWriter>.Instance : loggerFactory.CreateLogger<InstanceSpecificationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInstanceSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInstanceSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInstanceSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InstanceSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InstanceSpecification");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Classifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "classifier", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deployment", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Slot)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "slot", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInstanceSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInstanceSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInstanceSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InstanceSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InstanceSpecification");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Classifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "classifier", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deployment", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Slot)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "slot", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InstanceValueWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InstanceValueWriter.cs
@@ -1,0 +1,326 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InstanceValueWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InstanceValueWriter"/> is to write an instance of <see cref="IInstanceValue"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InstanceValueWriter : XmiElementWriter<IInstanceValue>, IXmiElementWriter<IInstanceValue>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InstanceValueWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstanceValueWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InstanceValueWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InstanceValueWriter>.Instance : loggerFactory.CreateLogger<InstanceValueWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInstanceValue"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInstanceValue"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInstanceValue element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InstanceValue with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InstanceValue");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Instance != null && writeContext.IsLocal(element.Instance))
+            {
+                xmlWriter.WriteAttributeString("instance", element.Instance.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Instance != null && !writeContext.IsLocal(element.Instance))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Instance, "instance", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInstanceValue"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInstanceValue"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInstanceValue element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InstanceValue with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InstanceValue");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Instance != null && writeContext.IsLocal(element.Instance))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "instance", null, element.Instance.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Instance != null && !writeContext.IsLocal(element.Instance))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Instance, "instance", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionConstraintWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InteractionConstraintWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InteractionConstraintWriter"/> is to write an instance of <see cref="IInteractionConstraint"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InteractionConstraintWriter : XmiElementWriter<IInteractionConstraint>, IXmiElementWriter<IInteractionConstraint>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InteractionConstraintWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InteractionConstraintWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InteractionConstraintWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InteractionConstraintWriter>.Instance : loggerFactory.CreateLogger<InteractionConstraintWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInteractionConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInteractionConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInteractionConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InteractionConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionConstraint");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                xmlWriter.WriteAttributeString("context", element.Context.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.Maxint)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "maxint", writeContext);
+            }
+
+            foreach (var value in element.Minint)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "minint", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInteractionConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInteractionConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInteractionConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InteractionConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionConstraint");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "context", null, element.Context.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.Maxint)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "maxint", writeContext);
+            }
+
+            foreach (var value in element.Minint)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "minint", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionOperandWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionOperandWriter.cs
@@ -1,0 +1,356 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InteractionOperandWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InteractionOperandWriter"/> is to write an instance of <see cref="IInteractionOperand"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InteractionOperandWriter : XmiElementWriter<IInteractionOperand>, IXmiElementWriter<IInteractionOperand>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InteractionOperandWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InteractionOperandWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InteractionOperandWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InteractionOperandWriter>.Instance : loggerFactory.CreateLogger<InteractionOperandWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInteractionOperand"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInteractionOperand"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInteractionOperand element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InteractionOperand with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionOperand");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Covered)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "covered", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.Fragment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "fragment", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.Guard)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "guard", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInteractionOperand"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInteractionOperand"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInteractionOperand element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InteractionOperand with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionOperand");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Covered)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "covered", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.Fragment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "fragment", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.Guard)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "guard", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionUseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionUseWriter.cs
@@ -1,0 +1,376 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InteractionUseWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InteractionUseWriter"/> is to write an instance of <see cref="IInteractionUse"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InteractionUseWriter : XmiElementWriter<IInteractionUse>, IXmiElementWriter<IInteractionUse>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InteractionUseWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InteractionUseWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InteractionUseWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InteractionUseWriter>.Instance : loggerFactory.CreateLogger<InteractionUseWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInteractionUse"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInteractionUse"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInteractionUse element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InteractionUse with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionUse");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.RefersTo != null && writeContext.IsLocal(element.RefersTo))
+            {
+                xmlWriter.WriteAttributeString("refersTo", element.RefersTo.XmiId);
+            }
+
+            if (element.ReturnValueRecipient != null && writeContext.IsLocal(element.ReturnValueRecipient))
+            {
+                xmlWriter.WriteAttributeString("returnValueRecipient", element.ReturnValueRecipient.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ActualGate)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "actualGate", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.RefersTo != null && !writeContext.IsLocal(element.RefersTo))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.RefersTo, "refersTo", writeContext);
+            }
+
+            foreach (var value in element.ReturnValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "returnValue", writeContext);
+            }
+
+            if (element.ReturnValueRecipient != null && !writeContext.IsLocal(element.ReturnValueRecipient))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ReturnValueRecipient, "returnValueRecipient", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInteractionUse"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInteractionUse"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInteractionUse element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InteractionUse with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionUse");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.RefersTo != null && writeContext.IsLocal(element.RefersTo))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "refersTo", null, element.RefersTo.XmiId);
+            }
+
+            if (element.ReturnValueRecipient != null && writeContext.IsLocal(element.ReturnValueRecipient))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "returnValueRecipient", null, element.ReturnValueRecipient.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ActualGate)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "actualGate", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.RefersTo != null && !writeContext.IsLocal(element.RefersTo))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.RefersTo, "refersTo", writeContext);
+            }
+
+            foreach (var value in element.ReturnValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "returnValue", writeContext);
+            }
+
+            if (element.ReturnValueRecipient != null && !writeContext.IsLocal(element.ReturnValueRecipient))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReturnValueRecipient, "returnValueRecipient", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionWriter.cs
@@ -1,0 +1,766 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InteractionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InteractionWriter"/> is to write an instance of <see cref="IInteraction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InteractionWriter : XmiElementWriter<IInteraction>, IXmiElementWriter<IInteraction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InteractionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InteractionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InteractionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InteractionWriter>.Instance : loggerFactory.CreateLogger<InteractionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInteraction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInteraction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInteraction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Interaction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interaction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                xmlWriter.WriteAttributeString("isReentrant", XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                xmlWriter.WriteAttributeString("specification", element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Action)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "action", writeContext);
+            }
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "covered", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.FormalGate)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "formalGate", writeContext);
+            }
+
+            foreach (var value in element.Fragment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "fragment", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.Lifeline)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lifeline", writeContext);
+            }
+
+            foreach (var value in element.Message)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "message", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedBehavior", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInteraction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInteraction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInteraction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Interaction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interaction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReentrant", null, XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specification", null, element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Action)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "action", writeContext);
+            }
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "covered", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.FormalGate)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "formalGate", writeContext);
+            }
+
+            foreach (var value in element.Fragment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "fragment", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.Lifeline)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lifeline", writeContext);
+            }
+
+            foreach (var value in element.Message)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "message", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedBehavior", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InterfaceRealizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InterfaceRealizationWriter.cs
@@ -1,0 +1,356 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InterfaceRealizationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InterfaceRealizationWriter"/> is to write an instance of <see cref="IInterfaceRealization"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InterfaceRealizationWriter : XmiElementWriter<IInterfaceRealization>, IXmiElementWriter<IInterfaceRealization>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InterfaceRealizationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InterfaceRealizationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InterfaceRealizationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InterfaceRealizationWriter>.Instance : loggerFactory.CreateLogger<InterfaceRealizationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInterfaceRealization"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInterfaceRealization"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInterfaceRealization element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InterfaceRealization with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InterfaceRealization");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Contract != null && writeContext.IsLocal(element.Contract))
+            {
+                xmlWriter.WriteAttributeString("contract", element.Contract.XmiId);
+            }
+
+            if (element.ImplementingClassifier != null && writeContext.IsLocal(element.ImplementingClassifier))
+            {
+                xmlWriter.WriteAttributeString("implementingClassifier", element.ImplementingClassifier.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "client", writeContext);
+            }
+
+            if (element.Contract != null && !writeContext.IsLocal(element.Contract))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Contract, "contract", writeContext);
+            }
+
+            if (element.ImplementingClassifier != null && !writeContext.IsLocal(element.ImplementingClassifier))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ImplementingClassifier, "implementingClassifier", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInterfaceRealization"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInterfaceRealization"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInterfaceRealization element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InterfaceRealization with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InterfaceRealization");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Contract != null && writeContext.IsLocal(element.Contract))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "contract", null, element.Contract.XmiId);
+            }
+
+            if (element.ImplementingClassifier != null && writeContext.IsLocal(element.ImplementingClassifier))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "implementingClassifier", null, element.ImplementingClassifier.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "client", writeContext);
+            }
+
+            if (element.Contract != null && !writeContext.IsLocal(element.Contract))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Contract, "contract", writeContext);
+            }
+
+            if (element.ImplementingClassifier != null && !writeContext.IsLocal(element.ImplementingClassifier))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ImplementingClassifier, "implementingClassifier", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InterfaceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InterfaceWriter.cs
@@ -1,0 +1,536 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InterfaceWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InterfaceWriter"/> is to write an instance of <see cref="IInterface"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InterfaceWriter : XmiElementWriter<IInterface>, IXmiElementWriter<IInterface>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InterfaceWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InterfaceWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InterfaceWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InterfaceWriter>.Instance : loggerFactory.CreateLogger<InterfaceWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInterface"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInterface"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInterface element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Interface with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interface");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Protocol)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "protocol", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedInterface)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedInterface", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInterface"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInterface"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInterface element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Interface with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interface");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Protocol)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "protocol", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedInterface)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedInterface", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/InterruptibleActivityRegionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InterruptibleActivityRegionWriter.cs
@@ -1,0 +1,286 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="InterruptibleActivityRegionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="InterruptibleActivityRegionWriter"/> is to write an instance of <see cref="IInterruptibleActivityRegion"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class InterruptibleActivityRegionWriter : XmiElementWriter<IInterruptibleActivityRegion>, IXmiElementWriter<IInterruptibleActivityRegion>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<InterruptibleActivityRegionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InterruptibleActivityRegionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public InterruptibleActivityRegionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<InterruptibleActivityRegionWriter>.Instance : loggerFactory.CreateLogger<InterruptibleActivityRegionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInterruptibleActivityRegion"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInterruptibleActivityRegion"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInterruptibleActivityRegion element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InterruptibleActivityRegion with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InterruptibleActivityRegion");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.InActivity != null && writeContext.IsLocal(element.InActivity))
+            {
+                xmlWriter.WriteAttributeString("inActivity", element.InActivity.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.InActivity != null && !writeContext.IsLocal(element.InActivity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InActivity, "inActivity", writeContext);
+            }
+
+            foreach (var value in element.InterruptingEdge)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "interruptingEdge", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInterruptibleActivityRegion"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInterruptibleActivityRegion"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInterruptibleActivityRegion element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the InterruptibleActivityRegion with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InterruptibleActivityRegion");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.InActivity != null && writeContext.IsLocal(element.InActivity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inActivity", null, element.InActivity.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.InActivity != null && !writeContext.IsLocal(element.InActivity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InActivity, "inActivity", writeContext);
+            }
+
+            foreach (var value in element.InterruptingEdge)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "interruptingEdge", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/IntervalConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/IntervalConstraintWriter.cs
@@ -1,0 +1,326 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="IntervalConstraintWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="IntervalConstraintWriter"/> is to write an instance of <see cref="IIntervalConstraint"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class IntervalConstraintWriter : XmiElementWriter<IIntervalConstraint>, IXmiElementWriter<IIntervalConstraint>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<IntervalConstraintWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IntervalConstraintWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public IntervalConstraintWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<IntervalConstraintWriter>.Instance : loggerFactory.CreateLogger<IntervalConstraintWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IIntervalConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IIntervalConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IIntervalConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the IntervalConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:IntervalConstraint");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                xmlWriter.WriteAttributeString("context", element.Context.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IIntervalConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IIntervalConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IIntervalConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the IntervalConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:IntervalConstraint");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "context", null, element.Context.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/IntervalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/IntervalWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="IntervalWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="IntervalWriter"/> is to write an instance of <see cref="IInterval"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class IntervalWriter : XmiElementWriter<IInterval>, IXmiElementWriter<IInterval>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<IntervalWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IntervalWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public IntervalWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<IntervalWriter>.Instance : loggerFactory.CreateLogger<IntervalWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IInterval"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInterval"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IInterval element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Interval with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interval");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Max != null && writeContext.IsLocal(element.Max))
+            {
+                xmlWriter.WriteAttributeString("max", element.Max.XmiId);
+            }
+
+            if (element.Min != null && writeContext.IsLocal(element.Min))
+            {
+                xmlWriter.WriteAttributeString("min", element.Min.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Max != null && !writeContext.IsLocal(element.Max))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Max, "max", writeContext);
+            }
+
+            if (element.Min != null && !writeContext.IsLocal(element.Min))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Min, "min", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IInterval"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IInterval"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IInterval element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Interval with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interval");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Max != null && writeContext.IsLocal(element.Max))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "max", null, element.Max.XmiId);
+            }
+
+            if (element.Min != null && writeContext.IsLocal(element.Min))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "min", null, element.Min.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Max != null && !writeContext.IsLocal(element.Max))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Max, "max", writeContext);
+            }
+
+            if (element.Min != null && !writeContext.IsLocal(element.Min))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Min, "min", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/JoinNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/JoinNodeWriter.cs
@@ -1,0 +1,366 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="JoinNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="JoinNodeWriter"/> is to write an instance of <see cref="IJoinNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class JoinNodeWriter : XmiElementWriter<IJoinNode>, IXmiElementWriter<IJoinNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<JoinNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JoinNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public JoinNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<JoinNodeWriter>.Instance : loggerFactory.CreateLogger<JoinNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IJoinNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IJoinNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IJoinNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the JoinNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:JoinNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (!element.IsCombineDuplicate)
+            {
+                xmlWriter.WriteAttributeString("isCombineDuplicate", XmlConvert.ToString(element.IsCombineDuplicate));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.JoinSpec)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "joinSpec", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IJoinNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IJoinNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IJoinNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the JoinNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:JoinNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (!element.IsCombineDuplicate)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isCombineDuplicate", null, XmlConvert.ToString(element.IsCombineDuplicate));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.JoinSpec)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "joinSpec", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LifelineWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LifelineWriter.cs
@@ -1,0 +1,326 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LifelineWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LifelineWriter"/> is to write an instance of <see cref="ILifeline"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LifelineWriter : XmiElementWriter<ILifeline>, IXmiElementWriter<ILifeline>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LifelineWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LifelineWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LifelineWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LifelineWriter>.Instance : loggerFactory.CreateLogger<LifelineWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILifeline"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILifeline"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILifeline element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Lifeline with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Lifeline");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.DecomposedAs != null && writeContext.IsLocal(element.DecomposedAs))
+            {
+                xmlWriter.WriteAttributeString("decomposedAs", element.DecomposedAs.XmiId);
+            }
+
+            if (element.Interaction != null && writeContext.IsLocal(element.Interaction))
+            {
+                xmlWriter.WriteAttributeString("interaction", element.Interaction.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Represents != null && writeContext.IsLocal(element.Represents))
+            {
+                xmlWriter.WriteAttributeString("represents", element.Represents.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CoveredBy)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "coveredBy", writeContext);
+            }
+
+            if (element.DecomposedAs != null && !writeContext.IsLocal(element.DecomposedAs))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.DecomposedAs, "decomposedAs", writeContext);
+            }
+
+            if (element.Interaction != null && !writeContext.IsLocal(element.Interaction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Interaction, "interaction", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Represents != null && !writeContext.IsLocal(element.Represents))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Represents, "represents", writeContext);
+            }
+
+            foreach (var value in element.Selector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "selector", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILifeline"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILifeline"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILifeline element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Lifeline with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Lifeline");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.DecomposedAs != null && writeContext.IsLocal(element.DecomposedAs))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "decomposedAs", null, element.DecomposedAs.XmiId);
+            }
+
+            if (element.Interaction != null && writeContext.IsLocal(element.Interaction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interaction", null, element.Interaction.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Represents != null && writeContext.IsLocal(element.Represents))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "represents", null, element.Represents.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CoveredBy)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "coveredBy", writeContext);
+            }
+
+            if (element.DecomposedAs != null && !writeContext.IsLocal(element.DecomposedAs))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.DecomposedAs, "decomposedAs", writeContext);
+            }
+
+            if (element.Interaction != null && !writeContext.IsLocal(element.Interaction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Interaction, "interaction", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Represents != null && !writeContext.IsLocal(element.Represents))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Represents, "represents", writeContext);
+            }
+
+            foreach (var value in element.Selector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "selector", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LinkEndCreationDataWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LinkEndCreationDataWriter.cs
@@ -1,0 +1,296 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LinkEndCreationDataWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LinkEndCreationDataWriter"/> is to write an instance of <see cref="ILinkEndCreationData"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LinkEndCreationDataWriter : XmiElementWriter<ILinkEndCreationData>, IXmiElementWriter<ILinkEndCreationData>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LinkEndCreationDataWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LinkEndCreationDataWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LinkEndCreationDataWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LinkEndCreationDataWriter>.Instance : loggerFactory.CreateLogger<LinkEndCreationDataWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILinkEndCreationData"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILinkEndCreationData"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILinkEndCreationData element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LinkEndCreationData with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndCreationData");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.End != null && writeContext.IsLocal(element.End))
+            {
+                xmlWriter.WriteAttributeString("end", element.End.XmiId);
+            }
+
+            if (element.InsertAt != null && writeContext.IsLocal(element.InsertAt))
+            {
+                xmlWriter.WriteAttributeString("insertAt", element.InsertAt.XmiId);
+            }
+
+            if (element.IsReplaceAll)
+            {
+                xmlWriter.WriteAttributeString("isReplaceAll", XmlConvert.ToString(element.IsReplaceAll));
+            }
+
+            if (element.Value != null && writeContext.IsLocal(element.Value))
+            {
+                xmlWriter.WriteAttributeString("value", element.Value.XmiId);
+            }
+
+
+            if (element.End != null && !writeContext.IsLocal(element.End))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.End, "end", writeContext);
+            }
+
+            if (element.InsertAt != null && !writeContext.IsLocal(element.InsertAt))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InsertAt, "insertAt", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            if (element.Value != null && !writeContext.IsLocal(element.Value))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Value, "value", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILinkEndCreationData"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILinkEndCreationData"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILinkEndCreationData element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LinkEndCreationData with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndCreationData");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.End != null && writeContext.IsLocal(element.End))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "end", null, element.End.XmiId);
+            }
+
+            if (element.InsertAt != null && writeContext.IsLocal(element.InsertAt))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "insertAt", null, element.InsertAt.XmiId);
+            }
+
+            if (element.IsReplaceAll)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReplaceAll", null, XmlConvert.ToString(element.IsReplaceAll));
+            }
+
+            if (element.Value != null && writeContext.IsLocal(element.Value))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, element.Value.XmiId);
+            }
+
+
+            if (element.End != null && !writeContext.IsLocal(element.End))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.End, "end", writeContext);
+            }
+
+            if (element.InsertAt != null && !writeContext.IsLocal(element.InsertAt))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InsertAt, "insertAt", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            if (element.Value != null && !writeContext.IsLocal(element.Value))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LinkEndDataWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LinkEndDataWriter.cs
@@ -1,0 +1,266 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LinkEndDataWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LinkEndDataWriter"/> is to write an instance of <see cref="ILinkEndData"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LinkEndDataWriter : XmiElementWriter<ILinkEndData>, IXmiElementWriter<ILinkEndData>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LinkEndDataWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LinkEndDataWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LinkEndDataWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LinkEndDataWriter>.Instance : loggerFactory.CreateLogger<LinkEndDataWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILinkEndData"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILinkEndData"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILinkEndData element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LinkEndData with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndData");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.End != null && writeContext.IsLocal(element.End))
+            {
+                xmlWriter.WriteAttributeString("end", element.End.XmiId);
+            }
+
+            if (element.Value != null && writeContext.IsLocal(element.Value))
+            {
+                xmlWriter.WriteAttributeString("value", element.Value.XmiId);
+            }
+
+
+            if (element.End != null && !writeContext.IsLocal(element.End))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.End, "end", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            if (element.Value != null && !writeContext.IsLocal(element.Value))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Value, "value", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILinkEndData"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILinkEndData"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILinkEndData element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LinkEndData with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndData");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.End != null && writeContext.IsLocal(element.End))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "end", null, element.End.XmiId);
+            }
+
+            if (element.Value != null && writeContext.IsLocal(element.Value))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, element.Value.XmiId);
+            }
+
+
+            if (element.End != null && !writeContext.IsLocal(element.End))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.End, "end", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            if (element.Value != null && !writeContext.IsLocal(element.Value))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LinkEndDestructionDataWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LinkEndDestructionDataWriter.cs
@@ -1,0 +1,296 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LinkEndDestructionDataWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LinkEndDestructionDataWriter"/> is to write an instance of <see cref="ILinkEndDestructionData"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LinkEndDestructionDataWriter : XmiElementWriter<ILinkEndDestructionData>, IXmiElementWriter<ILinkEndDestructionData>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LinkEndDestructionDataWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LinkEndDestructionDataWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LinkEndDestructionDataWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LinkEndDestructionDataWriter>.Instance : loggerFactory.CreateLogger<LinkEndDestructionDataWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILinkEndDestructionData"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILinkEndDestructionData"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILinkEndDestructionData element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LinkEndDestructionData with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndDestructionData");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.DestroyAt != null && writeContext.IsLocal(element.DestroyAt))
+            {
+                xmlWriter.WriteAttributeString("destroyAt", element.DestroyAt.XmiId);
+            }
+
+            if (element.End != null && writeContext.IsLocal(element.End))
+            {
+                xmlWriter.WriteAttributeString("end", element.End.XmiId);
+            }
+
+            if (element.IsDestroyDuplicates)
+            {
+                xmlWriter.WriteAttributeString("isDestroyDuplicates", XmlConvert.ToString(element.IsDestroyDuplicates));
+            }
+
+            if (element.Value != null && writeContext.IsLocal(element.Value))
+            {
+                xmlWriter.WriteAttributeString("value", element.Value.XmiId);
+            }
+
+
+            if (element.DestroyAt != null && !writeContext.IsLocal(element.DestroyAt))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.DestroyAt, "destroyAt", writeContext);
+            }
+
+            if (element.End != null && !writeContext.IsLocal(element.End))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.End, "end", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            if (element.Value != null && !writeContext.IsLocal(element.Value))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Value, "value", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILinkEndDestructionData"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILinkEndDestructionData"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILinkEndDestructionData element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LinkEndDestructionData with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndDestructionData");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.DestroyAt != null && writeContext.IsLocal(element.DestroyAt))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "destroyAt", null, element.DestroyAt.XmiId);
+            }
+
+            if (element.End != null && writeContext.IsLocal(element.End))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "end", null, element.End.XmiId);
+            }
+
+            if (element.IsDestroyDuplicates)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDestroyDuplicates", null, XmlConvert.ToString(element.IsDestroyDuplicates));
+            }
+
+            if (element.Value != null && writeContext.IsLocal(element.Value))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, element.Value.XmiId);
+            }
+
+
+            if (element.DestroyAt != null && !writeContext.IsLocal(element.DestroyAt))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.DestroyAt, "destroyAt", writeContext);
+            }
+
+            if (element.End != null && !writeContext.IsLocal(element.End))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.End, "end", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            if (element.Value != null && !writeContext.IsLocal(element.Value))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralBooleanWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralBooleanWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralBooleanWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LiteralBooleanWriter"/> is to write an instance of <see cref="ILiteralBoolean"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LiteralBooleanWriter : XmiElementWriter<ILiteralBoolean>, IXmiElementWriter<ILiteralBoolean>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LiteralBooleanWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiteralBooleanWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LiteralBooleanWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LiteralBooleanWriter>.Instance : loggerFactory.CreateLogger<LiteralBooleanWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILiteralBoolean"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralBoolean"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILiteralBoolean element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralBoolean with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralBoolean");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Value)
+            {
+                xmlWriter.WriteAttributeString("value", XmlConvert.ToString(element.Value));
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILiteralBoolean"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralBoolean"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILiteralBoolean element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralBoolean with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralBoolean");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Value)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, XmlConvert.ToString(element.Value));
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralIntegerWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralIntegerWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralIntegerWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LiteralIntegerWriter"/> is to write an instance of <see cref="ILiteralInteger"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LiteralIntegerWriter : XmiElementWriter<ILiteralInteger>, IXmiElementWriter<ILiteralInteger>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LiteralIntegerWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiteralIntegerWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LiteralIntegerWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LiteralIntegerWriter>.Instance : loggerFactory.CreateLogger<LiteralIntegerWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILiteralInteger"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralInteger"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILiteralInteger element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralInteger with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralInteger");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Value != 0)
+            {
+                xmlWriter.WriteAttributeString("value", XmlConvert.ToString(element.Value));
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILiteralInteger"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralInteger"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILiteralInteger element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralInteger with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralInteger");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Value != 0)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, XmlConvert.ToString(element.Value));
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralNullWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralNullWriter.cs
@@ -1,0 +1,306 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralNullWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LiteralNullWriter"/> is to write an instance of <see cref="ILiteralNull"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LiteralNullWriter : XmiElementWriter<ILiteralNull>, IXmiElementWriter<ILiteralNull>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LiteralNullWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiteralNullWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LiteralNullWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LiteralNullWriter>.Instance : loggerFactory.CreateLogger<LiteralNullWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILiteralNull"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralNull"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILiteralNull element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralNull with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralNull");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILiteralNull"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralNull"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILiteralNull element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralNull with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralNull");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralRealWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralRealWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralRealWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LiteralRealWriter"/> is to write an instance of <see cref="ILiteralReal"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LiteralRealWriter : XmiElementWriter<ILiteralReal>, IXmiElementWriter<ILiteralReal>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LiteralRealWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiteralRealWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LiteralRealWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LiteralRealWriter>.Instance : loggerFactory.CreateLogger<LiteralRealWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILiteralReal"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralReal"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILiteralReal element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralReal with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralReal");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Value != 0)
+            {
+                xmlWriter.WriteAttributeString("value", XmlConvert.ToString(element.Value));
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILiteralReal"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralReal"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILiteralReal element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralReal with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralReal");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Value != 0)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, XmlConvert.ToString(element.Value));
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralStringWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralStringWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralStringWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LiteralStringWriter"/> is to write an instance of <see cref="ILiteralString"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LiteralStringWriter : XmiElementWriter<ILiteralString>, IXmiElementWriter<ILiteralString>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LiteralStringWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiteralStringWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LiteralStringWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LiteralStringWriter>.Instance : loggerFactory.CreateLogger<LiteralStringWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILiteralString"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralString"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILiteralString element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralString with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralString");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Value))
+            {
+                xmlWriter.WriteAttributeString("value", element.Value);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILiteralString"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralString"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILiteralString element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralString with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralString");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Value))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, element.Value);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LiteralUnlimitedNaturalWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LiteralUnlimitedNaturalWriter"/> is to write an instance of <see cref="ILiteralUnlimitedNatural"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LiteralUnlimitedNaturalWriter : XmiElementWriter<ILiteralUnlimitedNatural>, IXmiElementWriter<ILiteralUnlimitedNatural>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LiteralUnlimitedNaturalWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiteralUnlimitedNaturalWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LiteralUnlimitedNaturalWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LiteralUnlimitedNaturalWriter>.Instance : loggerFactory.CreateLogger<LiteralUnlimitedNaturalWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILiteralUnlimitedNatural"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralUnlimitedNatural"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILiteralUnlimitedNatural element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralUnlimitedNatural with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralUnlimitedNatural");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Value))
+            {
+                xmlWriter.WriteAttributeString("value", element.Value);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILiteralUnlimitedNatural"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILiteralUnlimitedNatural"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILiteralUnlimitedNatural element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LiteralUnlimitedNatural with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralUnlimitedNatural");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Value))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, element.Value);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/LoopNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LoopNodeWriter.cs
@@ -1,0 +1,556 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="LoopNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="LoopNodeWriter"/> is to write an instance of <see cref="ILoopNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class LoopNodeWriter : XmiElementWriter<ILoopNode>, IXmiElementWriter<ILoopNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<LoopNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoopNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public LoopNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<LoopNodeWriter>.Instance : loggerFactory.CreateLogger<LoopNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ILoopNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILoopNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ILoopNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LoopNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LoopNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.Decider != null && writeContext.IsLocal(element.Decider))
+            {
+                xmlWriter.WriteAttributeString("decider", element.Decider.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsTestedFirst)
+            {
+                xmlWriter.WriteAttributeString("isTestedFirst", XmlConvert.ToString(element.IsTestedFirst));
+            }
+
+            if (element.MustIsolate)
+            {
+                xmlWriter.WriteAttributeString("mustIsolate", XmlConvert.ToString(element.MustIsolate));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.BodyOutput)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "bodyOutput", writeContext);
+            }
+
+            foreach (var value in element.BodyPart)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "bodyPart", writeContext);
+            }
+
+            if (element.Decider != null && !writeContext.IsLocal(element.Decider))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Decider, "decider", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.LoopVariable)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "loopVariable", writeContext);
+            }
+
+            foreach (var value in element.LoopVariableInput)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "loopVariableInput", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.SetupPart)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "setupPart", writeContext);
+            }
+
+            foreach (var value in element.Test)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "test", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ILoopNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ILoopNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ILoopNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the LoopNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LoopNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.Decider != null && writeContext.IsLocal(element.Decider))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "decider", null, element.Decider.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsTestedFirst)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isTestedFirst", null, XmlConvert.ToString(element.IsTestedFirst));
+            }
+
+            if (element.MustIsolate)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "mustIsolate", null, XmlConvert.ToString(element.MustIsolate));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.BodyOutput)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "bodyOutput", writeContext);
+            }
+
+            foreach (var value in element.BodyPart)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "bodyPart", writeContext);
+            }
+
+            if (element.Decider != null && !writeContext.IsLocal(element.Decider))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Decider, "decider", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.LoopVariable)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "loopVariable", writeContext);
+            }
+
+            foreach (var value in element.LoopVariableInput)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "loopVariableInput", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.SetupPart)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "setupPart", writeContext);
+            }
+
+            foreach (var value in element.Test)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "test", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ManifestationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ManifestationWriter.cs
@@ -1,0 +1,336 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ManifestationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ManifestationWriter"/> is to write an instance of <see cref="IManifestation"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ManifestationWriter : XmiElementWriter<IManifestation>, IXmiElementWriter<IManifestation>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ManifestationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManifestationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ManifestationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ManifestationWriter>.Instance : loggerFactory.CreateLogger<ManifestationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IManifestation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IManifestation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IManifestation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Manifestation with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Manifestation");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.UtilizedElement != null && writeContext.IsLocal(element.UtilizedElement))
+            {
+                xmlWriter.WriteAttributeString("utilizedElement", element.UtilizedElement.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.UtilizedElement != null && !writeContext.IsLocal(element.UtilizedElement))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.UtilizedElement, "utilizedElement", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IManifestation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IManifestation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IManifestation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Manifestation with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Manifestation");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.UtilizedElement != null && writeContext.IsLocal(element.UtilizedElement))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "utilizedElement", null, element.UtilizedElement.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.UtilizedElement != null && !writeContext.IsLocal(element.UtilizedElement))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.UtilizedElement, "utilizedElement", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/MergeNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/MergeNodeWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MergeNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="MergeNodeWriter"/> is to write an instance of <see cref="IMergeNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class MergeNodeWriter : XmiElementWriter<IMergeNode>, IXmiElementWriter<IMergeNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<MergeNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MergeNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public MergeNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<MergeNodeWriter>.Instance : loggerFactory.CreateLogger<MergeNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IMergeNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IMergeNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IMergeNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the MergeNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:MergeNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IMergeNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IMergeNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IMergeNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the MergeNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:MergeNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/MessageOccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/MessageOccurrenceSpecificationWriter.cs
@@ -1,0 +1,356 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MessageOccurrenceSpecificationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="MessageOccurrenceSpecificationWriter"/> is to write an instance of <see cref="IMessageOccurrenceSpecification"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class MessageOccurrenceSpecificationWriter : XmiElementWriter<IMessageOccurrenceSpecification>, IXmiElementWriter<IMessageOccurrenceSpecification>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<MessageOccurrenceSpecificationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageOccurrenceSpecificationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public MessageOccurrenceSpecificationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<MessageOccurrenceSpecificationWriter>.Instance : loggerFactory.CreateLogger<MessageOccurrenceSpecificationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IMessageOccurrenceSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IMessageOccurrenceSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IMessageOccurrenceSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the MessageOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:MessageOccurrenceSpecification");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Covered != null && writeContext.IsLocal(element.Covered))
+            {
+                xmlWriter.WriteAttributeString("covered", element.Covered.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (element.Message != null && writeContext.IsLocal(element.Message))
+            {
+                xmlWriter.WriteAttributeString("message", element.Message.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Covered != null && !writeContext.IsLocal(element.Covered))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Covered, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            if (element.Message != null && !writeContext.IsLocal(element.Message))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Message, "message", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.ToAfter)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "toAfter", writeContext);
+            }
+
+            foreach (var value in element.ToBefore)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "toBefore", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IMessageOccurrenceSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IMessageOccurrenceSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IMessageOccurrenceSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the MessageOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:MessageOccurrenceSpecification");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Covered != null && writeContext.IsLocal(element.Covered))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "covered", null, element.Covered.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (element.Message != null && writeContext.IsLocal(element.Message))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "message", null, element.Message.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Covered != null && !writeContext.IsLocal(element.Covered))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Covered, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            if (element.Message != null && !writeContext.IsLocal(element.Message))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Message, "message", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.ToAfter)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toAfter", writeContext);
+            }
+
+            foreach (var value in element.ToBefore)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/MessageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/MessageWriter.cs
@@ -1,0 +1,366 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="MessageWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="MessageWriter"/> is to write an instance of <see cref="IMessage"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class MessageWriter : XmiElementWriter<IMessage>, IXmiElementWriter<IMessage>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<MessageWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public MessageWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<MessageWriter>.Instance : loggerFactory.CreateLogger<MessageWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IMessage"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IMessage"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IMessage element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Message with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Message");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Connector != null && writeContext.IsLocal(element.Connector))
+            {
+                xmlWriter.WriteAttributeString("connector", element.Connector.XmiId);
+            }
+
+            if (element.Interaction != null && writeContext.IsLocal(element.Interaction))
+            {
+                xmlWriter.WriteAttributeString("interaction", element.Interaction.XmiId);
+            }
+
+            if (element.MessageSort != MessageSort.SynchCall)
+            {
+                xmlWriter.WriteAttributeString("messageSort", LowerCaseFirstLetter(element.MessageSort.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.ReceiveEvent != null && writeContext.IsLocal(element.ReceiveEvent))
+            {
+                xmlWriter.WriteAttributeString("receiveEvent", element.ReceiveEvent.XmiId);
+            }
+
+            if (element.SendEvent != null && writeContext.IsLocal(element.SendEvent))
+            {
+                xmlWriter.WriteAttributeString("sendEvent", element.SendEvent.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                xmlWriter.WriteAttributeString("signature", element.Signature.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Argument)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "argument", writeContext);
+            }
+
+            if (element.Connector != null && !writeContext.IsLocal(element.Connector))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Connector, "connector", writeContext);
+            }
+
+            if (element.Interaction != null && !writeContext.IsLocal(element.Interaction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Interaction, "interaction", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.ReceiveEvent != null && !writeContext.IsLocal(element.ReceiveEvent))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ReceiveEvent, "receiveEvent", writeContext);
+            }
+
+            if (element.SendEvent != null && !writeContext.IsLocal(element.SendEvent))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.SendEvent, "sendEvent", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IMessage"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IMessage"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IMessage element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Message with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Message");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Connector != null && writeContext.IsLocal(element.Connector))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "connector", null, element.Connector.XmiId);
+            }
+
+            if (element.Interaction != null && writeContext.IsLocal(element.Interaction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interaction", null, element.Interaction.XmiId);
+            }
+
+            if (element.MessageSort != MessageSort.SynchCall)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "messageSort", null, LowerCaseFirstLetter(element.MessageSort.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.ReceiveEvent != null && writeContext.IsLocal(element.ReceiveEvent))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "receiveEvent", null, element.ReceiveEvent.XmiId);
+            }
+
+            if (element.SendEvent != null && writeContext.IsLocal(element.SendEvent))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "sendEvent", null, element.SendEvent.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "signature", null, element.Signature.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Argument)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "argument", writeContext);
+            }
+
+            if (element.Connector != null && !writeContext.IsLocal(element.Connector))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Connector, "connector", writeContext);
+            }
+
+            if (element.Interaction != null && !writeContext.IsLocal(element.Interaction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Interaction, "interaction", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.ReceiveEvent != null && !writeContext.IsLocal(element.ReceiveEvent))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReceiveEvent, "receiveEvent", writeContext);
+            }
+
+            if (element.SendEvent != null && !writeContext.IsLocal(element.SendEvent))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.SendEvent, "sendEvent", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ModelWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ModelWriter.cs
@@ -1,0 +1,406 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ModelWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ModelWriter"/> is to write an instance of <see cref="IModel"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ModelWriter : XmiElementWriter<IModel>, IXmiElementWriter<IModel>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ModelWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ModelWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ModelWriter>.Instance : loggerFactory.CreateLogger<ModelWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IModel"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IModel"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IModel element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Model with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Model");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.NestingPackage != null && writeContext.IsLocal(element.NestingPackage))
+            {
+                xmlWriter.WriteAttributeString("nestingPackage", element.NestingPackage.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.URI))
+            {
+                xmlWriter.WriteAttributeString("URI", element.URI);
+            }
+
+            if (!string.IsNullOrEmpty(element.Viewpoint))
+            {
+                xmlWriter.WriteAttributeString("viewpoint", element.Viewpoint);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.NestingPackage != null && !writeContext.IsLocal(element.NestingPackage))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.NestingPackage, "nestingPackage", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.PackagedElement)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packagedElement", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PackageMerge)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageMerge", writeContext);
+            }
+
+            foreach (var value in element.ProfileApplication)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "profileApplication", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IModel"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IModel"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IModel element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Model with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Model");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.NestingPackage != null && writeContext.IsLocal(element.NestingPackage))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "nestingPackage", null, element.NestingPackage.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.URI))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "URI", null, element.URI);
+            }
+
+            if (!string.IsNullOrEmpty(element.Viewpoint))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "viewpoint", null, element.Viewpoint);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.NestingPackage != null && !writeContext.IsLocal(element.NestingPackage))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.NestingPackage, "nestingPackage", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.PackagedElement)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packagedElement", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PackageMerge)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageMerge", writeContext);
+            }
+
+            foreach (var value in element.ProfileApplication)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "profileApplication", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/NodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/NodeWriter.cs
@@ -1,0 +1,596 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="NodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="NodeWriter"/> is to write an instance of <see cref="INode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class NodeWriter : XmiElementWriter<INode>, IXmiElementWriter<INode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<NodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public NodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<NodeWriter>.Instance : loggerFactory.CreateLogger<NodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="INode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="INode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, INode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Node with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Node");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deployment", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.NestedNode)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedNode", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="INode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="INode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, INode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Node with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Node");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deployment", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.NestedNode)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedNode", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ObjectFlowWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ObjectFlowWriter.cs
@@ -1,0 +1,456 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ObjectFlowWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ObjectFlowWriter"/> is to write an instance of <see cref="IObjectFlow"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ObjectFlowWriter : XmiElementWriter<IObjectFlow>, IXmiElementWriter<IObjectFlow>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ObjectFlowWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectFlowWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ObjectFlowWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ObjectFlowWriter>.Instance : loggerFactory.CreateLogger<ObjectFlowWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IObjectFlow"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IObjectFlow"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IObjectFlow element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ObjectFlow with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ObjectFlow");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.Interrupts != null && writeContext.IsLocal(element.Interrupts))
+            {
+                xmlWriter.WriteAttributeString("interrupts", element.Interrupts.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsMulticast)
+            {
+                xmlWriter.WriteAttributeString("isMulticast", XmlConvert.ToString(element.IsMulticast));
+            }
+
+            if (element.IsMultireceive)
+            {
+                xmlWriter.WriteAttributeString("isMultireceive", XmlConvert.ToString(element.IsMultireceive));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                xmlWriter.WriteAttributeString("selection", element.Selection.XmiId);
+            }
+
+            if (element.Source != null && writeContext.IsLocal(element.Source))
+            {
+                xmlWriter.WriteAttributeString("source", element.Source.XmiId);
+            }
+
+            if (element.Target != null && writeContext.IsLocal(element.Target))
+            {
+                xmlWriter.WriteAttributeString("target", element.Target.XmiId);
+            }
+
+            if (element.Transformation != null && writeContext.IsLocal(element.Transformation))
+            {
+                xmlWriter.WriteAttributeString("transformation", element.Transformation.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Guard)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "guard", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            if (element.Interrupts != null && !writeContext.IsLocal(element.Interrupts))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Interrupts, "interrupts", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedEdge)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedEdge", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Source != null && !writeContext.IsLocal(element.Source))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Source, "source", writeContext);
+            }
+
+            if (element.Target != null && !writeContext.IsLocal(element.Target))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Target, "target", writeContext);
+            }
+
+            if (element.Transformation != null && !writeContext.IsLocal(element.Transformation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Transformation, "transformation", writeContext);
+            }
+
+            foreach (var value in element.Weight)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "weight", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IObjectFlow"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IObjectFlow"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IObjectFlow element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ObjectFlow with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ObjectFlow");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.Interrupts != null && writeContext.IsLocal(element.Interrupts))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interrupts", null, element.Interrupts.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsMulticast)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isMulticast", null, XmlConvert.ToString(element.IsMulticast));
+            }
+
+            if (element.IsMultireceive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isMultireceive", null, XmlConvert.ToString(element.IsMultireceive));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "selection", null, element.Selection.XmiId);
+            }
+
+            if (element.Source != null && writeContext.IsLocal(element.Source))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "source", null, element.Source.XmiId);
+            }
+
+            if (element.Target != null && writeContext.IsLocal(element.Target))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "target", null, element.Target.XmiId);
+            }
+
+            if (element.Transformation != null && writeContext.IsLocal(element.Transformation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "transformation", null, element.Transformation.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Guard)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "guard", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            if (element.Interrupts != null && !writeContext.IsLocal(element.Interrupts))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Interrupts, "interrupts", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedEdge)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedEdge", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Source != null && !writeContext.IsLocal(element.Source))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Source, "source", writeContext);
+            }
+
+            if (element.Target != null && !writeContext.IsLocal(element.Target))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Target, "target", writeContext);
+            }
+
+            if (element.Transformation != null && !writeContext.IsLocal(element.Transformation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Transformation, "transformation", writeContext);
+            }
+
+            foreach (var value in element.Weight)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "weight", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/OccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OccurrenceSpecificationWriter.cs
@@ -1,0 +1,336 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OccurrenceSpecificationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="OccurrenceSpecificationWriter"/> is to write an instance of <see cref="IOccurrenceSpecification"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class OccurrenceSpecificationWriter : XmiElementWriter<IOccurrenceSpecification>, IXmiElementWriter<IOccurrenceSpecification>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<OccurrenceSpecificationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OccurrenceSpecificationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public OccurrenceSpecificationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<OccurrenceSpecificationWriter>.Instance : loggerFactory.CreateLogger<OccurrenceSpecificationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IOccurrenceSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOccurrenceSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IOccurrenceSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OccurrenceSpecification");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Covered != null && writeContext.IsLocal(element.Covered))
+            {
+                xmlWriter.WriteAttributeString("covered", element.Covered.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Covered != null && !writeContext.IsLocal(element.Covered))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Covered, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.ToAfter)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "toAfter", writeContext);
+            }
+
+            foreach (var value in element.ToBefore)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "toBefore", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IOccurrenceSpecification"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOccurrenceSpecification"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IOccurrenceSpecification element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OccurrenceSpecification");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Covered != null && writeContext.IsLocal(element.Covered))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "covered", null, element.Covered.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Covered != null && !writeContext.IsLocal(element.Covered))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Covered, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.ToAfter)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toAfter", writeContext);
+            }
+
+            foreach (var value in element.ToBefore)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/OpaqueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OpaqueActionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OpaqueActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="OpaqueActionWriter"/> is to write an instance of <see cref="IOpaqueAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class OpaqueActionWriter : XmiElementWriter<IOpaqueAction>, IXmiElementWriter<IOpaqueAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<OpaqueActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpaqueActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public OpaqueActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<OpaqueActionWriter>.Instance : loggerFactory.CreateLogger<OpaqueActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IOpaqueAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOpaqueAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IOpaqueAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OpaqueAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Body)
+            {
+                xmlWriter.WriteElementString("body", value);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "inputValue", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.Language)
+            {
+                xmlWriter.WriteElementString("language", value);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OutputValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "outputValue", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IOpaqueAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOpaqueAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IOpaqueAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OpaqueAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Body)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "body", null, value);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "inputValue", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.Language)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "language", null, value);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OutputValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "outputValue", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/OpaqueBehaviorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OpaqueBehaviorWriter.cs
@@ -1,0 +1,676 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OpaqueBehaviorWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="OpaqueBehaviorWriter"/> is to write an instance of <see cref="IOpaqueBehavior"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class OpaqueBehaviorWriter : XmiElementWriter<IOpaqueBehavior>, IXmiElementWriter<IOpaqueBehavior>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<OpaqueBehaviorWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpaqueBehaviorWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public OpaqueBehaviorWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<OpaqueBehaviorWriter>.Instance : loggerFactory.CreateLogger<OpaqueBehaviorWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IOpaqueBehavior"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOpaqueBehavior"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IOpaqueBehavior element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OpaqueBehavior with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueBehavior");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                xmlWriter.WriteAttributeString("isReentrant", XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                xmlWriter.WriteAttributeString("specification", element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Body)
+            {
+                xmlWriter.WriteElementString("body", value);
+            }
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.Language)
+            {
+                xmlWriter.WriteElementString("language", value);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedBehavior", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IOpaqueBehavior"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOpaqueBehavior"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IOpaqueBehavior element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OpaqueBehavior with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueBehavior");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReentrant", null, XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specification", null, element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Body)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "body", null, value);
+            }
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.Language)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "language", null, value);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedBehavior", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/OpaqueExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OpaqueExpressionWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OpaqueExpressionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="OpaqueExpressionWriter"/> is to write an instance of <see cref="IOpaqueExpression"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class OpaqueExpressionWriter : XmiElementWriter<IOpaqueExpression>, IXmiElementWriter<IOpaqueExpression>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<OpaqueExpressionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpaqueExpressionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public OpaqueExpressionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<OpaqueExpressionWriter>.Instance : loggerFactory.CreateLogger<OpaqueExpressionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IOpaqueExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOpaqueExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IOpaqueExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OpaqueExpression with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueExpression");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Behavior != null && writeContext.IsLocal(element.Behavior))
+            {
+                xmlWriter.WriteAttributeString("behavior", element.Behavior.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Behavior != null && !writeContext.IsLocal(element.Behavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Behavior, "behavior", writeContext);
+            }
+
+            foreach (var value in element.Body)
+            {
+                xmlWriter.WriteElementString("body", value);
+            }
+
+            foreach (var value in element.Language)
+            {
+                xmlWriter.WriteElementString("language", value);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IOpaqueExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOpaqueExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IOpaqueExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OpaqueExpression with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueExpression");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Behavior != null && writeContext.IsLocal(element.Behavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "behavior", null, element.Behavior.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Behavior != null && !writeContext.IsLocal(element.Behavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Behavior, "behavior", writeContext);
+            }
+
+            foreach (var value in element.Body)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "body", null, value);
+            }
+
+            foreach (var value in element.Language)
+            {
+                await xmlWriter.WriteElementStringAsync(null, "language", null, value);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/OperationTemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OperationTemplateParameterWriter.cs
@@ -1,0 +1,296 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OperationTemplateParameterWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="OperationTemplateParameterWriter"/> is to write an instance of <see cref="IOperationTemplateParameter"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class OperationTemplateParameterWriter : XmiElementWriter<IOperationTemplateParameter>, IXmiElementWriter<IOperationTemplateParameter>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<OperationTemplateParameterWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationTemplateParameterWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public OperationTemplateParameterWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<OperationTemplateParameterWriter>.Instance : loggerFactory.CreateLogger<OperationTemplateParameterWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IOperationTemplateParameter"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOperationTemplateParameter"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IOperationTemplateParameter element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OperationTemplateParameter with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OperationTemplateParameter");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Default != null && writeContext.IsLocal(element.Default))
+            {
+                xmlWriter.WriteAttributeString("default", element.Default.XmiId);
+            }
+
+            if (element.ParameteredElement != null && writeContext.IsLocal(element.ParameteredElement))
+            {
+                xmlWriter.WriteAttributeString("parameteredElement", element.ParameteredElement.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                xmlWriter.WriteAttributeString("signature", element.Signature.XmiId);
+            }
+
+
+            if (element.Default != null && !writeContext.IsLocal(element.Default))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Default, "default", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedDefault)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedDefault", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameteredElement)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameteredElement", writeContext);
+            }
+
+            if (element.ParameteredElement != null && !writeContext.IsLocal(element.ParameteredElement))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ParameteredElement, "parameteredElement", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IOperationTemplateParameter"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOperationTemplateParameter"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IOperationTemplateParameter element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OperationTemplateParameter with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OperationTemplateParameter");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Default != null && writeContext.IsLocal(element.Default))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "default", null, element.Default.XmiId);
+            }
+
+            if (element.ParameteredElement != null && writeContext.IsLocal(element.ParameteredElement))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "parameteredElement", null, element.ParameteredElement.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "signature", null, element.Signature.XmiId);
+            }
+
+
+            if (element.Default != null && !writeContext.IsLocal(element.Default))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Default, "default", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedDefault)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedDefault", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameteredElement)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameteredElement", writeContext);
+            }
+
+            if (element.ParameteredElement != null && !writeContext.IsLocal(element.ParameteredElement))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ParameteredElement, "parameteredElement", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/OperationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OperationWriter.cs
@@ -1,0 +1,526 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OperationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="OperationWriter"/> is to write an instance of <see cref="IOperation"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class OperationWriter : XmiElementWriter<IOperation>, IXmiElementWriter<IOperation>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<OperationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public OperationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<OperationWriter>.Instance : loggerFactory.CreateLogger<OperationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IOperation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOperation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IOperation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Operation with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Operation");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Class != null && writeContext.IsLocal(element.Class))
+            {
+                xmlWriter.WriteAttributeString("class", element.Class.XmiId);
+            }
+
+            if (element.Concurrency != CallConcurrencyKind.Sequential)
+            {
+                xmlWriter.WriteAttributeString("concurrency", LowerCaseFirstLetter(element.Concurrency.ToString()));
+            }
+
+            if (element.Datatype != null && writeContext.IsLocal(element.Datatype))
+            {
+                xmlWriter.WriteAttributeString("datatype", element.Datatype.XmiId);
+            }
+
+            if (element.Interface != null && writeContext.IsLocal(element.Interface))
+            {
+                xmlWriter.WriteAttributeString("interface", element.Interface.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsQuery)
+            {
+                xmlWriter.WriteAttributeString("isQuery", XmlConvert.ToString(element.IsQuery));
+            }
+
+            if (element.IsStatic)
+            {
+                xmlWriter.WriteAttributeString("isStatic", XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.BodyCondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "bodyCondition", writeContext);
+            }
+
+            if (element.Class != null && !writeContext.IsLocal(element.Class))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Class, "class", writeContext);
+            }
+
+            if (element.Datatype != null && !writeContext.IsLocal(element.Datatype))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Datatype, "datatype", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            if (element.Interface != null && !writeContext.IsLocal(element.Interface))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Interface, "interface", writeContext);
+            }
+
+            foreach (var value in element.Method)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "method", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RaisedException)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "raisedException", writeContext);
+            }
+
+            foreach (var value in element.RedefinedOperation)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedOperation", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IOperation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOperation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IOperation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Operation with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Operation");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Class != null && writeContext.IsLocal(element.Class))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "class", null, element.Class.XmiId);
+            }
+
+            if (element.Concurrency != CallConcurrencyKind.Sequential)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "concurrency", null, LowerCaseFirstLetter(element.Concurrency.ToString()));
+            }
+
+            if (element.Datatype != null && writeContext.IsLocal(element.Datatype))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "datatype", null, element.Datatype.XmiId);
+            }
+
+            if (element.Interface != null && writeContext.IsLocal(element.Interface))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interface", null, element.Interface.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsQuery)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isQuery", null, XmlConvert.ToString(element.IsQuery));
+            }
+
+            if (element.IsStatic)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isStatic", null, XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.BodyCondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "bodyCondition", writeContext);
+            }
+
+            if (element.Class != null && !writeContext.IsLocal(element.Class))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Class, "class", writeContext);
+            }
+
+            if (element.Datatype != null && !writeContext.IsLocal(element.Datatype))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Datatype, "datatype", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            if (element.Interface != null && !writeContext.IsLocal(element.Interface))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Interface, "interface", writeContext);
+            }
+
+            foreach (var value in element.Method)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "method", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RaisedException)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "raisedException", writeContext);
+            }
+
+            foreach (var value in element.RedefinedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedOperation", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/OutputPinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OutputPinWriter.cs
@@ -1,0 +1,476 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="OutputPinWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="OutputPinWriter"/> is to write an instance of <see cref="IOutputPin"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class OutputPinWriter : XmiElementWriter<IOutputPin>, IXmiElementWriter<IOutputPin>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<OutputPinWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputPinWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public OutputPinWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<OutputPinWriter>.Instance : loggerFactory.CreateLogger<OutputPinWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IOutputPin"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOutputPin"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IOutputPin element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OutputPin with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OutputPin");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControl)
+            {
+                xmlWriter.WriteAttributeString("isControl", XmlConvert.ToString(element.IsControl));
+            }
+
+            if (element.IsControlType)
+            {
+                xmlWriter.WriteAttributeString("isControlType", XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                xmlWriter.WriteAttributeString("ordering", LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                xmlWriter.WriteAttributeString("selection", element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperBound", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IOutputPin"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IOutputPin"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IOutputPin element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the OutputPin with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OutputPin");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControl)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControl", null, XmlConvert.ToString(element.IsControl));
+            }
+
+            if (element.IsControlType)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControlType", null, XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "ordering", null, LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "selection", null, element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/PackageImportWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PackageImportWriter.cs
@@ -1,0 +1,266 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PackageImportWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="PackageImportWriter"/> is to write an instance of <see cref="IPackageImport"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class PackageImportWriter : XmiElementWriter<IPackageImport>, IXmiElementWriter<IPackageImport>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<PackageImportWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PackageImportWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public PackageImportWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<PackageImportWriter>.Instance : loggerFactory.CreateLogger<PackageImportWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IPackageImport"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPackageImport"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IPackageImport element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the PackageImport with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PackageImport");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ImportedPackage != null && writeContext.IsLocal(element.ImportedPackage))
+            {
+                xmlWriter.WriteAttributeString("importedPackage", element.ImportedPackage.XmiId);
+            }
+
+            if (element.ImportingNamespace != null && writeContext.IsLocal(element.ImportingNamespace))
+            {
+                xmlWriter.WriteAttributeString("importingNamespace", element.ImportingNamespace.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ImportedPackage != null && !writeContext.IsLocal(element.ImportedPackage))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ImportedPackage, "importedPackage", writeContext);
+            }
+
+            if (element.ImportingNamespace != null && !writeContext.IsLocal(element.ImportingNamespace))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ImportingNamespace, "importingNamespace", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IPackageImport"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPackageImport"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IPackageImport element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the PackageImport with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PackageImport");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ImportedPackage != null && writeContext.IsLocal(element.ImportedPackage))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "importedPackage", null, element.ImportedPackage.XmiId);
+            }
+
+            if (element.ImportingNamespace != null && writeContext.IsLocal(element.ImportingNamespace))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "importingNamespace", null, element.ImportingNamespace.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ImportedPackage != null && !writeContext.IsLocal(element.ImportedPackage))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ImportedPackage, "importedPackage", writeContext);
+            }
+
+            if (element.ImportingNamespace != null && !writeContext.IsLocal(element.ImportingNamespace))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ImportingNamespace, "importingNamespace", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/PackageMergeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PackageMergeWriter.cs
@@ -1,0 +1,256 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PackageMergeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="PackageMergeWriter"/> is to write an instance of <see cref="IPackageMerge"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class PackageMergeWriter : XmiElementWriter<IPackageMerge>, IXmiElementWriter<IPackageMerge>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<PackageMergeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PackageMergeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public PackageMergeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<PackageMergeWriter>.Instance : loggerFactory.CreateLogger<PackageMergeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IPackageMerge"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPackageMerge"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IPackageMerge element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the PackageMerge with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PackageMerge");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.MergedPackage != null && writeContext.IsLocal(element.MergedPackage))
+            {
+                xmlWriter.WriteAttributeString("mergedPackage", element.MergedPackage.XmiId);
+            }
+
+            if (element.ReceivingPackage != null && writeContext.IsLocal(element.ReceivingPackage))
+            {
+                xmlWriter.WriteAttributeString("receivingPackage", element.ReceivingPackage.XmiId);
+            }
+
+
+            if (element.MergedPackage != null && !writeContext.IsLocal(element.MergedPackage))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.MergedPackage, "mergedPackage", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.ReceivingPackage != null && !writeContext.IsLocal(element.ReceivingPackage))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ReceivingPackage, "receivingPackage", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IPackageMerge"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPackageMerge"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IPackageMerge element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the PackageMerge with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PackageMerge");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.MergedPackage != null && writeContext.IsLocal(element.MergedPackage))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "mergedPackage", null, element.MergedPackage.XmiId);
+            }
+
+            if (element.ReceivingPackage != null && writeContext.IsLocal(element.ReceivingPackage))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "receivingPackage", null, element.ReceivingPackage.XmiId);
+            }
+
+
+            if (element.MergedPackage != null && !writeContext.IsLocal(element.MergedPackage))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.MergedPackage, "mergedPackage", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.ReceivingPackage != null && !writeContext.IsLocal(element.ReceivingPackage))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReceivingPackage, "receivingPackage", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/PackageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PackageWriter.cs
@@ -1,0 +1,396 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PackageWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="PackageWriter"/> is to write an instance of <see cref="IPackage"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class PackageWriter : XmiElementWriter<IPackage>, IXmiElementWriter<IPackage>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<PackageWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PackageWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public PackageWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<PackageWriter>.Instance : loggerFactory.CreateLogger<PackageWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IPackage"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IPackage element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Package with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Package");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.NestingPackage != null && writeContext.IsLocal(element.NestingPackage))
+            {
+                xmlWriter.WriteAttributeString("nestingPackage", element.NestingPackage.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.URI))
+            {
+                xmlWriter.WriteAttributeString("URI", element.URI);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.NestingPackage != null && !writeContext.IsLocal(element.NestingPackage))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.NestingPackage, "nestingPackage", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.PackagedElement)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packagedElement", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PackageMerge)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageMerge", writeContext);
+            }
+
+            foreach (var value in element.ProfileApplication)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "profileApplication", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IPackage"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IPackage element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Package with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Package");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.NestingPackage != null && writeContext.IsLocal(element.NestingPackage))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "nestingPackage", null, element.NestingPackage.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.URI))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "URI", null, element.URI);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.NestingPackage != null && !writeContext.IsLocal(element.NestingPackage))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.NestingPackage, "nestingPackage", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.PackagedElement)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packagedElement", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PackageMerge)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageMerge", writeContext);
+            }
+
+            foreach (var value in element.ProfileApplication)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "profileApplication", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ParameterSetWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ParameterSetWriter.cs
@@ -1,0 +1,266 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ParameterSetWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ParameterSetWriter"/> is to write an instance of <see cref="IParameterSet"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ParameterSetWriter : XmiElementWriter<IParameterSet>, IXmiElementWriter<IParameterSet>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ParameterSetWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterSetWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ParameterSetWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ParameterSetWriter>.Instance : loggerFactory.CreateLogger<ParameterSetWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IParameterSet"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IParameterSet"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IParameterSet element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ParameterSet with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ParameterSet");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Condition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "condition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.Parameter)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "parameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IParameterSet"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IParameterSet"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IParameterSet element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ParameterSet with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ParameterSet");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Condition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "condition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.Parameter)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "parameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ParameterWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ParameterWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ParameterWriter"/> is to write an instance of <see cref="IParameter"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ParameterWriter : XmiElementWriter<IParameter>, IXmiElementWriter<IParameter>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ParameterWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ParameterWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ParameterWriter>.Instance : loggerFactory.CreateLogger<ParameterWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IParameter"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IParameter"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IParameter element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Parameter with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Parameter");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Direction != ParameterDirectionKind.In)
+            {
+                xmlWriter.WriteAttributeString("direction", LowerCaseFirstLetter(element.Direction.ToString()));
+            }
+
+            if (element.Effect != default(ParameterEffectKind))
+            {
+                xmlWriter.WriteAttributeString("effect", LowerCaseFirstLetter(element.Effect.ToString()));
+            }
+
+            if (element.IsException)
+            {
+                xmlWriter.WriteAttributeString("isException", XmlConvert.ToString(element.IsException));
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (element.IsStream)
+            {
+                xmlWriter.WriteAttributeString("isStream", XmlConvert.ToString(element.IsStream));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Operation != null && writeContext.IsLocal(element.Operation))
+            {
+                xmlWriter.WriteAttributeString("operation", element.Operation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.DefaultValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "defaultValue", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.Operation != null && !writeContext.IsLocal(element.Operation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Operation, "operation", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.ParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "parameterSet", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IParameter"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IParameter"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IParameter element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Parameter with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Parameter");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Direction != ParameterDirectionKind.In)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "direction", null, LowerCaseFirstLetter(element.Direction.ToString()));
+            }
+
+            if (element.Effect != default(ParameterEffectKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "effect", null, LowerCaseFirstLetter(element.Effect.ToString()));
+            }
+
+            if (element.IsException)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isException", null, XmlConvert.ToString(element.IsException));
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (element.IsStream)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isStream", null, XmlConvert.ToString(element.IsStream));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Operation != null && writeContext.IsLocal(element.Operation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "operation", null, element.Operation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.DefaultValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "defaultValue", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.Operation != null && !writeContext.IsLocal(element.Operation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Operation, "operation", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.ParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "parameterSet", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/PartDecompositionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PartDecompositionWriter.cs
@@ -1,0 +1,376 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PartDecompositionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="PartDecompositionWriter"/> is to write an instance of <see cref="IPartDecomposition"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class PartDecompositionWriter : XmiElementWriter<IPartDecomposition>, IXmiElementWriter<IPartDecomposition>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<PartDecompositionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartDecompositionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public PartDecompositionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<PartDecompositionWriter>.Instance : loggerFactory.CreateLogger<PartDecompositionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IPartDecomposition"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPartDecomposition"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IPartDecomposition element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the PartDecomposition with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PartDecomposition");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.RefersTo != null && writeContext.IsLocal(element.RefersTo))
+            {
+                xmlWriter.WriteAttributeString("refersTo", element.RefersTo.XmiId);
+            }
+
+            if (element.ReturnValueRecipient != null && writeContext.IsLocal(element.ReturnValueRecipient))
+            {
+                xmlWriter.WriteAttributeString("returnValueRecipient", element.ReturnValueRecipient.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ActualGate)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "actualGate", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.RefersTo != null && !writeContext.IsLocal(element.RefersTo))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.RefersTo, "refersTo", writeContext);
+            }
+
+            foreach (var value in element.ReturnValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "returnValue", writeContext);
+            }
+
+            if (element.ReturnValueRecipient != null && !writeContext.IsLocal(element.ReturnValueRecipient))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ReturnValueRecipient, "returnValueRecipient", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IPartDecomposition"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPartDecomposition"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IPartDecomposition element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the PartDecomposition with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PartDecomposition");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.RefersTo != null && writeContext.IsLocal(element.RefersTo))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "refersTo", null, element.RefersTo.XmiId);
+            }
+
+            if (element.ReturnValueRecipient != null && writeContext.IsLocal(element.ReturnValueRecipient))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "returnValueRecipient", null, element.ReturnValueRecipient.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ActualGate)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "actualGate", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Covered)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.RefersTo != null && !writeContext.IsLocal(element.RefersTo))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.RefersTo, "refersTo", writeContext);
+            }
+
+            foreach (var value in element.ReturnValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "returnValue", writeContext);
+            }
+
+            if (element.ReturnValueRecipient != null && !writeContext.IsLocal(element.ReturnValueRecipient))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReturnValueRecipient, "returnValueRecipient", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/PortWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PortWriter.cs
@@ -1,0 +1,646 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PortWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="PortWriter"/> is to write an instance of <see cref="IPort"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class PortWriter : XmiElementWriter<IPort>, IXmiElementWriter<IPort>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<PortWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PortWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public PortWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<PortWriter>.Instance : loggerFactory.CreateLogger<PortWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IPort"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPort"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IPort element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Port with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Port");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Aggregation != AggregationKind.None)
+            {
+                xmlWriter.WriteAttributeString("aggregation", LowerCaseFirstLetter(element.Aggregation.ToString()));
+            }
+
+            if (element.Association != null && writeContext.IsLocal(element.Association))
+            {
+                xmlWriter.WriteAttributeString("association", element.Association.XmiId);
+            }
+
+            if (element.AssociationEnd != null && writeContext.IsLocal(element.AssociationEnd))
+            {
+                xmlWriter.WriteAttributeString("associationEnd", element.AssociationEnd.XmiId);
+            }
+
+            if (element.Class != null && writeContext.IsLocal(element.Class))
+            {
+                xmlWriter.WriteAttributeString("class", element.Class.XmiId);
+            }
+
+            if (element.Datatype != null && writeContext.IsLocal(element.Datatype))
+            {
+                xmlWriter.WriteAttributeString("datatype", element.Datatype.XmiId);
+            }
+
+            if (element.Interface != null && writeContext.IsLocal(element.Interface))
+            {
+                xmlWriter.WriteAttributeString("interface", element.Interface.XmiId);
+            }
+
+            if (element.IsBehavior)
+            {
+                xmlWriter.WriteAttributeString("isBehavior", XmlConvert.ToString(element.IsBehavior));
+            }
+
+            if (element.IsConjugated)
+            {
+                xmlWriter.WriteAttributeString("isConjugated", XmlConvert.ToString(element.IsConjugated));
+            }
+
+            if (element.IsDerived)
+            {
+                xmlWriter.WriteAttributeString("isDerived", XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsDerivedUnion)
+            {
+                xmlWriter.WriteAttributeString("isDerivedUnion", XmlConvert.ToString(element.IsDerivedUnion));
+            }
+
+            if (element.IsID)
+            {
+                xmlWriter.WriteAttributeString("isID", XmlConvert.ToString(element.IsID));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (element.IsReadOnly)
+            {
+                xmlWriter.WriteAttributeString("isReadOnly", XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (!element.IsService)
+            {
+                xmlWriter.WriteAttributeString("isService", XmlConvert.ToString(element.IsService));
+            }
+
+            if (element.IsStatic)
+            {
+                xmlWriter.WriteAttributeString("isStatic", XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningAssociation != null && writeContext.IsLocal(element.OwningAssociation))
+            {
+                xmlWriter.WriteAttributeString("owningAssociation", element.OwningAssociation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Protocol != null && writeContext.IsLocal(element.Protocol))
+            {
+                xmlWriter.WriteAttributeString("protocol", element.Protocol.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Association != null && !writeContext.IsLocal(element.Association))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Association, "association", writeContext);
+            }
+
+            if (element.AssociationEnd != null && !writeContext.IsLocal(element.AssociationEnd))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.AssociationEnd, "associationEnd", writeContext);
+            }
+
+            if (element.Class != null && !writeContext.IsLocal(element.Class))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Class, "class", writeContext);
+            }
+
+            if (element.Datatype != null && !writeContext.IsLocal(element.Datatype))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Datatype, "datatype", writeContext);
+            }
+
+            foreach (var value in element.DefaultValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "defaultValue", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deployment", writeContext);
+            }
+
+            if (element.Interface != null && !writeContext.IsLocal(element.Interface))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Interface, "interface", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningAssociation != null && !writeContext.IsLocal(element.OwningAssociation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningAssociation, "owningAssociation", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Protocol != null && !writeContext.IsLocal(element.Protocol))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Protocol, "protocol", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedPort)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedPort", writeContext);
+            }
+
+            foreach (var value in element.RedefinedProperty)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedProperty", writeContext);
+            }
+
+            foreach (var value in element.SubsettedProperty)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "subsettedProperty", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IPort"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPort"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IPort element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Port with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Port");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Aggregation != AggregationKind.None)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "aggregation", null, LowerCaseFirstLetter(element.Aggregation.ToString()));
+            }
+
+            if (element.Association != null && writeContext.IsLocal(element.Association))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "association", null, element.Association.XmiId);
+            }
+
+            if (element.AssociationEnd != null && writeContext.IsLocal(element.AssociationEnd))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "associationEnd", null, element.AssociationEnd.XmiId);
+            }
+
+            if (element.Class != null && writeContext.IsLocal(element.Class))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "class", null, element.Class.XmiId);
+            }
+
+            if (element.Datatype != null && writeContext.IsLocal(element.Datatype))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "datatype", null, element.Datatype.XmiId);
+            }
+
+            if (element.Interface != null && writeContext.IsLocal(element.Interface))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interface", null, element.Interface.XmiId);
+            }
+
+            if (element.IsBehavior)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isBehavior", null, XmlConvert.ToString(element.IsBehavior));
+            }
+
+            if (element.IsConjugated)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isConjugated", null, XmlConvert.ToString(element.IsConjugated));
+            }
+
+            if (element.IsDerived)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerived", null, XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsDerivedUnion)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerivedUnion", null, XmlConvert.ToString(element.IsDerivedUnion));
+            }
+
+            if (element.IsID)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isID", null, XmlConvert.ToString(element.IsID));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (element.IsReadOnly)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReadOnly", null, XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (!element.IsService)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isService", null, XmlConvert.ToString(element.IsService));
+            }
+
+            if (element.IsStatic)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isStatic", null, XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningAssociation != null && writeContext.IsLocal(element.OwningAssociation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningAssociation", null, element.OwningAssociation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Protocol != null && writeContext.IsLocal(element.Protocol))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "protocol", null, element.Protocol.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Association != null && !writeContext.IsLocal(element.Association))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Association, "association", writeContext);
+            }
+
+            if (element.AssociationEnd != null && !writeContext.IsLocal(element.AssociationEnd))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.AssociationEnd, "associationEnd", writeContext);
+            }
+
+            if (element.Class != null && !writeContext.IsLocal(element.Class))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Class, "class", writeContext);
+            }
+
+            if (element.Datatype != null && !writeContext.IsLocal(element.Datatype))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Datatype, "datatype", writeContext);
+            }
+
+            foreach (var value in element.DefaultValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "defaultValue", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deployment", writeContext);
+            }
+
+            if (element.Interface != null && !writeContext.IsLocal(element.Interface))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Interface, "interface", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningAssociation != null && !writeContext.IsLocal(element.OwningAssociation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningAssociation, "owningAssociation", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Protocol != null && !writeContext.IsLocal(element.Protocol))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Protocol, "protocol", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedPort)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedPort", writeContext);
+            }
+
+            foreach (var value in element.RedefinedProperty)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedProperty", writeContext);
+            }
+
+            foreach (var value in element.SubsettedProperty)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "subsettedProperty", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/PrimitiveTypeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PrimitiveTypeWriter.cs
@@ -1,0 +1,496 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PrimitiveTypeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="PrimitiveTypeWriter"/> is to write an instance of <see cref="IPrimitiveType"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class PrimitiveTypeWriter : XmiElementWriter<IPrimitiveType>, IXmiElementWriter<IPrimitiveType>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<PrimitiveTypeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PrimitiveTypeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public PrimitiveTypeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<PrimitiveTypeWriter>.Instance : loggerFactory.CreateLogger<PrimitiveTypeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IPrimitiveType"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPrimitiveType"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IPrimitiveType element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the PrimitiveType with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PrimitiveType");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IPrimitiveType"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPrimitiveType"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IPrimitiveType element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the PrimitiveType with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PrimitiveType");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ProfileApplicationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProfileApplicationWriter.cs
@@ -1,0 +1,266 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ProfileApplicationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ProfileApplicationWriter"/> is to write an instance of <see cref="IProfileApplication"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ProfileApplicationWriter : XmiElementWriter<IProfileApplication>, IXmiElementWriter<IProfileApplication>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ProfileApplicationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProfileApplicationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ProfileApplicationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ProfileApplicationWriter>.Instance : loggerFactory.CreateLogger<ProfileApplicationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IProfileApplication"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProfileApplication"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IProfileApplication element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ProfileApplication with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProfileApplication");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.AppliedProfile != null && writeContext.IsLocal(element.AppliedProfile))
+            {
+                xmlWriter.WriteAttributeString("appliedProfile", element.AppliedProfile.XmiId);
+            }
+
+            if (element.ApplyingPackage != null && writeContext.IsLocal(element.ApplyingPackage))
+            {
+                xmlWriter.WriteAttributeString("applyingPackage", element.ApplyingPackage.XmiId);
+            }
+
+            if (element.IsStrict)
+            {
+                xmlWriter.WriteAttributeString("isStrict", XmlConvert.ToString(element.IsStrict));
+            }
+
+
+            if (element.AppliedProfile != null && !writeContext.IsLocal(element.AppliedProfile))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.AppliedProfile, "appliedProfile", writeContext);
+            }
+
+            if (element.ApplyingPackage != null && !writeContext.IsLocal(element.ApplyingPackage))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ApplyingPackage, "applyingPackage", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IProfileApplication"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProfileApplication"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IProfileApplication element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ProfileApplication with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProfileApplication");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.AppliedProfile != null && writeContext.IsLocal(element.AppliedProfile))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "appliedProfile", null, element.AppliedProfile.XmiId);
+            }
+
+            if (element.ApplyingPackage != null && writeContext.IsLocal(element.ApplyingPackage))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "applyingPackage", null, element.ApplyingPackage.XmiId);
+            }
+
+            if (element.IsStrict)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isStrict", null, XmlConvert.ToString(element.IsStrict));
+            }
+
+
+            if (element.AppliedProfile != null && !writeContext.IsLocal(element.AppliedProfile))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.AppliedProfile, "appliedProfile", writeContext);
+            }
+
+            if (element.ApplyingPackage != null && !writeContext.IsLocal(element.ApplyingPackage))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ApplyingPackage, "applyingPackage", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ProfileWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProfileWriter.cs
@@ -1,0 +1,416 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ProfileWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ProfileWriter"/> is to write an instance of <see cref="IProfile"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ProfileWriter : XmiElementWriter<IProfile>, IXmiElementWriter<IProfile>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ProfileWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProfileWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ProfileWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ProfileWriter>.Instance : loggerFactory.CreateLogger<ProfileWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IProfile"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProfile"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IProfile element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Profile with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Profile");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.NestingPackage != null && writeContext.IsLocal(element.NestingPackage))
+            {
+                xmlWriter.WriteAttributeString("nestingPackage", element.NestingPackage.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.URI))
+            {
+                xmlWriter.WriteAttributeString("URI", element.URI);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.MetaclassReference)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "metaclassReference", writeContext);
+            }
+
+            foreach (var value in element.MetamodelReference)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "metamodelReference", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.NestingPackage != null && !writeContext.IsLocal(element.NestingPackage))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.NestingPackage, "nestingPackage", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.PackagedElement)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packagedElement", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PackageMerge)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageMerge", writeContext);
+            }
+
+            foreach (var value in element.ProfileApplication)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "profileApplication", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IProfile"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProfile"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IProfile element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Profile with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Profile");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.NestingPackage != null && writeContext.IsLocal(element.NestingPackage))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "nestingPackage", null, element.NestingPackage.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.URI))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "URI", null, element.URI);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.MetaclassReference)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "metaclassReference", writeContext);
+            }
+
+            foreach (var value in element.MetamodelReference)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "metamodelReference", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.NestingPackage != null && !writeContext.IsLocal(element.NestingPackage))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.NestingPackage, "nestingPackage", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.PackagedElement)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packagedElement", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PackageMerge)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageMerge", writeContext);
+            }
+
+            foreach (var value in element.ProfileApplication)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "profileApplication", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/PropertyWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PropertyWriter.cs
@@ -1,0 +1,586 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PropertyWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="PropertyWriter"/> is to write an instance of <see cref="IProperty"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class PropertyWriter : XmiElementWriter<IProperty>, IXmiElementWriter<IProperty>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<PropertyWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public PropertyWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<PropertyWriter>.Instance : loggerFactory.CreateLogger<PropertyWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IProperty"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProperty"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IProperty element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Property with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Property");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Aggregation != AggregationKind.None)
+            {
+                xmlWriter.WriteAttributeString("aggregation", LowerCaseFirstLetter(element.Aggregation.ToString()));
+            }
+
+            if (element.Association != null && writeContext.IsLocal(element.Association))
+            {
+                xmlWriter.WriteAttributeString("association", element.Association.XmiId);
+            }
+
+            if (element.AssociationEnd != null && writeContext.IsLocal(element.AssociationEnd))
+            {
+                xmlWriter.WriteAttributeString("associationEnd", element.AssociationEnd.XmiId);
+            }
+
+            if (element.Class != null && writeContext.IsLocal(element.Class))
+            {
+                xmlWriter.WriteAttributeString("class", element.Class.XmiId);
+            }
+
+            if (element.Datatype != null && writeContext.IsLocal(element.Datatype))
+            {
+                xmlWriter.WriteAttributeString("datatype", element.Datatype.XmiId);
+            }
+
+            if (element.Interface != null && writeContext.IsLocal(element.Interface))
+            {
+                xmlWriter.WriteAttributeString("interface", element.Interface.XmiId);
+            }
+
+            if (element.IsDerived)
+            {
+                xmlWriter.WriteAttributeString("isDerived", XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsDerivedUnion)
+            {
+                xmlWriter.WriteAttributeString("isDerivedUnion", XmlConvert.ToString(element.IsDerivedUnion));
+            }
+
+            if (element.IsID)
+            {
+                xmlWriter.WriteAttributeString("isID", XmlConvert.ToString(element.IsID));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (element.IsReadOnly)
+            {
+                xmlWriter.WriteAttributeString("isReadOnly", XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (element.IsStatic)
+            {
+                xmlWriter.WriteAttributeString("isStatic", XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningAssociation != null && writeContext.IsLocal(element.OwningAssociation))
+            {
+                xmlWriter.WriteAttributeString("owningAssociation", element.OwningAssociation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Association != null && !writeContext.IsLocal(element.Association))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Association, "association", writeContext);
+            }
+
+            if (element.AssociationEnd != null && !writeContext.IsLocal(element.AssociationEnd))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.AssociationEnd, "associationEnd", writeContext);
+            }
+
+            if (element.Class != null && !writeContext.IsLocal(element.Class))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Class, "class", writeContext);
+            }
+
+            if (element.Datatype != null && !writeContext.IsLocal(element.Datatype))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Datatype, "datatype", writeContext);
+            }
+
+            foreach (var value in element.DefaultValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "defaultValue", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deployment", writeContext);
+            }
+
+            if (element.Interface != null && !writeContext.IsLocal(element.Interface))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Interface, "interface", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningAssociation != null && !writeContext.IsLocal(element.OwningAssociation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningAssociation, "owningAssociation", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedProperty)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedProperty", writeContext);
+            }
+
+            foreach (var value in element.SubsettedProperty)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "subsettedProperty", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IProperty"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProperty"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IProperty element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Property with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Property");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Aggregation != AggregationKind.None)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "aggregation", null, LowerCaseFirstLetter(element.Aggregation.ToString()));
+            }
+
+            if (element.Association != null && writeContext.IsLocal(element.Association))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "association", null, element.Association.XmiId);
+            }
+
+            if (element.AssociationEnd != null && writeContext.IsLocal(element.AssociationEnd))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "associationEnd", null, element.AssociationEnd.XmiId);
+            }
+
+            if (element.Class != null && writeContext.IsLocal(element.Class))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "class", null, element.Class.XmiId);
+            }
+
+            if (element.Datatype != null && writeContext.IsLocal(element.Datatype))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "datatype", null, element.Datatype.XmiId);
+            }
+
+            if (element.Interface != null && writeContext.IsLocal(element.Interface))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "interface", null, element.Interface.XmiId);
+            }
+
+            if (element.IsDerived)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerived", null, XmlConvert.ToString(element.IsDerived));
+            }
+
+            if (element.IsDerivedUnion)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDerivedUnion", null, XmlConvert.ToString(element.IsDerivedUnion));
+            }
+
+            if (element.IsID)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isID", null, XmlConvert.ToString(element.IsID));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (element.IsReadOnly)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReadOnly", null, XmlConvert.ToString(element.IsReadOnly));
+            }
+
+            if (element.IsStatic)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isStatic", null, XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningAssociation != null && writeContext.IsLocal(element.OwningAssociation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningAssociation", null, element.OwningAssociation.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Association != null && !writeContext.IsLocal(element.Association))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Association, "association", writeContext);
+            }
+
+            if (element.AssociationEnd != null && !writeContext.IsLocal(element.AssociationEnd))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.AssociationEnd, "associationEnd", writeContext);
+            }
+
+            if (element.Class != null && !writeContext.IsLocal(element.Class))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Class, "class", writeContext);
+            }
+
+            if (element.Datatype != null && !writeContext.IsLocal(element.Datatype))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Datatype, "datatype", writeContext);
+            }
+
+            foreach (var value in element.DefaultValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "defaultValue", writeContext);
+            }
+
+            foreach (var value in element.Deployment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deployment", writeContext);
+            }
+
+            if (element.Interface != null && !writeContext.IsLocal(element.Interface))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Interface, "interface", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningAssociation != null && !writeContext.IsLocal(element.OwningAssociation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningAssociation, "owningAssociation", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Qualifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "qualifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedProperty)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedProperty", writeContext);
+            }
+
+            foreach (var value in element.SubsettedProperty)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "subsettedProperty", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ProtocolConformanceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProtocolConformanceWriter.cs
@@ -1,0 +1,256 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ProtocolConformanceWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ProtocolConformanceWriter"/> is to write an instance of <see cref="IProtocolConformance"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ProtocolConformanceWriter : XmiElementWriter<IProtocolConformance>, IXmiElementWriter<IProtocolConformance>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ProtocolConformanceWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProtocolConformanceWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ProtocolConformanceWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ProtocolConformanceWriter>.Instance : loggerFactory.CreateLogger<ProtocolConformanceWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IProtocolConformance"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProtocolConformance"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IProtocolConformance element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ProtocolConformance with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolConformance");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.GeneralMachine != null && writeContext.IsLocal(element.GeneralMachine))
+            {
+                xmlWriter.WriteAttributeString("generalMachine", element.GeneralMachine.XmiId);
+            }
+
+            if (element.SpecificMachine != null && writeContext.IsLocal(element.SpecificMachine))
+            {
+                xmlWriter.WriteAttributeString("specificMachine", element.SpecificMachine.XmiId);
+            }
+
+
+            if (element.GeneralMachine != null && !writeContext.IsLocal(element.GeneralMachine))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.GeneralMachine, "generalMachine", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.SpecificMachine != null && !writeContext.IsLocal(element.SpecificMachine))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.SpecificMachine, "specificMachine", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IProtocolConformance"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProtocolConformance"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IProtocolConformance element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ProtocolConformance with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolConformance");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.GeneralMachine != null && writeContext.IsLocal(element.GeneralMachine))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "generalMachine", null, element.GeneralMachine.XmiId);
+            }
+
+            if (element.SpecificMachine != null && writeContext.IsLocal(element.SpecificMachine))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specificMachine", null, element.SpecificMachine.XmiId);
+            }
+
+
+            if (element.GeneralMachine != null && !writeContext.IsLocal(element.GeneralMachine))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.GeneralMachine, "generalMachine", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.SpecificMachine != null && !writeContext.IsLocal(element.SpecificMachine))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.SpecificMachine, "specificMachine", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ProtocolStateMachineWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProtocolStateMachineWriter.cs
@@ -1,0 +1,696 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ProtocolStateMachineWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ProtocolStateMachineWriter"/> is to write an instance of <see cref="IProtocolStateMachine"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ProtocolStateMachineWriter : XmiElementWriter<IProtocolStateMachine>, IXmiElementWriter<IProtocolStateMachine>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ProtocolStateMachineWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProtocolStateMachineWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ProtocolStateMachineWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ProtocolStateMachineWriter>.Instance : loggerFactory.CreateLogger<ProtocolStateMachineWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IProtocolStateMachine"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProtocolStateMachine"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IProtocolStateMachine element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ProtocolStateMachine with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolStateMachine");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                xmlWriter.WriteAttributeString("isReentrant", XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                xmlWriter.WriteAttributeString("specification", element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Conformance)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "conformance", writeContext);
+            }
+
+            foreach (var value in element.ConnectionPoint)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "connectionPoint", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.ExtendedStateMachine)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "extendedStateMachine", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            foreach (var value in element.Region)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "region", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.SubmachineState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "submachineState", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IProtocolStateMachine"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProtocolStateMachine"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IProtocolStateMachine element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ProtocolStateMachine with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolStateMachine");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReentrant", null, XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specification", null, element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.Conformance)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "conformance", writeContext);
+            }
+
+            foreach (var value in element.ConnectionPoint)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "connectionPoint", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.ExtendedStateMachine)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "extendedStateMachine", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            foreach (var value in element.Region)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "region", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.SubmachineState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "submachineState", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ProtocolTransitionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProtocolTransitionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ProtocolTransitionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ProtocolTransitionWriter"/> is to write an instance of <see cref="IProtocolTransition"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ProtocolTransitionWriter : XmiElementWriter<IProtocolTransition>, IXmiElementWriter<IProtocolTransition>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ProtocolTransitionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProtocolTransitionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ProtocolTransitionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ProtocolTransitionWriter>.Instance : loggerFactory.CreateLogger<ProtocolTransitionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IProtocolTransition"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProtocolTransition"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IProtocolTransition element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ProtocolTransition with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolTransition");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                xmlWriter.WriteAttributeString("container", element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.Kind != TransitionKind.External)
+            {
+                xmlWriter.WriteAttributeString("kind", LowerCaseFirstLetter(element.Kind.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.RedefinedTransition != null && writeContext.IsLocal(element.RedefinedTransition))
+            {
+                xmlWriter.WriteAttributeString("redefinedTransition", element.RedefinedTransition.XmiId);
+            }
+
+            if (element.Source != null && writeContext.IsLocal(element.Source))
+            {
+                xmlWriter.WriteAttributeString("source", element.Source.XmiId);
+            }
+
+            if (element.Target != null && writeContext.IsLocal(element.Target))
+            {
+                xmlWriter.WriteAttributeString("target", element.Target.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.Effect)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "effect", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Guard)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "guard", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PostCondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "postCondition", writeContext);
+            }
+
+            foreach (var value in element.PreCondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "preCondition", writeContext);
+            }
+
+            if (element.RedefinedTransition != null && !writeContext.IsLocal(element.RedefinedTransition))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.RedefinedTransition, "redefinedTransition", writeContext);
+            }
+
+            if (element.Source != null && !writeContext.IsLocal(element.Source))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Source, "source", writeContext);
+            }
+
+            if (element.Target != null && !writeContext.IsLocal(element.Target))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Target, "target", writeContext);
+            }
+
+            foreach (var value in element.Trigger)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "trigger", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IProtocolTransition"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IProtocolTransition"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IProtocolTransition element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ProtocolTransition with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolTransition");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "container", null, element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.Kind != TransitionKind.External)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "kind", null, LowerCaseFirstLetter(element.Kind.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.RedefinedTransition != null && writeContext.IsLocal(element.RedefinedTransition))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "redefinedTransition", null, element.RedefinedTransition.XmiId);
+            }
+
+            if (element.Source != null && writeContext.IsLocal(element.Source))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "source", null, element.Source.XmiId);
+            }
+
+            if (element.Target != null && writeContext.IsLocal(element.Target))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "target", null, element.Target.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.Effect)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "effect", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Guard)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "guard", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PostCondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "postCondition", writeContext);
+            }
+
+            foreach (var value in element.PreCondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "preCondition", writeContext);
+            }
+
+            if (element.RedefinedTransition != null && !writeContext.IsLocal(element.RedefinedTransition))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.RedefinedTransition, "redefinedTransition", writeContext);
+            }
+
+            if (element.Source != null && !writeContext.IsLocal(element.Source))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Source, "source", writeContext);
+            }
+
+            if (element.Target != null && !writeContext.IsLocal(element.Target))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Target, "target", writeContext);
+            }
+
+            foreach (var value in element.Trigger)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/PseudostateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PseudostateWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="PseudostateWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="PseudostateWriter"/> is to write an instance of <see cref="IPseudostate"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class PseudostateWriter : XmiElementWriter<IPseudostate>, IXmiElementWriter<IPseudostate>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<PseudostateWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PseudostateWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public PseudostateWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<PseudostateWriter>.Instance : loggerFactory.CreateLogger<PseudostateWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IPseudostate"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPseudostate"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IPseudostate element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Pseudostate with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Pseudostate");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                xmlWriter.WriteAttributeString("container", element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.Kind != PseudostateKind.Initial)
+            {
+                xmlWriter.WriteAttributeString("kind", LowerCaseFirstLetter(element.Kind.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.RedefinedVertex != null && writeContext.IsLocal(element.RedefinedVertex))
+            {
+                xmlWriter.WriteAttributeString("redefinedVertex", element.RedefinedVertex.XmiId);
+            }
+
+            if (element.State != null && writeContext.IsLocal(element.State))
+            {
+                xmlWriter.WriteAttributeString("state", element.State.XmiId);
+            }
+
+            if (element.StateMachine != null && writeContext.IsLocal(element.StateMachine))
+            {
+                xmlWriter.WriteAttributeString("stateMachine", element.StateMachine.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.RedefinedVertex != null && !writeContext.IsLocal(element.RedefinedVertex))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.RedefinedVertex, "redefinedVertex", writeContext);
+            }
+
+            if (element.State != null && !writeContext.IsLocal(element.State))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.State, "state", writeContext);
+            }
+
+            if (element.StateMachine != null && !writeContext.IsLocal(element.StateMachine))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.StateMachine, "stateMachine", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IPseudostate"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IPseudostate"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IPseudostate element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Pseudostate with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Pseudostate");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "container", null, element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.Kind != PseudostateKind.Initial)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "kind", null, LowerCaseFirstLetter(element.Kind.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.RedefinedVertex != null && writeContext.IsLocal(element.RedefinedVertex))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "redefinedVertex", null, element.RedefinedVertex.XmiId);
+            }
+
+            if (element.State != null && writeContext.IsLocal(element.State))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "state", null, element.State.XmiId);
+            }
+
+            if (element.StateMachine != null && writeContext.IsLocal(element.StateMachine))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "stateMachine", null, element.StateMachine.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.RedefinedVertex != null && !writeContext.IsLocal(element.RedefinedVertex))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.RedefinedVertex, "redefinedVertex", writeContext);
+            }
+
+            if (element.State != null && !writeContext.IsLocal(element.State))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.State, "state", writeContext);
+            }
+
+            if (element.StateMachine != null && !writeContext.IsLocal(element.StateMachine))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StateMachine, "stateMachine", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/QualifierValueWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/QualifierValueWriter.cs
@@ -1,0 +1,256 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="QualifierValueWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="QualifierValueWriter"/> is to write an instance of <see cref="IQualifierValue"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class QualifierValueWriter : XmiElementWriter<IQualifierValue>, IXmiElementWriter<IQualifierValue>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<QualifierValueWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QualifierValueWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public QualifierValueWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<QualifierValueWriter>.Instance : loggerFactory.CreateLogger<QualifierValueWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IQualifierValue"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IQualifierValue"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IQualifierValue element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the QualifierValue with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:QualifierValue");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Qualifier != null && writeContext.IsLocal(element.Qualifier))
+            {
+                xmlWriter.WriteAttributeString("qualifier", element.Qualifier.XmiId);
+            }
+
+            if (element.Value != null && writeContext.IsLocal(element.Value))
+            {
+                xmlWriter.WriteAttributeString("value", element.Value.XmiId);
+            }
+
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Qualifier != null && !writeContext.IsLocal(element.Qualifier))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Qualifier, "qualifier", writeContext);
+            }
+
+            if (element.Value != null && !writeContext.IsLocal(element.Value))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Value, "value", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IQualifierValue"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IQualifierValue"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IQualifierValue element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the QualifierValue with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:QualifierValue");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Qualifier != null && writeContext.IsLocal(element.Qualifier))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "qualifier", null, element.Qualifier.XmiId);
+            }
+
+            if (element.Value != null && writeContext.IsLocal(element.Value))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "value", null, element.Value.XmiId);
+            }
+
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Qualifier != null && !writeContext.IsLocal(element.Qualifier))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Qualifier, "qualifier", writeContext);
+            }
+
+            if (element.Value != null && !writeContext.IsLocal(element.Value))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/RaiseExceptionActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RaiseExceptionActionWriter.cs
@@ -1,0 +1,396 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RaiseExceptionActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="RaiseExceptionActionWriter"/> is to write an instance of <see cref="IRaiseExceptionAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class RaiseExceptionActionWriter : XmiElementWriter<IRaiseExceptionAction>, IXmiElementWriter<IRaiseExceptionAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<RaiseExceptionActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RaiseExceptionActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public RaiseExceptionActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<RaiseExceptionActionWriter>.Instance : loggerFactory.CreateLogger<RaiseExceptionActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IRaiseExceptionAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRaiseExceptionAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IRaiseExceptionAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the RaiseExceptionAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RaiseExceptionAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Exception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "exception", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IRaiseExceptionAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRaiseExceptionAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IRaiseExceptionAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the RaiseExceptionAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RaiseExceptionAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Exception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "exception", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReadExtentActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadExtentActionWriter.cs
@@ -1,0 +1,416 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReadExtentActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReadExtentActionWriter"/> is to write an instance of <see cref="IReadExtentAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReadExtentActionWriter : XmiElementWriter<IReadExtentAction>, IXmiElementWriter<IReadExtentAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReadExtentActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadExtentActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReadExtentActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReadExtentActionWriter>.Instance : loggerFactory.CreateLogger<ReadExtentActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReadExtentAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadExtentAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReadExtentAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadExtentAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadExtentAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.Classifier != null && writeContext.IsLocal(element.Classifier))
+            {
+                xmlWriter.WriteAttributeString("classifier", element.Classifier.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.Classifier != null && !writeContext.IsLocal(element.Classifier))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Classifier, "classifier", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReadExtentAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadExtentAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReadExtentAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadExtentAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadExtentAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.Classifier != null && writeContext.IsLocal(element.Classifier))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifier", null, element.Classifier.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.Classifier != null && !writeContext.IsLocal(element.Classifier))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Classifier, "classifier", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReadIsClassifiedObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadIsClassifiedObjectActionWriter.cs
@@ -1,0 +1,436 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReadIsClassifiedObjectActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReadIsClassifiedObjectActionWriter"/> is to write an instance of <see cref="IReadIsClassifiedObjectAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReadIsClassifiedObjectActionWriter : XmiElementWriter<IReadIsClassifiedObjectAction>, IXmiElementWriter<IReadIsClassifiedObjectAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReadIsClassifiedObjectActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadIsClassifiedObjectActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReadIsClassifiedObjectActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReadIsClassifiedObjectActionWriter>.Instance : loggerFactory.CreateLogger<ReadIsClassifiedObjectActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReadIsClassifiedObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadIsClassifiedObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReadIsClassifiedObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadIsClassifiedObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadIsClassifiedObjectAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.Classifier != null && writeContext.IsLocal(element.Classifier))
+            {
+                xmlWriter.WriteAttributeString("classifier", element.Classifier.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsDirect)
+            {
+                xmlWriter.WriteAttributeString("isDirect", XmlConvert.ToString(element.IsDirect));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.Classifier != null && !writeContext.IsLocal(element.Classifier))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Classifier, "classifier", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReadIsClassifiedObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadIsClassifiedObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReadIsClassifiedObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadIsClassifiedObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadIsClassifiedObjectAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.Classifier != null && writeContext.IsLocal(element.Classifier))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifier", null, element.Classifier.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsDirect)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isDirect", null, XmlConvert.ToString(element.IsDirect));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.Classifier != null && !writeContext.IsLocal(element.Classifier))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Classifier, "classifier", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReadLinkActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadLinkActionWriter.cs
@@ -1,0 +1,416 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReadLinkActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReadLinkActionWriter"/> is to write an instance of <see cref="IReadLinkAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReadLinkActionWriter : XmiElementWriter<IReadLinkAction>, IXmiElementWriter<IReadLinkAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReadLinkActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadLinkActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReadLinkActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReadLinkActionWriter>.Instance : loggerFactory.CreateLogger<ReadLinkActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReadLinkAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadLinkAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReadLinkAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadLinkAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.EndData)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "endData", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "inputValue", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReadLinkAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadLinkAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReadLinkAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadLinkAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.EndData)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "endData", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InputValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "inputValue", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndActionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReadLinkObjectEndActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReadLinkObjectEndActionWriter"/> is to write an instance of <see cref="IReadLinkObjectEndAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReadLinkObjectEndActionWriter : XmiElementWriter<IReadLinkObjectEndAction>, IXmiElementWriter<IReadLinkObjectEndAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReadLinkObjectEndActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadLinkObjectEndActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReadLinkObjectEndActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReadLinkObjectEndActionWriter>.Instance : loggerFactory.CreateLogger<ReadLinkObjectEndActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReadLinkObjectEndAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadLinkObjectEndAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReadLinkObjectEndAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadLinkObjectEndAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkObjectEndAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.End != null && writeContext.IsLocal(element.End))
+            {
+                xmlWriter.WriteAttributeString("end", element.End.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.End != null && !writeContext.IsLocal(element.End))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.End, "end", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReadLinkObjectEndAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadLinkObjectEndAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReadLinkObjectEndAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadLinkObjectEndAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkObjectEndAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.End != null && writeContext.IsLocal(element.End))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "end", null, element.End.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            if (element.End != null && !writeContext.IsLocal(element.End))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.End, "end", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndQualifierActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndQualifierActionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReadLinkObjectEndQualifierActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReadLinkObjectEndQualifierActionWriter"/> is to write an instance of <see cref="IReadLinkObjectEndQualifierAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReadLinkObjectEndQualifierActionWriter : XmiElementWriter<IReadLinkObjectEndQualifierAction>, IXmiElementWriter<IReadLinkObjectEndQualifierAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReadLinkObjectEndQualifierActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadLinkObjectEndQualifierActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReadLinkObjectEndQualifierActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReadLinkObjectEndQualifierActionWriter>.Instance : loggerFactory.CreateLogger<ReadLinkObjectEndQualifierActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReadLinkObjectEndQualifierAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadLinkObjectEndQualifierAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReadLinkObjectEndQualifierAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadLinkObjectEndQualifierAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkObjectEndQualifierAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Qualifier != null && writeContext.IsLocal(element.Qualifier))
+            {
+                xmlWriter.WriteAttributeString("qualifier", element.Qualifier.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Qualifier != null && !writeContext.IsLocal(element.Qualifier))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Qualifier, "qualifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReadLinkObjectEndQualifierAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadLinkObjectEndQualifierAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReadLinkObjectEndQualifierAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadLinkObjectEndQualifierAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkObjectEndQualifierAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Qualifier != null && writeContext.IsLocal(element.Qualifier))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "qualifier", null, element.Qualifier.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.Qualifier != null && !writeContext.IsLocal(element.Qualifier))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Qualifier, "qualifier", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReadSelfActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadSelfActionWriter.cs
@@ -1,0 +1,396 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReadSelfActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReadSelfActionWriter"/> is to write an instance of <see cref="IReadSelfAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReadSelfActionWriter : XmiElementWriter<IReadSelfAction>, IXmiElementWriter<IReadSelfAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReadSelfActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadSelfActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReadSelfActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReadSelfActionWriter>.Instance : loggerFactory.CreateLogger<ReadSelfActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReadSelfAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadSelfAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReadSelfAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadSelfAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadSelfAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReadSelfAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadSelfAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReadSelfAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadSelfAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadSelfAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReadStructuralFeatureActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadStructuralFeatureActionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReadStructuralFeatureActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReadStructuralFeatureActionWriter"/> is to write an instance of <see cref="IReadStructuralFeatureAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReadStructuralFeatureActionWriter : XmiElementWriter<IReadStructuralFeatureAction>, IXmiElementWriter<IReadStructuralFeatureAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReadStructuralFeatureActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadStructuralFeatureActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReadStructuralFeatureActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReadStructuralFeatureActionWriter>.Instance : loggerFactory.CreateLogger<ReadStructuralFeatureActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReadStructuralFeatureAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadStructuralFeatureAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReadStructuralFeatureAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadStructuralFeatureAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadStructuralFeatureAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.StructuralFeature != null && writeContext.IsLocal(element.StructuralFeature))
+            {
+                xmlWriter.WriteAttributeString("structuralFeature", element.StructuralFeature.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.StructuralFeature != null && !writeContext.IsLocal(element.StructuralFeature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReadStructuralFeatureAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadStructuralFeatureAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReadStructuralFeatureAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadStructuralFeatureAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadStructuralFeatureAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.StructuralFeature != null && writeContext.IsLocal(element.StructuralFeature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "structuralFeature", null, element.StructuralFeature.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.StructuralFeature != null && !writeContext.IsLocal(element.StructuralFeature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReadVariableActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadVariableActionWriter.cs
@@ -1,0 +1,416 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReadVariableActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReadVariableActionWriter"/> is to write an instance of <see cref="IReadVariableAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReadVariableActionWriter : XmiElementWriter<IReadVariableAction>, IXmiElementWriter<IReadVariableAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReadVariableActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadVariableActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReadVariableActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReadVariableActionWriter>.Instance : loggerFactory.CreateLogger<ReadVariableActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReadVariableAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadVariableAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReadVariableAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadVariableAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadVariableAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Variable != null && writeContext.IsLocal(element.Variable))
+            {
+                xmlWriter.WriteAttributeString("variable", element.Variable.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.Variable != null && !writeContext.IsLocal(element.Variable))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Variable, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReadVariableAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReadVariableAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReadVariableAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReadVariableAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadVariableAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Variable != null && writeContext.IsLocal(element.Variable))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "variable", null, element.Variable.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.Variable != null && !writeContext.IsLocal(element.Variable))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/RealizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RealizationWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RealizationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="RealizationWriter"/> is to write an instance of <see cref="IRealization"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class RealizationWriter : XmiElementWriter<IRealization>, IXmiElementWriter<IRealization>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<RealizationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RealizationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public RealizationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<RealizationWriter>.Instance : loggerFactory.CreateLogger<RealizationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IRealization"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRealization"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IRealization element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Realization with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Realization");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IRealization"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRealization"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IRealization element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Realization with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Realization");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReceptionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReceptionWriter.cs
@@ -1,0 +1,376 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReceptionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReceptionWriter"/> is to write an instance of <see cref="IReception"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReceptionWriter : XmiElementWriter<IReception>, IXmiElementWriter<IReception>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReceptionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReceptionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReceptionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReceptionWriter>.Instance : loggerFactory.CreateLogger<ReceptionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReception"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReception"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReception element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Reception with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Reception");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Concurrency != CallConcurrencyKind.Sequential)
+            {
+                xmlWriter.WriteAttributeString("concurrency", LowerCaseFirstLetter(element.Concurrency.ToString()));
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsStatic)
+            {
+                xmlWriter.WriteAttributeString("isStatic", XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Signal != null && writeContext.IsLocal(element.Signal))
+            {
+                xmlWriter.WriteAttributeString("signal", element.Signal.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Method)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "method", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RaisedException)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "raisedException", writeContext);
+            }
+
+            if (element.Signal != null && !writeContext.IsLocal(element.Signal))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signal, "signal", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReception"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReception"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReception element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Reception with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Reception");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Concurrency != CallConcurrencyKind.Sequential)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "concurrency", null, LowerCaseFirstLetter(element.Concurrency.ToString()));
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsStatic)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isStatic", null, XmlConvert.ToString(element.IsStatic));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Signal != null && writeContext.IsLocal(element.Signal))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "signal", null, element.Signal.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Method)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "method", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RaisedException)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "raisedException", writeContext);
+            }
+
+            if (element.Signal != null && !writeContext.IsLocal(element.Signal))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signal, "signal", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReclassifyObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReclassifyObjectActionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReclassifyObjectActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReclassifyObjectActionWriter"/> is to write an instance of <see cref="IReclassifyObjectAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReclassifyObjectActionWriter : XmiElementWriter<IReclassifyObjectAction>, IXmiElementWriter<IReclassifyObjectAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReclassifyObjectActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReclassifyObjectActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReclassifyObjectActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReclassifyObjectActionWriter>.Instance : loggerFactory.CreateLogger<ReclassifyObjectActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReclassifyObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReclassifyObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReclassifyObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReclassifyObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReclassifyObjectAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsReplaceAll)
+            {
+                xmlWriter.WriteAttributeString("isReplaceAll", XmlConvert.ToString(element.IsReplaceAll));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NewClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "newClassifier", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.OldClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "oldClassifier", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReclassifyObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReclassifyObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReclassifyObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReclassifyObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReclassifyObjectAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsReplaceAll)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReplaceAll", null, XmlConvert.ToString(element.IsReplaceAll));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NewClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "newClassifier", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.OldClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "oldClassifier", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/RedefinableTemplateSignatureWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RedefinableTemplateSignatureWriter.cs
@@ -1,0 +1,306 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RedefinableTemplateSignatureWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="RedefinableTemplateSignatureWriter"/> is to write an instance of <see cref="IRedefinableTemplateSignature"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class RedefinableTemplateSignatureWriter : XmiElementWriter<IRedefinableTemplateSignature>, IXmiElementWriter<IRedefinableTemplateSignature>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<RedefinableTemplateSignatureWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedefinableTemplateSignatureWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public RedefinableTemplateSignatureWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<RedefinableTemplateSignatureWriter>.Instance : loggerFactory.CreateLogger<RedefinableTemplateSignatureWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IRedefinableTemplateSignature"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRedefinableTemplateSignature"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IRedefinableTemplateSignature element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the RedefinableTemplateSignature with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RedefinableTemplateSignature");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Classifier != null && writeContext.IsLocal(element.Classifier))
+            {
+                xmlWriter.WriteAttributeString("classifier", element.Classifier.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Classifier != null && !writeContext.IsLocal(element.Classifier))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Classifier, "classifier", writeContext);
+            }
+
+            foreach (var value in element.ExtendedSignature)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "extendedSignature", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.Parameter)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "parameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IRedefinableTemplateSignature"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRedefinableTemplateSignature"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IRedefinableTemplateSignature element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the RedefinableTemplateSignature with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RedefinableTemplateSignature");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Classifier != null && writeContext.IsLocal(element.Classifier))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifier", null, element.Classifier.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Classifier != null && !writeContext.IsLocal(element.Classifier))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Classifier, "classifier", writeContext);
+            }
+
+            foreach (var value in element.ExtendedSignature)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "extendedSignature", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.Parameter)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "parameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReduceActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReduceActionWriter.cs
@@ -1,0 +1,436 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReduceActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReduceActionWriter"/> is to write an instance of <see cref="IReduceAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReduceActionWriter : XmiElementWriter<IReduceAction>, IXmiElementWriter<IReduceAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReduceActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReduceActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReduceActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReduceActionWriter>.Instance : loggerFactory.CreateLogger<ReduceActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReduceAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReduceAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReduceAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReduceAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReduceAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Reducer != null && writeContext.IsLocal(element.Reducer))
+            {
+                xmlWriter.WriteAttributeString("reducer", element.Reducer.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Collection)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collection", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Reducer != null && !writeContext.IsLocal(element.Reducer))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Reducer, "reducer", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReduceAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReduceAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReduceAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReduceAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReduceAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Reducer != null && writeContext.IsLocal(element.Reducer))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "reducer", null, element.Reducer.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Collection)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collection", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Reducer != null && !writeContext.IsLocal(element.Reducer))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Reducer, "reducer", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/RegionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RegionWriter.cs
@@ -1,0 +1,366 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RegionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="RegionWriter"/> is to write an instance of <see cref="IRegion"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class RegionWriter : XmiElementWriter<IRegion>, IXmiElementWriter<IRegion>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<RegionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public RegionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<RegionWriter>.Instance : loggerFactory.CreateLogger<RegionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IRegion"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRegion"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IRegion element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Region with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Region");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ExtendedRegion != null && writeContext.IsLocal(element.ExtendedRegion))
+            {
+                xmlWriter.WriteAttributeString("extendedRegion", element.ExtendedRegion.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.State != null && writeContext.IsLocal(element.State))
+            {
+                xmlWriter.WriteAttributeString("state", element.State.XmiId);
+            }
+
+            if (element.StateMachine != null && writeContext.IsLocal(element.StateMachine))
+            {
+                xmlWriter.WriteAttributeString("stateMachine", element.StateMachine.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            if (element.ExtendedRegion != null && !writeContext.IsLocal(element.ExtendedRegion))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ExtendedRegion, "extendedRegion", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            if (element.State != null && !writeContext.IsLocal(element.State))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.State, "state", writeContext);
+            }
+
+            if (element.StateMachine != null && !writeContext.IsLocal(element.StateMachine))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.StateMachine, "stateMachine", writeContext);
+            }
+
+            foreach (var value in element.Subvertex)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "subvertex", writeContext);
+            }
+
+            foreach (var value in element.Transition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "transition", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IRegion"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRegion"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IRegion element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Region with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Region");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ExtendedRegion != null && writeContext.IsLocal(element.ExtendedRegion))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "extendedRegion", null, element.ExtendedRegion.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.State != null && writeContext.IsLocal(element.State))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "state", null, element.State.XmiId);
+            }
+
+            if (element.StateMachine != null && writeContext.IsLocal(element.StateMachine))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "stateMachine", null, element.StateMachine.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            if (element.ExtendedRegion != null && !writeContext.IsLocal(element.ExtendedRegion))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ExtendedRegion, "extendedRegion", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            if (element.State != null && !writeContext.IsLocal(element.State))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.State, "state", writeContext);
+            }
+
+            if (element.StateMachine != null && !writeContext.IsLocal(element.StateMachine))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StateMachine, "stateMachine", writeContext);
+            }
+
+            foreach (var value in element.Subvertex)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "subvertex", writeContext);
+            }
+
+            foreach (var value in element.Transition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "transition", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/RemoveStructuralFeatureValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RemoveStructuralFeatureValueActionWriter.cs
@@ -1,0 +1,456 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RemoveStructuralFeatureValueActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="RemoveStructuralFeatureValueActionWriter"/> is to write an instance of <see cref="IRemoveStructuralFeatureValueAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class RemoveStructuralFeatureValueActionWriter : XmiElementWriter<IRemoveStructuralFeatureValueAction>, IXmiElementWriter<IRemoveStructuralFeatureValueAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<RemoveStructuralFeatureValueActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemoveStructuralFeatureValueActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public RemoveStructuralFeatureValueActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<RemoveStructuralFeatureValueActionWriter>.Instance : loggerFactory.CreateLogger<RemoveStructuralFeatureValueActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IRemoveStructuralFeatureValueAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRemoveStructuralFeatureValueAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IRemoveStructuralFeatureValueAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the RemoveStructuralFeatureValueAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RemoveStructuralFeatureValueAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsRemoveDuplicates)
+            {
+                xmlWriter.WriteAttributeString("isRemoveDuplicates", XmlConvert.ToString(element.IsRemoveDuplicates));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.StructuralFeature != null && writeContext.IsLocal(element.StructuralFeature))
+            {
+                xmlWriter.WriteAttributeString("structuralFeature", element.StructuralFeature.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.RemoveAt)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "removeAt", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.StructuralFeature != null && !writeContext.IsLocal(element.StructuralFeature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "value", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IRemoveStructuralFeatureValueAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRemoveStructuralFeatureValueAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IRemoveStructuralFeatureValueAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the RemoveStructuralFeatureValueAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RemoveStructuralFeatureValueAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsRemoveDuplicates)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isRemoveDuplicates", null, XmlConvert.ToString(element.IsRemoveDuplicates));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.StructuralFeature != null && writeContext.IsLocal(element.StructuralFeature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "structuralFeature", null, element.StructuralFeature.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.RemoveAt)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "removeAt", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.StructuralFeature != null && !writeContext.IsLocal(element.StructuralFeature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/RemoveVariableValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RemoveVariableValueActionWriter.cs
@@ -1,0 +1,436 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RemoveVariableValueActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="RemoveVariableValueActionWriter"/> is to write an instance of <see cref="IRemoveVariableValueAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class RemoveVariableValueActionWriter : XmiElementWriter<IRemoveVariableValueAction>, IXmiElementWriter<IRemoveVariableValueAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<RemoveVariableValueActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemoveVariableValueActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public RemoveVariableValueActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<RemoveVariableValueActionWriter>.Instance : loggerFactory.CreateLogger<RemoveVariableValueActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IRemoveVariableValueAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRemoveVariableValueAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IRemoveVariableValueAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the RemoveVariableValueAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RemoveVariableValueAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsRemoveDuplicates)
+            {
+                xmlWriter.WriteAttributeString("isRemoveDuplicates", XmlConvert.ToString(element.IsRemoveDuplicates));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Variable != null && writeContext.IsLocal(element.Variable))
+            {
+                xmlWriter.WriteAttributeString("variable", element.Variable.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.RemoveAt)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "removeAt", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "value", writeContext);
+            }
+
+            if (element.Variable != null && !writeContext.IsLocal(element.Variable))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Variable, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IRemoveVariableValueAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IRemoveVariableValueAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IRemoveVariableValueAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the RemoveVariableValueAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RemoveVariableValueAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.IsRemoveDuplicates)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isRemoveDuplicates", null, XmlConvert.ToString(element.IsRemoveDuplicates));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Variable != null && writeContext.IsLocal(element.Variable))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "variable", null, element.Variable.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.RemoveAt)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "removeAt", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
+            }
+
+            if (element.Variable != null && !writeContext.IsLocal(element.Variable))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ReplyActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReplyActionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReplyActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReplyActionWriter"/> is to write an instance of <see cref="IReplyAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ReplyActionWriter : XmiElementWriter<IReplyAction>, IXmiElementWriter<IReplyAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ReplyActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReplyActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ReplyActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ReplyActionWriter>.Instance : loggerFactory.CreateLogger<ReplyActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IReplyAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReplyAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IReplyAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReplyAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReplyAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.ReplyToCall != null && writeContext.IsLocal(element.ReplyToCall))
+            {
+                xmlWriter.WriteAttributeString("replyToCall", element.ReplyToCall.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.ReplyToCall != null && !writeContext.IsLocal(element.ReplyToCall))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ReplyToCall, "replyToCall", writeContext);
+            }
+
+            foreach (var value in element.ReplyValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "replyValue", writeContext);
+            }
+
+            foreach (var value in element.ReturnInformation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "returnInformation", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IReplyAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IReplyAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IReplyAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ReplyAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReplyAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.ReplyToCall != null && writeContext.IsLocal(element.ReplyToCall))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "replyToCall", null, element.ReplyToCall.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.ReplyToCall != null && !writeContext.IsLocal(element.ReplyToCall))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReplyToCall, "replyToCall", writeContext);
+            }
+
+            foreach (var value in element.ReplyValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "replyValue", writeContext);
+            }
+
+            foreach (var value in element.ReturnInformation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "returnInformation", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/SendObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SendObjectActionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SendObjectActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="SendObjectActionWriter"/> is to write an instance of <see cref="ISendObjectAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class SendObjectActionWriter : XmiElementWriter<ISendObjectAction>, IXmiElementWriter<ISendObjectAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<SendObjectActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SendObjectActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public SendObjectActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<SendObjectActionWriter>.Instance : loggerFactory.CreateLogger<SendObjectActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ISendObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISendObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ISendObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the SendObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SendObjectAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                xmlWriter.WriteAttributeString("onPort", element.OnPort.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Request)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "request", writeContext);
+            }
+
+            foreach (var value in element.Target)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "target", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ISendObjectAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISendObjectAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ISendObjectAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the SendObjectAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SendObjectAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "onPort", null, element.OnPort.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Request)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "request", writeContext);
+            }
+
+            foreach (var value in element.Target)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/SendSignalActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SendSignalActionWriter.cs
@@ -1,0 +1,446 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SendSignalActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="SendSignalActionWriter"/> is to write an instance of <see cref="ISendSignalAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class SendSignalActionWriter : XmiElementWriter<ISendSignalAction>, IXmiElementWriter<ISendSignalAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<SendSignalActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SendSignalActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public SendSignalActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<SendSignalActionWriter>.Instance : loggerFactory.CreateLogger<SendSignalActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ISendSignalAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISendSignalAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ISendSignalAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the SendSignalAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SendSignalAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                xmlWriter.WriteAttributeString("onPort", element.OnPort.XmiId);
+            }
+
+            if (element.Signal != null && writeContext.IsLocal(element.Signal))
+            {
+                xmlWriter.WriteAttributeString("signal", element.Signal.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Signal != null && !writeContext.IsLocal(element.Signal))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signal, "signal", writeContext);
+            }
+
+            foreach (var value in element.Target)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "target", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ISendSignalAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISendSignalAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ISendSignalAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the SendSignalAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SendSignalAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "onPort", null, element.OnPort.XmiId);
+            }
+
+            if (element.Signal != null && writeContext.IsLocal(element.Signal))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "signal", null, element.Signal.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Signal != null && !writeContext.IsLocal(element.Signal))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signal, "signal", writeContext);
+            }
+
+            foreach (var value in element.Target)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/SequenceNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SequenceNodeWriter.cs
@@ -1,0 +1,476 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SequenceNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="SequenceNodeWriter"/> is to write an instance of <see cref="ISequenceNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class SequenceNodeWriter : XmiElementWriter<ISequenceNode>, IXmiElementWriter<ISequenceNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<SequenceNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SequenceNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public SequenceNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<SequenceNodeWriter>.Instance : loggerFactory.CreateLogger<SequenceNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ISequenceNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISequenceNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ISequenceNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the SequenceNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SequenceNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.MustIsolate)
+            {
+                xmlWriter.WriteAttributeString("mustIsolate", XmlConvert.ToString(element.MustIsolate));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.ExecutableNode)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "executableNode", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeInput)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "structuredNodeInput", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeOutput)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "structuredNodeOutput", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ISequenceNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISequenceNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ISequenceNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the SequenceNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SequenceNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.MustIsolate)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "mustIsolate", null, XmlConvert.ToString(element.MustIsolate));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.ExecutableNode)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "executableNode", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeInput)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "structuredNodeInput", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeOutput)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "structuredNodeOutput", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/SignalEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SignalEventWriter.cs
@@ -1,0 +1,306 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SignalEventWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="SignalEventWriter"/> is to write an instance of <see cref="ISignalEvent"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class SignalEventWriter : XmiElementWriter<ISignalEvent>, IXmiElementWriter<ISignalEvent>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<SignalEventWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignalEventWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public SignalEventWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<SignalEventWriter>.Instance : loggerFactory.CreateLogger<SignalEventWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ISignalEvent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISignalEvent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ISignalEvent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the SignalEvent with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SignalEvent");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Signal != null && writeContext.IsLocal(element.Signal))
+            {
+                xmlWriter.WriteAttributeString("signal", element.Signal.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Signal != null && !writeContext.IsLocal(element.Signal))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signal, "signal", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ISignalEvent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISignalEvent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ISignalEvent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the SignalEvent with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SignalEvent");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Signal != null && writeContext.IsLocal(element.Signal))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "signal", null, element.Signal.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Signal != null && !writeContext.IsLocal(element.Signal))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signal, "signal", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/SignalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SignalWriter.cs
@@ -1,0 +1,486 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SignalWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="SignalWriter"/> is to write an instance of <see cref="ISignal"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class SignalWriter : XmiElementWriter<ISignal>, IXmiElementWriter<ISignal>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<SignalWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignalWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public SignalWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<SignalWriter>.Instance : loggerFactory.CreateLogger<SignalWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ISignal"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISignal"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ISignal element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Signal with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Signal");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ISignal"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISignal"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ISignal element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Signal with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Signal");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/SlotWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SlotWriter.cs
@@ -1,0 +1,266 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SlotWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="SlotWriter"/> is to write an instance of <see cref="ISlot"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class SlotWriter : XmiElementWriter<ISlot>, IXmiElementWriter<ISlot>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<SlotWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SlotWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public SlotWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<SlotWriter>.Instance : loggerFactory.CreateLogger<SlotWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ISlot"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISlot"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ISlot element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Slot with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Slot");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.DefiningFeature != null && writeContext.IsLocal(element.DefiningFeature))
+            {
+                xmlWriter.WriteAttributeString("definingFeature", element.DefiningFeature.XmiId);
+            }
+
+            if (element.OwningInstance != null && writeContext.IsLocal(element.OwningInstance))
+            {
+                xmlWriter.WriteAttributeString("owningInstance", element.OwningInstance.XmiId);
+            }
+
+
+            if (element.DefiningFeature != null && !writeContext.IsLocal(element.DefiningFeature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.DefiningFeature, "definingFeature", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningInstance != null && !writeContext.IsLocal(element.OwningInstance))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningInstance, "owningInstance", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "value", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ISlot"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISlot"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ISlot element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Slot with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Slot");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.DefiningFeature != null && writeContext.IsLocal(element.DefiningFeature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "definingFeature", null, element.DefiningFeature.XmiId);
+            }
+
+            if (element.OwningInstance != null && writeContext.IsLocal(element.OwningInstance))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningInstance", null, element.OwningInstance.XmiId);
+            }
+
+
+            if (element.DefiningFeature != null && !writeContext.IsLocal(element.DefiningFeature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.DefiningFeature, "definingFeature", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningInstance != null && !writeContext.IsLocal(element.OwningInstance))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningInstance, "owningInstance", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/StartClassifierBehaviorActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StartClassifierBehaviorActionWriter.cs
@@ -1,0 +1,396 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StartClassifierBehaviorActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="StartClassifierBehaviorActionWriter"/> is to write an instance of <see cref="IStartClassifierBehaviorAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class StartClassifierBehaviorActionWriter : XmiElementWriter<IStartClassifierBehaviorAction>, IXmiElementWriter<IStartClassifierBehaviorAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<StartClassifierBehaviorActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StartClassifierBehaviorActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public StartClassifierBehaviorActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<StartClassifierBehaviorActionWriter>.Instance : loggerFactory.CreateLogger<StartClassifierBehaviorActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IStartClassifierBehaviorAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStartClassifierBehaviorAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IStartClassifierBehaviorAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StartClassifierBehaviorAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StartClassifierBehaviorAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IStartClassifierBehaviorAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStartClassifierBehaviorAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IStartClassifierBehaviorAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StartClassifierBehaviorAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StartClassifierBehaviorAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/StartObjectBehaviorActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StartObjectBehaviorActionWriter.cs
@@ -1,0 +1,446 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StartObjectBehaviorActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="StartObjectBehaviorActionWriter"/> is to write an instance of <see cref="IStartObjectBehaviorAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class StartObjectBehaviorActionWriter : XmiElementWriter<IStartObjectBehaviorAction>, IXmiElementWriter<IStartObjectBehaviorAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<StartObjectBehaviorActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StartObjectBehaviorActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public StartObjectBehaviorActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<StartObjectBehaviorActionWriter>.Instance : loggerFactory.CreateLogger<StartObjectBehaviorActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IStartObjectBehaviorAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStartObjectBehaviorAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IStartObjectBehaviorAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StartObjectBehaviorAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StartObjectBehaviorAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!element.IsSynchronous)
+            {
+                xmlWriter.WriteAttributeString("isSynchronous", XmlConvert.ToString(element.IsSynchronous));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                xmlWriter.WriteAttributeString("onPort", element.OnPort.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IStartObjectBehaviorAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStartObjectBehaviorAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IStartObjectBehaviorAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StartObjectBehaviorAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StartObjectBehaviorAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!element.IsSynchronous)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isSynchronous", null, XmlConvert.ToString(element.IsSynchronous));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OnPort != null && writeContext.IsLocal(element.OnPort))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "onPort", null, element.OnPort.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Argument)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "argument", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            if (element.OnPort != null && !writeContext.IsLocal(element.OnPort))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OnPort, "onPort", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/StateInvariantWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StateInvariantWriter.cs
@@ -1,0 +1,326 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StateInvariantWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="StateInvariantWriter"/> is to write an instance of <see cref="IStateInvariant"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class StateInvariantWriter : XmiElementWriter<IStateInvariant>, IXmiElementWriter<IStateInvariant>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<StateInvariantWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StateInvariantWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public StateInvariantWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<StateInvariantWriter>.Instance : loggerFactory.CreateLogger<StateInvariantWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IStateInvariant"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStateInvariant"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IStateInvariant element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StateInvariant with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateInvariant");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Covered != null && writeContext.IsLocal(element.Covered))
+            {
+                xmlWriter.WriteAttributeString("covered", element.Covered.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                xmlWriter.WriteAttributeString("enclosingInteraction", element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                xmlWriter.WriteAttributeString("enclosingOperand", element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Covered != null && !writeContext.IsLocal(element.Covered))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Covered, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.Invariant)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "invariant", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IStateInvariant"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStateInvariant"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IStateInvariant element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StateInvariant with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateInvariant");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Covered != null && writeContext.IsLocal(element.Covered))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "covered", null, element.Covered.XmiId);
+            }
+
+            if (element.EnclosingInteraction != null && writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingInteraction", null, element.EnclosingInteraction.XmiId);
+            }
+
+            if (element.EnclosingOperand != null && writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "enclosingOperand", null, element.EnclosingOperand.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Covered != null && !writeContext.IsLocal(element.Covered))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Covered, "covered", writeContext);
+            }
+
+            if (element.EnclosingInteraction != null && !writeContext.IsLocal(element.EnclosingInteraction))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingInteraction, "enclosingInteraction", writeContext);
+            }
+
+            if (element.EnclosingOperand != null && !writeContext.IsLocal(element.EnclosingOperand))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.EnclosingOperand, "enclosingOperand", writeContext);
+            }
+
+            foreach (var value in element.GeneralOrdering)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalOrdering", writeContext);
+            }
+
+            foreach (var value in element.Invariant)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "invariant", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/StateMachineWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StateMachineWriter.cs
@@ -1,0 +1,686 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StateMachineWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="StateMachineWriter"/> is to write an instance of <see cref="IStateMachine"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class StateMachineWriter : XmiElementWriter<IStateMachine>, IXmiElementWriter<IStateMachine>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<StateMachineWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StateMachineWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public StateMachineWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<StateMachineWriter>.Instance : loggerFactory.CreateLogger<StateMachineWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IStateMachine"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStateMachine"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IStateMachine element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StateMachine with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateMachine");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                xmlWriter.WriteAttributeString("isReentrant", XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                xmlWriter.WriteAttributeString("specification", element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ConnectionPoint)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "connectionPoint", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.ExtendedStateMachine)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "extendedStateMachine", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            foreach (var value in element.Region)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "region", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.SubmachineState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "submachineState", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IStateMachine"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStateMachine"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IStateMachine element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StateMachine with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateMachine");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!element.IsReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isReentrant", null, XmlConvert.ToString(element.IsReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.Specification != null && writeContext.IsLocal(element.Specification))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "specification", null, element.Specification.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ConnectionPoint)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "connectionPoint", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.ExtendedStateMachine)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "extendedStateMachine", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameterSet)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameterSet", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.Postcondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "postcondition", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.Precondition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "precondition", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            foreach (var value in element.Region)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "region", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            if (element.Specification != null && !writeContext.IsLocal(element.Specification))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specification, "specification", writeContext);
+            }
+
+            foreach (var value in element.SubmachineState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "submachineState", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/StateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StateWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StateWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="StateWriter"/> is to write an instance of <see cref="IState"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class StateWriter : XmiElementWriter<IState>, IXmiElementWriter<IState>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<StateWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StateWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public StateWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<StateWriter>.Instance : loggerFactory.CreateLogger<StateWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IState"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IState"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IState element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the State with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:State");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                xmlWriter.WriteAttributeString("container", element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.RedefinedVertex != null && writeContext.IsLocal(element.RedefinedVertex))
+            {
+                xmlWriter.WriteAttributeString("redefinedVertex", element.RedefinedVertex.XmiId);
+            }
+
+            if (element.Submachine != null && writeContext.IsLocal(element.Submachine))
+            {
+                xmlWriter.WriteAttributeString("submachine", element.Submachine.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Connection)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "connection", writeContext);
+            }
+
+            foreach (var value in element.ConnectionPoint)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "connectionPoint", writeContext);
+            }
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.DeferrableTrigger)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "deferrableTrigger", writeContext);
+            }
+
+            foreach (var value in element.DoActivity)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "doActivity", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Entry)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "entry", writeContext);
+            }
+
+            foreach (var value in element.Exit)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "exit", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            if (element.RedefinedVertex != null && !writeContext.IsLocal(element.RedefinedVertex))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.RedefinedVertex, "redefinedVertex", writeContext);
+            }
+
+            foreach (var value in element.Region)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "region", writeContext);
+            }
+
+            foreach (var value in element.StateInvariant)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "stateInvariant", writeContext);
+            }
+
+            if (element.Submachine != null && !writeContext.IsLocal(element.Submachine))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Submachine, "submachine", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IState"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IState"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IState element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the State with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:State");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "container", null, element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.RedefinedVertex != null && writeContext.IsLocal(element.RedefinedVertex))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "redefinedVertex", null, element.RedefinedVertex.XmiId);
+            }
+
+            if (element.Submachine != null && writeContext.IsLocal(element.Submachine))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "submachine", null, element.Submachine.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Connection)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "connection", writeContext);
+            }
+
+            foreach (var value in element.ConnectionPoint)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "connectionPoint", writeContext);
+            }
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.DeferrableTrigger)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "deferrableTrigger", writeContext);
+            }
+
+            foreach (var value in element.DoActivity)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "doActivity", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Entry)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "entry", writeContext);
+            }
+
+            foreach (var value in element.Exit)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "exit", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            if (element.RedefinedVertex != null && !writeContext.IsLocal(element.RedefinedVertex))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.RedefinedVertex, "redefinedVertex", writeContext);
+            }
+
+            foreach (var value in element.Region)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "region", writeContext);
+            }
+
+            foreach (var value in element.StateInvariant)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "stateInvariant", writeContext);
+            }
+
+            if (element.Submachine != null && !writeContext.IsLocal(element.Submachine))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Submachine, "submachine", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/StereotypeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StereotypeWriter.cs
@@ -1,0 +1,586 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StereotypeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="StereotypeWriter"/> is to write an instance of <see cref="IStereotype"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class StereotypeWriter : XmiElementWriter<IStereotype>, IXmiElementWriter<IStereotype>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<StereotypeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StereotypeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public StereotypeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<StereotypeWriter>.Instance : loggerFactory.CreateLogger<StereotypeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IStereotype"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStereotype"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IStereotype element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Stereotype with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Stereotype");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                xmlWriter.WriteAttributeString("isActive", XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Icon)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "icon", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IStereotype"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStereotype"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IStereotype element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Stereotype with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Stereotype");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsActive)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isActive", null, XmlConvert.ToString(element.IsActive));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Icon)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "icon", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.NestedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nestedClassifier", writeContext);
+            }
+
+            foreach (var value in element.OwnedAttribute)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedAttribute", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedConnector)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedConnector", writeContext);
+            }
+
+            foreach (var value in element.OwnedOperation)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedOperation", writeContext);
+            }
+
+            foreach (var value in element.OwnedReception)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedReception", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/StringExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StringExpressionWriter.cs
@@ -1,0 +1,376 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StringExpressionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="StringExpressionWriter"/> is to write an instance of <see cref="IStringExpression"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class StringExpressionWriter : XmiElementWriter<IStringExpression>, IXmiElementWriter<IStringExpression>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<StringExpressionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringExpressionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public StringExpressionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<StringExpressionWriter>.Instance : loggerFactory.CreateLogger<StringExpressionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IStringExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStringExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IStringExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StringExpression with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StringExpression");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningExpression != null && writeContext.IsLocal(element.OwningExpression))
+            {
+                xmlWriter.WriteAttributeString("owningExpression", element.OwningExpression.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Symbol))
+            {
+                xmlWriter.WriteAttributeString("symbol", element.Symbol);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Operand)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "operand", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            if (element.OwningExpression != null && !writeContext.IsLocal(element.OwningExpression))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningExpression, "owningExpression", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.SubExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "subExpression", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IStringExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStringExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IStringExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StringExpression with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StringExpression");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningExpression != null && writeContext.IsLocal(element.OwningExpression))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningExpression", null, element.OwningExpression.XmiId);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Symbol))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "symbol", null, element.Symbol);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Operand)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "operand", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            if (element.OwningExpression != null && !writeContext.IsLocal(element.OwningExpression))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningExpression, "owningExpression", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.SubExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "subExpression", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/StructuredActivityNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StructuredActivityNodeWriter.cs
@@ -1,0 +1,476 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="StructuredActivityNodeWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="StructuredActivityNodeWriter"/> is to write an instance of <see cref="IStructuredActivityNode"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class StructuredActivityNodeWriter : XmiElementWriter<IStructuredActivityNode>, IXmiElementWriter<IStructuredActivityNode>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<StructuredActivityNodeWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StructuredActivityNodeWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public StructuredActivityNodeWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<StructuredActivityNodeWriter>.Instance : loggerFactory.CreateLogger<StructuredActivityNodeWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IStructuredActivityNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStructuredActivityNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IStructuredActivityNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StructuredActivityNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StructuredActivityNode");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.MustIsolate)
+            {
+                xmlWriter.WriteAttributeString("mustIsolate", XmlConvert.ToString(element.MustIsolate));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeInput)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "structuredNodeInput", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeOutput)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "structuredNodeOutput", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IStructuredActivityNode"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IStructuredActivityNode"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IStructuredActivityNode element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the StructuredActivityNode with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StructuredActivityNode");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (element.MustIsolate)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "mustIsolate", null, XmlConvert.ToString(element.MustIsolate));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Edge)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "edge", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Node)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "node", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeInput)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "structuredNodeInput", writeContext);
+            }
+
+            foreach (var value in element.StructuredNodeOutput)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "structuredNodeOutput", writeContext);
+            }
+
+            foreach (var value in element.Variable)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/SubstitutionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SubstitutionWriter.cs
@@ -1,0 +1,356 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="SubstitutionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="SubstitutionWriter"/> is to write an instance of <see cref="ISubstitution"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class SubstitutionWriter : XmiElementWriter<ISubstitution>, IXmiElementWriter<ISubstitution>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<SubstitutionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubstitutionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public SubstitutionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<SubstitutionWriter>.Instance : loggerFactory.CreateLogger<SubstitutionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ISubstitution"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISubstitution"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ISubstitution element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Substitution with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Substitution");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Contract != null && writeContext.IsLocal(element.Contract))
+            {
+                xmlWriter.WriteAttributeString("contract", element.Contract.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.SubstitutingClassifier != null && writeContext.IsLocal(element.SubstitutingClassifier))
+            {
+                xmlWriter.WriteAttributeString("substitutingClassifier", element.SubstitutingClassifier.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "client", writeContext);
+            }
+
+            if (element.Contract != null && !writeContext.IsLocal(element.Contract))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Contract, "contract", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.SubstitutingClassifier != null && !writeContext.IsLocal(element.SubstitutingClassifier))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.SubstitutingClassifier, "substitutingClassifier", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ISubstitution"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ISubstitution"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ISubstitution element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Substitution with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Substitution");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Contract != null && writeContext.IsLocal(element.Contract))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "contract", null, element.Contract.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.SubstitutingClassifier != null && writeContext.IsLocal(element.SubstitutingClassifier))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "substitutingClassifier", null, element.SubstitutingClassifier.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "client", writeContext);
+            }
+
+            if (element.Contract != null && !writeContext.IsLocal(element.Contract))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Contract, "contract", writeContext);
+            }
+
+            foreach (var value in element.Mapping)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "mapping", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.SubstitutingClassifier != null && !writeContext.IsLocal(element.SubstitutingClassifier))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.SubstitutingClassifier, "substitutingClassifier", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateBindingWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateBindingWriter.cs
@@ -1,0 +1,266 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TemplateBindingWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TemplateBindingWriter"/> is to write an instance of <see cref="ITemplateBinding"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TemplateBindingWriter : XmiElementWriter<ITemplateBinding>, IXmiElementWriter<ITemplateBinding>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TemplateBindingWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateBindingWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TemplateBindingWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TemplateBindingWriter>.Instance : loggerFactory.CreateLogger<TemplateBindingWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITemplateBinding"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITemplateBinding"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITemplateBinding element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TemplateBinding with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateBinding");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.BoundElement != null && writeContext.IsLocal(element.BoundElement))
+            {
+                xmlWriter.WriteAttributeString("boundElement", element.BoundElement.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                xmlWriter.WriteAttributeString("signature", element.Signature.XmiId);
+            }
+
+
+            if (element.BoundElement != null && !writeContext.IsLocal(element.BoundElement))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.BoundElement, "boundElement", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.ParameterSubstitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "parameterSubstitution", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITemplateBinding"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITemplateBinding"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITemplateBinding element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TemplateBinding with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateBinding");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.BoundElement != null && writeContext.IsLocal(element.BoundElement))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "boundElement", null, element.BoundElement.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "signature", null, element.Signature.XmiId);
+            }
+
+
+            if (element.BoundElement != null && !writeContext.IsLocal(element.BoundElement))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.BoundElement, "boundElement", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.ParameterSubstitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "parameterSubstitution", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateParameterSubstitutionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateParameterSubstitutionWriter.cs
@@ -1,0 +1,286 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TemplateParameterSubstitutionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TemplateParameterSubstitutionWriter"/> is to write an instance of <see cref="ITemplateParameterSubstitution"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TemplateParameterSubstitutionWriter : XmiElementWriter<ITemplateParameterSubstitution>, IXmiElementWriter<ITemplateParameterSubstitution>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TemplateParameterSubstitutionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateParameterSubstitutionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TemplateParameterSubstitutionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TemplateParameterSubstitutionWriter>.Instance : loggerFactory.CreateLogger<TemplateParameterSubstitutionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITemplateParameterSubstitution"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITemplateParameterSubstitution"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITemplateParameterSubstitution element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TemplateParameterSubstitution with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateParameterSubstitution");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Actual != null && writeContext.IsLocal(element.Actual))
+            {
+                xmlWriter.WriteAttributeString("actual", element.Actual.XmiId);
+            }
+
+            if (element.Formal != null && writeContext.IsLocal(element.Formal))
+            {
+                xmlWriter.WriteAttributeString("formal", element.Formal.XmiId);
+            }
+
+            if (element.TemplateBinding != null && writeContext.IsLocal(element.TemplateBinding))
+            {
+                xmlWriter.WriteAttributeString("templateBinding", element.TemplateBinding.XmiId);
+            }
+
+
+            if (element.Actual != null && !writeContext.IsLocal(element.Actual))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Actual, "actual", writeContext);
+            }
+
+            if (element.Formal != null && !writeContext.IsLocal(element.Formal))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Formal, "formal", writeContext);
+            }
+
+            foreach (var value in element.OwnedActual)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedActual", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.TemplateBinding != null && !writeContext.IsLocal(element.TemplateBinding))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateBinding, "templateBinding", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITemplateParameterSubstitution"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITemplateParameterSubstitution"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITemplateParameterSubstitution element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TemplateParameterSubstitution with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateParameterSubstitution");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Actual != null && writeContext.IsLocal(element.Actual))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "actual", null, element.Actual.XmiId);
+            }
+
+            if (element.Formal != null && writeContext.IsLocal(element.Formal))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "formal", null, element.Formal.XmiId);
+            }
+
+            if (element.TemplateBinding != null && writeContext.IsLocal(element.TemplateBinding))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateBinding", null, element.TemplateBinding.XmiId);
+            }
+
+
+            if (element.Actual != null && !writeContext.IsLocal(element.Actual))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Actual, "actual", writeContext);
+            }
+
+            if (element.Formal != null && !writeContext.IsLocal(element.Formal))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Formal, "formal", writeContext);
+            }
+
+            foreach (var value in element.OwnedActual)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedActual", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.TemplateBinding != null && !writeContext.IsLocal(element.TemplateBinding))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateBinding, "templateBinding", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateParameterWriter.cs
@@ -1,0 +1,296 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TemplateParameterWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TemplateParameterWriter"/> is to write an instance of <see cref="ITemplateParameter"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TemplateParameterWriter : XmiElementWriter<ITemplateParameter>, IXmiElementWriter<ITemplateParameter>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TemplateParameterWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateParameterWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TemplateParameterWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TemplateParameterWriter>.Instance : loggerFactory.CreateLogger<TemplateParameterWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITemplateParameter"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITemplateParameter"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITemplateParameter element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TemplateParameter with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateParameter");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Default != null && writeContext.IsLocal(element.Default))
+            {
+                xmlWriter.WriteAttributeString("default", element.Default.XmiId);
+            }
+
+            if (element.ParameteredElement != null && writeContext.IsLocal(element.ParameteredElement))
+            {
+                xmlWriter.WriteAttributeString("parameteredElement", element.ParameteredElement.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                xmlWriter.WriteAttributeString("signature", element.Signature.XmiId);
+            }
+
+
+            if (element.Default != null && !writeContext.IsLocal(element.Default))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Default, "default", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedDefault)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedDefault", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameteredElement)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameteredElement", writeContext);
+            }
+
+            if (element.ParameteredElement != null && !writeContext.IsLocal(element.ParameteredElement))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ParameteredElement, "parameteredElement", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITemplateParameter"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITemplateParameter"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITemplateParameter element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TemplateParameter with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateParameter");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Default != null && writeContext.IsLocal(element.Default))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "default", null, element.Default.XmiId);
+            }
+
+            if (element.ParameteredElement != null && writeContext.IsLocal(element.ParameteredElement))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "parameteredElement", null, element.ParameteredElement.XmiId);
+            }
+
+            if (element.Signature != null && writeContext.IsLocal(element.Signature))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "signature", null, element.Signature.XmiId);
+            }
+
+
+            if (element.Default != null && !writeContext.IsLocal(element.Default))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Default, "default", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedDefault)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedDefault", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameteredElement)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameteredElement", writeContext);
+            }
+
+            if (element.ParameteredElement != null && !writeContext.IsLocal(element.ParameteredElement))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ParameteredElement, "parameteredElement", writeContext);
+            }
+
+            if (element.Signature != null && !writeContext.IsLocal(element.Signature))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateSignatureWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateSignatureWriter.cs
@@ -1,0 +1,256 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TemplateSignatureWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TemplateSignatureWriter"/> is to write an instance of <see cref="ITemplateSignature"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TemplateSignatureWriter : XmiElementWriter<ITemplateSignature>, IXmiElementWriter<ITemplateSignature>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TemplateSignatureWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateSignatureWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TemplateSignatureWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TemplateSignatureWriter>.Instance : loggerFactory.CreateLogger<TemplateSignatureWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITemplateSignature"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITemplateSignature"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITemplateSignature element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TemplateSignature with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateSignature");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Template != null && writeContext.IsLocal(element.Template))
+            {
+                xmlWriter.WriteAttributeString("template", element.Template.XmiId);
+            }
+
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.Parameter)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "parameter", writeContext);
+            }
+
+            if (element.Template != null && !writeContext.IsLocal(element.Template))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Template, "template", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITemplateSignature"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITemplateSignature"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITemplateSignature element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TemplateSignature with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateSignature");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Template != null && writeContext.IsLocal(element.Template))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "template", null, element.Template.XmiId);
+            }
+
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedParameter)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedParameter", writeContext);
+            }
+
+            foreach (var value in element.Parameter)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "parameter", writeContext);
+            }
+
+            if (element.Template != null && !writeContext.IsLocal(element.Template))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Template, "template", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TestIdentityActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TestIdentityActionWriter.cs
@@ -1,0 +1,416 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TestIdentityActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TestIdentityActionWriter"/> is to write an instance of <see cref="ITestIdentityAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TestIdentityActionWriter : XmiElementWriter<ITestIdentityAction>, IXmiElementWriter<ITestIdentityAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TestIdentityActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestIdentityActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TestIdentityActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TestIdentityActionWriter>.Instance : loggerFactory.CreateLogger<TestIdentityActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITestIdentityAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITestIdentityAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITestIdentityAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TestIdentityAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TestIdentityAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.First)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "first", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.Second)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "second", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITestIdentityAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITestIdentityAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITestIdentityAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TestIdentityAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TestIdentityAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.First)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "first", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.Second)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "second", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TimeConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeConstraintWriter.cs
@@ -1,0 +1,336 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TimeConstraintWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TimeConstraintWriter"/> is to write an instance of <see cref="ITimeConstraint"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TimeConstraintWriter : XmiElementWriter<ITimeConstraint>, IXmiElementWriter<ITimeConstraint>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TimeConstraintWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeConstraintWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TimeConstraintWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TimeConstraintWriter>.Instance : loggerFactory.CreateLogger<TimeConstraintWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITimeConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITimeConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeConstraint");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                xmlWriter.WriteAttributeString("context", element.Context.XmiId);
+            }
+
+            if (!element.FirstEvent)
+            {
+                xmlWriter.WriteAttributeString("firstEvent", XmlConvert.ToString(element.FirstEvent));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITimeConstraint"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeConstraint"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITimeConstraint element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeConstraint with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeConstraint");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Context != null && writeContext.IsLocal(element.Context))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "context", null, element.Context.XmiId);
+            }
+
+            if (!element.FirstEvent)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "firstEvent", null, XmlConvert.ToString(element.FirstEvent));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.ConstrainedElement)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "constrainedElement", writeContext);
+            }
+
+            if (element.Context != null && !writeContext.IsLocal(element.Context))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Context, "context", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Specification)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "specification", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TimeEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeEventWriter.cs
@@ -1,0 +1,306 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TimeEventWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TimeEventWriter"/> is to write an instance of <see cref="ITimeEvent"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TimeEventWriter : XmiElementWriter<ITimeEvent>, IXmiElementWriter<ITimeEvent>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TimeEventWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeEventWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TimeEventWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TimeEventWriter>.Instance : loggerFactory.CreateLogger<TimeEventWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITimeEvent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeEvent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITimeEvent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeEvent with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeEvent");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsRelative)
+            {
+                xmlWriter.WriteAttributeString("isRelative", XmlConvert.ToString(element.IsRelative));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.When)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "when", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITimeEvent"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeEvent"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITimeEvent element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeEvent with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeEvent");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.IsRelative)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isRelative", null, XmlConvert.ToString(element.IsRelative));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.When)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "when", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TimeExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeExpressionWriter.cs
@@ -1,0 +1,326 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TimeExpressionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TimeExpressionWriter"/> is to write an instance of <see cref="ITimeExpression"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TimeExpressionWriter : XmiElementWriter<ITimeExpression>, IXmiElementWriter<ITimeExpression>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TimeExpressionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeExpressionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TimeExpressionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TimeExpressionWriter>.Instance : loggerFactory.CreateLogger<TimeExpressionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITimeExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITimeExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeExpression with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeExpression");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Expr)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "expr", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Observation)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "observation", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITimeExpression"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeExpression"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITimeExpression element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeExpression with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeExpression");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Expr)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "expr", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Observation)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "observation", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TimeIntervalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeIntervalWriter.cs
@@ -1,0 +1,346 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TimeIntervalWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TimeIntervalWriter"/> is to write an instance of <see cref="ITimeInterval"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TimeIntervalWriter : XmiElementWriter<ITimeInterval>, IXmiElementWriter<ITimeInterval>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TimeIntervalWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeIntervalWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TimeIntervalWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TimeIntervalWriter>.Instance : loggerFactory.CreateLogger<TimeIntervalWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITimeInterval"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeInterval"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITimeInterval element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeInterval with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeInterval");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Max != null && writeContext.IsLocal(element.Max))
+            {
+                xmlWriter.WriteAttributeString("max", element.Max.XmiId);
+            }
+
+            if (element.Min != null && writeContext.IsLocal(element.Min))
+            {
+                xmlWriter.WriteAttributeString("min", element.Min.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Max != null && !writeContext.IsLocal(element.Max))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Max, "max", writeContext);
+            }
+
+            if (element.Min != null && !writeContext.IsLocal(element.Min))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Min, "min", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITimeInterval"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeInterval"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITimeInterval element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeInterval with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeInterval");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Max != null && writeContext.IsLocal(element.Max))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "max", null, element.Max.XmiId);
+            }
+
+            if (element.Min != null && writeContext.IsLocal(element.Min))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "min", null, element.Min.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Max != null && !writeContext.IsLocal(element.Max))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Max, "max", writeContext);
+            }
+
+            if (element.Min != null && !writeContext.IsLocal(element.Min))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Min, "min", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TimeObservationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeObservationWriter.cs
@@ -1,0 +1,316 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TimeObservationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TimeObservationWriter"/> is to write an instance of <see cref="ITimeObservation"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TimeObservationWriter : XmiElementWriter<ITimeObservation>, IXmiElementWriter<ITimeObservation>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TimeObservationWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeObservationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TimeObservationWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TimeObservationWriter>.Instance : loggerFactory.CreateLogger<TimeObservationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITimeObservation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeObservation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITimeObservation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeObservation with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeObservation");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Event != null && writeContext.IsLocal(element.Event))
+            {
+                xmlWriter.WriteAttributeString("event", element.Event.XmiId);
+            }
+
+            if (!element.FirstEvent)
+            {
+                xmlWriter.WriteAttributeString("firstEvent", XmlConvert.ToString(element.FirstEvent));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Event != null && !writeContext.IsLocal(element.Event))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Event, "event", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITimeObservation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITimeObservation"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITimeObservation element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the TimeObservation with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeObservation");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Event != null && writeContext.IsLocal(element.Event))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "event", null, element.Event.XmiId);
+            }
+
+            if (!element.FirstEvent)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "firstEvent", null, XmlConvert.ToString(element.FirstEvent));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Event != null && !writeContext.IsLocal(element.Event))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Event, "event", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TransitionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TransitionWriter.cs
@@ -1,0 +1,406 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TransitionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TransitionWriter"/> is to write an instance of <see cref="ITransition"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TransitionWriter : XmiElementWriter<ITransition>, IXmiElementWriter<ITransition>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TransitionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransitionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TransitionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TransitionWriter>.Instance : loggerFactory.CreateLogger<TransitionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITransition"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITransition"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITransition element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Transition with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Transition");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                xmlWriter.WriteAttributeString("container", element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.Kind != TransitionKind.External)
+            {
+                xmlWriter.WriteAttributeString("kind", LowerCaseFirstLetter(element.Kind.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.RedefinedTransition != null && writeContext.IsLocal(element.RedefinedTransition))
+            {
+                xmlWriter.WriteAttributeString("redefinedTransition", element.RedefinedTransition.XmiId);
+            }
+
+            if (element.Source != null && writeContext.IsLocal(element.Source))
+            {
+                xmlWriter.WriteAttributeString("source", element.Source.XmiId);
+            }
+
+            if (element.Target != null && writeContext.IsLocal(element.Target))
+            {
+                xmlWriter.WriteAttributeString("target", element.Target.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.Effect)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "effect", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Guard)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "guard", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            if (element.RedefinedTransition != null && !writeContext.IsLocal(element.RedefinedTransition))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.RedefinedTransition, "redefinedTransition", writeContext);
+            }
+
+            if (element.Source != null && !writeContext.IsLocal(element.Source))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Source, "source", writeContext);
+            }
+
+            if (element.Target != null && !writeContext.IsLocal(element.Target))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Target, "target", writeContext);
+            }
+
+            foreach (var value in element.Trigger)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "trigger", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITransition"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITransition"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITransition element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Transition with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Transition");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Container != null && writeContext.IsLocal(element.Container))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "container", null, element.Container.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.Kind != TransitionKind.External)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "kind", null, LowerCaseFirstLetter(element.Kind.ToString()));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.RedefinedTransition != null && writeContext.IsLocal(element.RedefinedTransition))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "redefinedTransition", null, element.RedefinedTransition.XmiId);
+            }
+
+            if (element.Source != null && writeContext.IsLocal(element.Source))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "source", null, element.Source.XmiId);
+            }
+
+            if (element.Target != null && writeContext.IsLocal(element.Target))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "target", null, element.Target.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Container != null && !writeContext.IsLocal(element.Container))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Container, "container", writeContext);
+            }
+
+            foreach (var value in element.Effect)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "effect", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Guard)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "guard", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            if (element.RedefinedTransition != null && !writeContext.IsLocal(element.RedefinedTransition))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.RedefinedTransition, "redefinedTransition", writeContext);
+            }
+
+            if (element.Source != null && !writeContext.IsLocal(element.Source))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Source, "source", writeContext);
+            }
+
+            if (element.Target != null && !writeContext.IsLocal(element.Target))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Target, "target", writeContext);
+            }
+
+            foreach (var value in element.Trigger)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/TriggerWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TriggerWriter.cs
@@ -1,0 +1,276 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="TriggerWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="TriggerWriter"/> is to write an instance of <see cref="ITrigger"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class TriggerWriter : XmiElementWriter<ITrigger>, IXmiElementWriter<ITrigger>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<TriggerWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TriggerWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public TriggerWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<TriggerWriter>.Instance : loggerFactory.CreateLogger<TriggerWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="ITrigger"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITrigger"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, ITrigger element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Trigger with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Trigger");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Event != null && writeContext.IsLocal(element.Event))
+            {
+                xmlWriter.WriteAttributeString("event", element.Event.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Event != null && !writeContext.IsLocal(element.Event))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Event, "event", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.Port)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "port", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="ITrigger"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="ITrigger"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, ITrigger element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Trigger with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Trigger");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Event != null && writeContext.IsLocal(element.Event))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "event", null, element.Event.XmiId);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Event != null && !writeContext.IsLocal(element.Event))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Event, "event", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.Port)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "port", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/UnmarshallActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/UnmarshallActionWriter.cs
@@ -1,0 +1,426 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="UnmarshallActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="UnmarshallActionWriter"/> is to write an instance of <see cref="IUnmarshallAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class UnmarshallActionWriter : XmiElementWriter<IUnmarshallAction>, IXmiElementWriter<IUnmarshallAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<UnmarshallActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnmarshallActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public UnmarshallActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<UnmarshallActionWriter>.Instance : loggerFactory.CreateLogger<UnmarshallActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IUnmarshallAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IUnmarshallAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IUnmarshallAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the UnmarshallAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:UnmarshallAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.UnmarshallType != null && writeContext.IsLocal(element.UnmarshallType))
+            {
+                xmlWriter.WriteAttributeString("unmarshallType", element.UnmarshallType.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.UnmarshallType != null && !writeContext.IsLocal(element.UnmarshallType))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.UnmarshallType, "unmarshallType", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IUnmarshallAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IUnmarshallAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IUnmarshallAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the UnmarshallAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:UnmarshallAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.UnmarshallType != null && writeContext.IsLocal(element.UnmarshallType))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "unmarshallType", null, element.UnmarshallType.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Object)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "object", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            if (element.UnmarshallType != null && !writeContext.IsLocal(element.UnmarshallType))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.UnmarshallType, "unmarshallType", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/UsageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/UsageWriter.cs
@@ -1,0 +1,306 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="UsageWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="UsageWriter"/> is to write an instance of <see cref="IUsage"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class UsageWriter : XmiElementWriter<IUsage>, IXmiElementWriter<IUsage>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<UsageWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsageWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public UsageWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<UsageWriter>.Instance : loggerFactory.CreateLogger<UsageWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IUsage"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IUsage"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IUsage element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Usage with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Usage");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IUsage"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IUsage"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IUsage element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Usage with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Usage");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            foreach (var value in element.Client)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "client", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            foreach (var value in element.Supplier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "supplier", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/UseCaseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/UseCaseWriter.cs
@@ -1,0 +1,556 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="UseCaseWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="UseCaseWriter"/> is to write an instance of <see cref="IUseCase"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class UseCaseWriter : XmiElementWriter<IUseCase>, IXmiElementWriter<IUseCase>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<UseCaseWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UseCaseWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public UseCaseWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<UseCaseWriter>.Instance : loggerFactory.CreateLogger<UseCaseWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IUseCase"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IUseCase"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IUseCase element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the UseCase with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:UseCase");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                xmlWriter.WriteAttributeString("classifierBehavior", element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                xmlWriter.WriteAttributeString("isAbstract", XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                xmlWriter.WriteAttributeString("isFinalSpecialization", XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                xmlWriter.WriteAttributeString("package", element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                xmlWriter.WriteAttributeString("representation", element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Extend)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "extend", writeContext);
+            }
+
+            foreach (var value in element.ExtensionPoint)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "extensionPoint", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Include)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "include", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Subject)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "subject", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IUseCase"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IUseCase"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IUseCase element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the UseCase with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:UseCase");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ClassifierBehavior != null && writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "classifierBehavior", null, element.ClassifierBehavior.XmiId);
+            }
+
+            if (element.IsAbstract)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isAbstract", null, XmlConvert.ToString(element.IsAbstract));
+            }
+
+            if (element.IsFinalSpecialization)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isFinalSpecialization", null, XmlConvert.ToString(element.IsFinalSpecialization));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Package != null && writeContext.IsLocal(element.Package))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "package", null, element.Package.XmiId);
+            }
+
+            if (element.Representation != null && writeContext.IsLocal(element.Representation))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "representation", null, element.Representation.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Visibility != VisibilityKind.Public)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ClassifierBehavior != null && !writeContext.IsLocal(element.ClassifierBehavior))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ClassifierBehavior, "classifierBehavior", writeContext);
+            }
+
+            foreach (var value in element.CollaborationUse)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "collaborationUse", writeContext);
+            }
+
+            foreach (var value in element.ElementImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "elementImport", writeContext);
+            }
+
+            foreach (var value in element.Extend)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "extend", writeContext);
+            }
+
+            foreach (var value in element.ExtensionPoint)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "extensionPoint", writeContext);
+            }
+
+            foreach (var value in element.Generalization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "generalization", writeContext);
+            }
+
+            foreach (var value in element.Include)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "include", writeContext);
+            }
+
+            foreach (var value in element.InterfaceRealization)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "interfaceRealization", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedBehavior)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedBehavior", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.OwnedRule)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedRule", writeContext);
+            }
+
+            foreach (var value in element.OwnedTemplateSignature)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedTemplateSignature", writeContext);
+            }
+
+            foreach (var value in element.OwnedUseCase)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedUseCase", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Package != null && !writeContext.IsLocal(element.Package))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Package, "package", writeContext);
+            }
+
+            foreach (var value in element.PackageImport)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
+            }
+
+            foreach (var value in element.PowertypeExtent)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "powertypeExtent", writeContext);
+            }
+
+            foreach (var value in element.RedefinedClassifier)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedClassifier", writeContext);
+            }
+
+            if (element.Representation != null && !writeContext.IsLocal(element.Representation))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Representation, "representation", writeContext);
+            }
+
+            foreach (var value in element.Subject)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "subject", writeContext);
+            }
+
+            foreach (var value in element.Substitution)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "substitution", writeContext);
+            }
+
+            foreach (var value in element.TemplateBinding)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "templateBinding", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            foreach (var value in element.UseCases)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ValuePinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ValuePinWriter.cs
@@ -1,0 +1,486 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ValuePinWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ValuePinWriter"/> is to write an instance of <see cref="IValuePin"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ValuePinWriter : XmiElementWriter<IValuePin>, IXmiElementWriter<IValuePin>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ValuePinWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValuePinWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ValuePinWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ValuePinWriter>.Instance : loggerFactory.CreateLogger<ValuePinWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IValuePin"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IValuePin"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IValuePin element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ValuePin with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ValuePin");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControl)
+            {
+                xmlWriter.WriteAttributeString("isControl", XmlConvert.ToString(element.IsControl));
+            }
+
+            if (element.IsControlType)
+            {
+                xmlWriter.WriteAttributeString("isControlType", XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                xmlWriter.WriteAttributeString("ordering", LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                xmlWriter.WriteAttributeString("selection", element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperBound", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "value", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IValuePin"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IValuePin"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IValuePin element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ValuePin with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ValuePin");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsControl)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControl", null, XmlConvert.ToString(element.IsControl));
+            }
+
+            if (element.IsControlType)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isControlType", null, XmlConvert.ToString(element.IsControlType));
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Ordering != ObjectNodeOrderingKind.FIFO)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "ordering", null, LowerCaseFirstLetter(element.Ordering.ToString()));
+            }
+
+            if (element.Selection != null && writeContext.IsLocal(element.Selection))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "selection", null, element.Selection.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            foreach (var value in element.InState)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inState", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            if (element.Selection != null && !writeContext.IsLocal(element.Selection))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Selection, "selection", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperBound)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/ValueSpecificationActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ValueSpecificationActionWriter.cs
@@ -1,0 +1,406 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ValueSpecificationActionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ValueSpecificationActionWriter"/> is to write an instance of <see cref="IValueSpecificationAction"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class ValueSpecificationActionWriter : XmiElementWriter<IValueSpecificationAction>, IXmiElementWriter<IValueSpecificationAction>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<ValueSpecificationActionWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueSpecificationActionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public ValueSpecificationActionWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<ValueSpecificationActionWriter>.Instance : loggerFactory.CreateLogger<ValueSpecificationActionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IValueSpecificationAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IValueSpecificationAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IValueSpecificationAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ValueSpecificationAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ValueSpecificationAction");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                xmlWriter.WriteAttributeString("activity", element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                xmlWriter.WriteAttributeString("inStructuredNode", element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                xmlWriter.WriteAttributeString("isLeaf", XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                xmlWriter.WriteAttributeString("isLocallyReentrant", XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "value", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IValueSpecificationAction"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IValueSpecificationAction"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IValueSpecificationAction element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the ValueSpecificationAction with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ValueSpecificationAction");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.Activity != null && writeContext.IsLocal(element.Activity))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activity", null, element.Activity.XmiId);
+            }
+
+            if (element.InStructuredNode != null && writeContext.IsLocal(element.InStructuredNode))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "inStructuredNode", null, element.InStructuredNode.XmiId);
+            }
+
+            if (element.IsLeaf)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLeaf", null, XmlConvert.ToString(element.IsLeaf));
+            }
+
+            if (element.IsLocallyReentrant)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isLocallyReentrant", null, XmlConvert.ToString(element.IsLocallyReentrant));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.Activity != null && !writeContext.IsLocal(element.Activity))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Activity, "activity", writeContext);
+            }
+
+            foreach (var value in element.Handler)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "handler", writeContext);
+            }
+
+            foreach (var value in element.Incoming)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "incoming", writeContext);
+            }
+
+            foreach (var value in element.InInterruptibleRegion)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inInterruptibleRegion", writeContext);
+            }
+
+            foreach (var value in element.InPartition)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "inPartition", writeContext);
+            }
+
+            if (element.InStructuredNode != null && !writeContext.IsLocal(element.InStructuredNode))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.InStructuredNode, "inStructuredNode", writeContext);
+            }
+
+            foreach (var value in element.LocalPostcondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPostcondition", writeContext);
+            }
+
+            foreach (var value in element.LocalPrecondition)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "localPrecondition", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.Outgoing)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "outgoing", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            foreach (var value in element.RedefinedNode)
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
+            }
+
+            foreach (var value in element.Result)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
+            }
+
+            foreach (var value in element.Value)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/VariableWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/VariableWriter.cs
@@ -1,0 +1,386 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="VariableWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="VariableWriter"/> is to write an instance of <see cref="IVariable"/>
+    /// to an XMI document
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class VariableWriter : XmiElementWriter<IVariable>, IXmiElementWriter<IVariable>
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<VariableWriter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VariableWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public VariableWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+            : base(xmiElementWriterFacade, xmiWriterSettings, loggerFactory)
+        {
+            this.logger = loggerFactory == null ? NullLogger<VariableWriter>.Instance : loggerFactory.CreateLogger<VariableWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="IVariable"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IVariable"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public override void Write(XmlWriter xmlWriter, IVariable element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Variable with id [{Id}] are not written", element.XmiId);
+            }
+
+            this.WriteStartElement(xmlWriter, elementName);
+
+            xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Variable");
+
+            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ActivityScope != null && writeContext.IsLocal(element.ActivityScope))
+            {
+                xmlWriter.WriteAttributeString("activityScope", element.ActivityScope.XmiId);
+            }
+
+            if (element.IsOrdered)
+            {
+                xmlWriter.WriteAttributeString("isOrdered", XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                xmlWriter.WriteAttributeString("isUnique", XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                xmlWriter.WriteAttributeString("name", element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("owningTemplateParameter", element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Scope != null && writeContext.IsLocal(element.Scope))
+            {
+                xmlWriter.WriteAttributeString("scope", element.Scope.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                xmlWriter.WriteAttributeString("templateParameter", element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                xmlWriter.WriteAttributeString("type", element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                xmlWriter.WriteAttributeString("visibility", LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ActivityScope != null && !writeContext.IsLocal(element.ActivityScope))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ActivityScope, "activityScope", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Scope != null && !writeContext.IsLocal(element.Scope))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Scope, "scope", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="IVariable"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IVariable"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public override async Task WriteAsync(XmlWriter xmlWriter, IVariable element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (string.IsNullOrEmpty(elementName))
+            {
+                throw new ArgumentException(nameof(elementName));
+            }
+
+            if (writeContext == null)
+            {
+                throw new ArgumentNullException(nameof(writeContext));
+            }
+
+            if (element.Extensions.Count > 0)
+            {
+                this.logger.LogWarning("The Extensions of the Variable with id [{Id}] are not written", element.XmiId);
+            }
+
+            await this.WriteStartElementAsync(xmlWriter, elementName);
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Variable");
+
+            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+
+            if (!string.IsNullOrEmpty(element.XmiGuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.XmiWriterSettings.XmiNamespaceUri, element.XmiGuid);
+            }
+
+            if (element.ActivityScope != null && writeContext.IsLocal(element.ActivityScope))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "activityScope", null, element.ActivityScope.XmiId);
+            }
+
+            if (element.IsOrdered)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isOrdered", null, XmlConvert.ToString(element.IsOrdered));
+            }
+
+            if (!element.IsUnique)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "isUnique", null, XmlConvert.ToString(element.IsUnique));
+            }
+
+            if (!string.IsNullOrEmpty(element.Name))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "name", null, element.Name);
+            }
+
+            if (element.OwningTemplateParameter != null && writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "owningTemplateParameter", null, element.OwningTemplateParameter.XmiId);
+            }
+
+            if (element.Scope != null && writeContext.IsLocal(element.Scope))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "scope", null, element.Scope.XmiId);
+            }
+
+            if (element.TemplateParameter != null && writeContext.IsLocal(element.TemplateParameter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "templateParameter", null, element.TemplateParameter.XmiId);
+            }
+
+            if (element.Type != null && writeContext.IsLocal(element.Type))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "type", null, element.Type.XmiId);
+            }
+
+            if (element.Visibility != default(VisibilityKind))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "visibility", null, LowerCaseFirstLetter(element.Visibility.ToString()));
+            }
+
+
+            if (element.ActivityScope != null && !writeContext.IsLocal(element.ActivityScope))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ActivityScope, "activityScope", writeContext);
+            }
+
+            foreach (var value in element.LowerValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "lowerValue", writeContext);
+            }
+
+            foreach (var value in element.NameExpression)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "nameExpression", writeContext);
+            }
+
+            foreach (var value in element.OwnedComment)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
+            }
+
+            if (element.OwningTemplateParameter != null && !writeContext.IsLocal(element.OwningTemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.OwningTemplateParameter, "owningTemplateParameter", writeContext);
+            }
+
+            if (element.Scope != null && !writeContext.IsLocal(element.Scope))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Scope, "scope", writeContext);
+            }
+
+            if (element.TemplateParameter != null && !writeContext.IsLocal(element.TemplateParameter))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
+            }
+
+            if (element.Type != null && !writeContext.IsLocal(element.Type))
+            {
+                await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
+            }
+
+            foreach (var value in element.UpperValue)
+            {
+                await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
+            }
+
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/AutoGenXmiWriters/XmiElementWriterFacade.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/XmiElementWriterFacade.cs
@@ -1,0 +1,2309 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiElementWriterFacade.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+
+    using uml4net;
+    using uml4net.Actions;
+    using uml4net.Activities;
+    using uml4net.Classification;
+    using uml4net.CommonBehavior;
+    using uml4net.CommonStructure;
+    using uml4net.Deployments;
+    using uml4net.InformationFlows;
+    using uml4net.Interactions;
+    using uml4net.Packages;
+    using uml4net.SimpleClassifiers;
+    using uml4net.StateMachines;
+    using uml4net.StructuredClassifiers;
+    using uml4net.UseCases;
+    using uml4net.Values;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="XmiElementWriterFacade"/> is to write an <see cref="IXmiElement"/> to an
+    /// <see cref="XmlWriter"/> using the appropriate <see cref="IXmiElementWriter{TXmiElement}"/> based on the
+    /// concrete type of the <see cref="IXmiElement"/>
+    /// </summary>
+    [GeneratedCode("uml4net", "latest")]
+    public class XmiElementWriterFacade : IXmiElementWriterFacade
+    {
+        /// <summary>
+        /// The injected <see cref="IXmiWriterSettings" /> that provides XMI writer settings
+        /// </summary>
+        private readonly IXmiWriterSettings xmiWriterSettings;
+
+        /// <summary>
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </summary>
+        private readonly ILoggerFactory loggerFactory;
+
+        /// <summary>
+        /// A dictionary that contains delegates to write an <see cref="IXmiElement"/> based on the name of
+        /// the concrete type of the <see cref="IXmiElement"/>
+        /// </summary>
+        private readonly Dictionary<string, Action<XmlWriter, IXmiElement, string, IXmiWriteContext>> writerCache;
+
+        /// <summary>
+        /// A dictionary that contains delegates to asynchronously write an <see cref="IXmiElement"/> based on the name of
+        /// the concrete type of the <see cref="IXmiElement"/>
+        /// </summary>
+        private readonly Dictionary<string, Func<XmlWriter, IXmiElement, string, IXmiWriteContext, Task>> writerAsyncCache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmiElementWriterFacade"/> class.
+        /// </summary>
+        /// <param name="xmiWriterSettings">
+        /// The injected <see cref="IXmiWriterSettings" /> that provides XMI writer settings
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public XmiElementWriterFacade(IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+        {
+            this.xmiWriterSettings = xmiWriterSettings;
+            this.loggerFactory = loggerFactory;
+
+            this.writerCache = new Dictionary<string, Action<XmlWriter, IXmiElement, string, IXmiWriteContext>>
+            {
+                ["Activity"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var activityWriter = new ActivityWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    activityWriter.Write(xmlWriter, (IActivity)element, elementName, writeContext);
+                },
+                ["ActivityFinalNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var activityFinalNodeWriter = new ActivityFinalNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    activityFinalNodeWriter.Write(xmlWriter, (IActivityFinalNode)element, elementName, writeContext);
+                },
+                ["ActivityParameterNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var activityParameterNodeWriter = new ActivityParameterNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    activityParameterNodeWriter.Write(xmlWriter, (IActivityParameterNode)element, elementName, writeContext);
+                },
+                ["ActivityPartition"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var activityPartitionWriter = new ActivityPartitionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    activityPartitionWriter.Write(xmlWriter, (IActivityPartition)element, elementName, writeContext);
+                },
+                ["CentralBufferNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var centralBufferNodeWriter = new CentralBufferNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    centralBufferNodeWriter.Write(xmlWriter, (ICentralBufferNode)element, elementName, writeContext);
+                },
+                ["ControlFlow"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var controlFlowWriter = new ControlFlowWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    controlFlowWriter.Write(xmlWriter, (IControlFlow)element, elementName, writeContext);
+                },
+                ["DataStoreNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var dataStoreNodeWriter = new DataStoreNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    dataStoreNodeWriter.Write(xmlWriter, (IDataStoreNode)element, elementName, writeContext);
+                },
+                ["DecisionNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var decisionNodeWriter = new DecisionNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    decisionNodeWriter.Write(xmlWriter, (IDecisionNode)element, elementName, writeContext);
+                },
+                ["ExceptionHandler"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var exceptionHandlerWriter = new ExceptionHandlerWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    exceptionHandlerWriter.Write(xmlWriter, (IExceptionHandler)element, elementName, writeContext);
+                },
+                ["FlowFinalNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var flowFinalNodeWriter = new FlowFinalNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    flowFinalNodeWriter.Write(xmlWriter, (IFlowFinalNode)element, elementName, writeContext);
+                },
+                ["ForkNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var forkNodeWriter = new ForkNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    forkNodeWriter.Write(xmlWriter, (IForkNode)element, elementName, writeContext);
+                },
+                ["InitialNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var initialNodeWriter = new InitialNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    initialNodeWriter.Write(xmlWriter, (IInitialNode)element, elementName, writeContext);
+                },
+                ["InterruptibleActivityRegion"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interruptibleActivityRegionWriter = new InterruptibleActivityRegionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    interruptibleActivityRegionWriter.Write(xmlWriter, (IInterruptibleActivityRegion)element, elementName, writeContext);
+                },
+                ["JoinNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var joinNodeWriter = new JoinNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    joinNodeWriter.Write(xmlWriter, (IJoinNode)element, elementName, writeContext);
+                },
+                ["MergeNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var mergeNodeWriter = new MergeNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    mergeNodeWriter.Write(xmlWriter, (IMergeNode)element, elementName, writeContext);
+                },
+                ["ObjectFlow"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var objectFlowWriter = new ObjectFlowWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    objectFlowWriter.Write(xmlWriter, (IObjectFlow)element, elementName, writeContext);
+                },
+                ["Variable"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var variableWriter = new VariableWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    variableWriter.Write(xmlWriter, (IVariable)element, elementName, writeContext);
+                },
+                ["Duration"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var durationWriter = new DurationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    durationWriter.Write(xmlWriter, (IDuration)element, elementName, writeContext);
+                },
+                ["DurationConstraint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var durationConstraintWriter = new DurationConstraintWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    durationConstraintWriter.Write(xmlWriter, (IDurationConstraint)element, elementName, writeContext);
+                },
+                ["DurationInterval"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var durationIntervalWriter = new DurationIntervalWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    durationIntervalWriter.Write(xmlWriter, (IDurationInterval)element, elementName, writeContext);
+                },
+                ["DurationObservation"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var durationObservationWriter = new DurationObservationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    durationObservationWriter.Write(xmlWriter, (IDurationObservation)element, elementName, writeContext);
+                },
+                ["Expression"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var expressionWriter = new ExpressionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    expressionWriter.Write(xmlWriter, (IExpression)element, elementName, writeContext);
+                },
+                ["Interval"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var intervalWriter = new IntervalWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    intervalWriter.Write(xmlWriter, (IInterval)element, elementName, writeContext);
+                },
+                ["IntervalConstraint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var intervalConstraintWriter = new IntervalConstraintWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    intervalConstraintWriter.Write(xmlWriter, (IIntervalConstraint)element, elementName, writeContext);
+                },
+                ["LiteralBoolean"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalBooleanWriter = new LiteralBooleanWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    literalBooleanWriter.Write(xmlWriter, (ILiteralBoolean)element, elementName, writeContext);
+                },
+                ["LiteralInteger"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalIntegerWriter = new LiteralIntegerWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    literalIntegerWriter.Write(xmlWriter, (ILiteralInteger)element, elementName, writeContext);
+                },
+                ["LiteralNull"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalNullWriter = new LiteralNullWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    literalNullWriter.Write(xmlWriter, (ILiteralNull)element, elementName, writeContext);
+                },
+                ["LiteralReal"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalRealWriter = new LiteralRealWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    literalRealWriter.Write(xmlWriter, (ILiteralReal)element, elementName, writeContext);
+                },
+                ["LiteralString"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalStringWriter = new LiteralStringWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    literalStringWriter.Write(xmlWriter, (ILiteralString)element, elementName, writeContext);
+                },
+                ["LiteralUnlimitedNatural"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalUnlimitedNaturalWriter = new LiteralUnlimitedNaturalWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    literalUnlimitedNaturalWriter.Write(xmlWriter, (ILiteralUnlimitedNatural)element, elementName, writeContext);
+                },
+                ["OpaqueExpression"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var opaqueExpressionWriter = new OpaqueExpressionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    opaqueExpressionWriter.Write(xmlWriter, (IOpaqueExpression)element, elementName, writeContext);
+                },
+                ["StringExpression"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var stringExpressionWriter = new StringExpressionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    stringExpressionWriter.Write(xmlWriter, (IStringExpression)element, elementName, writeContext);
+                },
+                ["TimeConstraint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var timeConstraintWriter = new TimeConstraintWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    timeConstraintWriter.Write(xmlWriter, (ITimeConstraint)element, elementName, writeContext);
+                },
+                ["TimeExpression"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var timeExpressionWriter = new TimeExpressionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    timeExpressionWriter.Write(xmlWriter, (ITimeExpression)element, elementName, writeContext);
+                },
+                ["TimeInterval"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var timeIntervalWriter = new TimeIntervalWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    timeIntervalWriter.Write(xmlWriter, (ITimeInterval)element, elementName, writeContext);
+                },
+                ["TimeObservation"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var timeObservationWriter = new TimeObservationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    timeObservationWriter.Write(xmlWriter, (ITimeObservation)element, elementName, writeContext);
+                },
+                ["Actor"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var actorWriter = new ActorWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    actorWriter.Write(xmlWriter, (IActor)element, elementName, writeContext);
+                },
+                ["Extend"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var extendWriter = new ExtendWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    extendWriter.Write(xmlWriter, (IExtend)element, elementName, writeContext);
+                },
+                ["ExtensionPoint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var extensionPointWriter = new ExtensionPointWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    extensionPointWriter.Write(xmlWriter, (IExtensionPoint)element, elementName, writeContext);
+                },
+                ["Include"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var includeWriter = new IncludeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    includeWriter.Write(xmlWriter, (IInclude)element, elementName, writeContext);
+                },
+                ["UseCase"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var useCaseWriter = new UseCaseWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    useCaseWriter.Write(xmlWriter, (IUseCase)element, elementName, writeContext);
+                },
+                ["Association"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var associationWriter = new AssociationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    associationWriter.Write(xmlWriter, (IAssociation)element, elementName, writeContext);
+                },
+                ["AssociationClass"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var associationClassWriter = new AssociationClassWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    associationClassWriter.Write(xmlWriter, (IAssociationClass)element, elementName, writeContext);
+                },
+                ["Class"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var classWriter = new ClassWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    classWriter.Write(xmlWriter, (IClass)element, elementName, writeContext);
+                },
+                ["Collaboration"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var collaborationWriter = new CollaborationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    collaborationWriter.Write(xmlWriter, (ICollaboration)element, elementName, writeContext);
+                },
+                ["CollaborationUse"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var collaborationUseWriter = new CollaborationUseWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    collaborationUseWriter.Write(xmlWriter, (ICollaborationUse)element, elementName, writeContext);
+                },
+                ["Component"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var componentWriter = new ComponentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    componentWriter.Write(xmlWriter, (IComponent)element, elementName, writeContext);
+                },
+                ["ComponentRealization"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var componentRealizationWriter = new ComponentRealizationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    componentRealizationWriter.Write(xmlWriter, (IComponentRealization)element, elementName, writeContext);
+                },
+                ["ConnectableElementTemplateParameter"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var connectableElementTemplateParameterWriter = new ConnectableElementTemplateParameterWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    connectableElementTemplateParameterWriter.Write(xmlWriter, (IConnectableElementTemplateParameter)element, elementName, writeContext);
+                },
+                ["Connector"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var connectorWriter = new ConnectorWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    connectorWriter.Write(xmlWriter, (IConnector)element, elementName, writeContext);
+                },
+                ["ConnectorEnd"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var connectorEndWriter = new ConnectorEndWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    connectorEndWriter.Write(xmlWriter, (IConnectorEnd)element, elementName, writeContext);
+                },
+                ["Port"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var portWriter = new PortWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    portWriter.Write(xmlWriter, (IPort)element, elementName, writeContext);
+                },
+                ["ConnectionPointReference"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var connectionPointReferenceWriter = new ConnectionPointReferenceWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    connectionPointReferenceWriter.Write(xmlWriter, (IConnectionPointReference)element, elementName, writeContext);
+                },
+                ["FinalState"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var finalStateWriter = new FinalStateWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    finalStateWriter.Write(xmlWriter, (IFinalState)element, elementName, writeContext);
+                },
+                ["ProtocolConformance"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var protocolConformanceWriter = new ProtocolConformanceWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    protocolConformanceWriter.Write(xmlWriter, (IProtocolConformance)element, elementName, writeContext);
+                },
+                ["ProtocolStateMachine"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var protocolStateMachineWriter = new ProtocolStateMachineWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    protocolStateMachineWriter.Write(xmlWriter, (IProtocolStateMachine)element, elementName, writeContext);
+                },
+                ["ProtocolTransition"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var protocolTransitionWriter = new ProtocolTransitionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    protocolTransitionWriter.Write(xmlWriter, (IProtocolTransition)element, elementName, writeContext);
+                },
+                ["Pseudostate"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var pseudostateWriter = new PseudostateWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    pseudostateWriter.Write(xmlWriter, (IPseudostate)element, elementName, writeContext);
+                },
+                ["Region"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var regionWriter = new RegionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    regionWriter.Write(xmlWriter, (IRegion)element, elementName, writeContext);
+                },
+                ["State"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var stateWriter = new StateWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    stateWriter.Write(xmlWriter, (IState)element, elementName, writeContext);
+                },
+                ["StateMachine"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var stateMachineWriter = new StateMachineWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    stateMachineWriter.Write(xmlWriter, (IStateMachine)element, elementName, writeContext);
+                },
+                ["Transition"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var transitionWriter = new TransitionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    transitionWriter.Write(xmlWriter, (ITransition)element, elementName, writeContext);
+                },
+                ["DataType"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var dataTypeWriter = new DataTypeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    dataTypeWriter.Write(xmlWriter, (IDataType)element, elementName, writeContext);
+                },
+                ["Enumeration"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var enumerationWriter = new EnumerationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    enumerationWriter.Write(xmlWriter, (IEnumeration)element, elementName, writeContext);
+                },
+                ["EnumerationLiteral"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var enumerationLiteralWriter = new EnumerationLiteralWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    enumerationLiteralWriter.Write(xmlWriter, (IEnumerationLiteral)element, elementName, writeContext);
+                },
+                ["Interface"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interfaceWriter = new InterfaceWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    interfaceWriter.Write(xmlWriter, (IInterface)element, elementName, writeContext);
+                },
+                ["InterfaceRealization"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interfaceRealizationWriter = new InterfaceRealizationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    interfaceRealizationWriter.Write(xmlWriter, (IInterfaceRealization)element, elementName, writeContext);
+                },
+                ["PrimitiveType"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var primitiveTypeWriter = new PrimitiveTypeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    primitiveTypeWriter.Write(xmlWriter, (IPrimitiveType)element, elementName, writeContext);
+                },
+                ["Reception"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var receptionWriter = new ReceptionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    receptionWriter.Write(xmlWriter, (IReception)element, elementName, writeContext);
+                },
+                ["Signal"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var signalWriter = new SignalWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    signalWriter.Write(xmlWriter, (ISignal)element, elementName, writeContext);
+                },
+                ["Extension"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var extensionWriter = new ExtensionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    extensionWriter.Write(xmlWriter, (IExtension)element, elementName, writeContext);
+                },
+                ["ExtensionEnd"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var extensionEndWriter = new ExtensionEndWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    extensionEndWriter.Write(xmlWriter, (IExtensionEnd)element, elementName, writeContext);
+                },
+                ["Image"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var imageWriter = new ImageWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    imageWriter.Write(xmlWriter, (IImage)element, elementName, writeContext);
+                },
+                ["Model"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var modelWriter = new ModelWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    modelWriter.Write(xmlWriter, (IModel)element, elementName, writeContext);
+                },
+                ["Package"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var packageWriter = new PackageWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    packageWriter.Write(xmlWriter, (IPackage)element, elementName, writeContext);
+                },
+                ["PackageMerge"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var packageMergeWriter = new PackageMergeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    packageMergeWriter.Write(xmlWriter, (IPackageMerge)element, elementName, writeContext);
+                },
+                ["Profile"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var profileWriter = new ProfileWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    profileWriter.Write(xmlWriter, (IProfile)element, elementName, writeContext);
+                },
+                ["ProfileApplication"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var profileApplicationWriter = new ProfileApplicationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    profileApplicationWriter.Write(xmlWriter, (IProfileApplication)element, elementName, writeContext);
+                },
+                ["Stereotype"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var stereotypeWriter = new StereotypeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    stereotypeWriter.Write(xmlWriter, (IStereotype)element, elementName, writeContext);
+                },
+                ["ActionExecutionSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var actionExecutionSpecificationWriter = new ActionExecutionSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    actionExecutionSpecificationWriter.Write(xmlWriter, (IActionExecutionSpecification)element, elementName, writeContext);
+                },
+                ["BehaviorExecutionSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var behaviorExecutionSpecificationWriter = new BehaviorExecutionSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    behaviorExecutionSpecificationWriter.Write(xmlWriter, (IBehaviorExecutionSpecification)element, elementName, writeContext);
+                },
+                ["CombinedFragment"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var combinedFragmentWriter = new CombinedFragmentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    combinedFragmentWriter.Write(xmlWriter, (ICombinedFragment)element, elementName, writeContext);
+                },
+                ["ConsiderIgnoreFragment"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var considerIgnoreFragmentWriter = new ConsiderIgnoreFragmentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    considerIgnoreFragmentWriter.Write(xmlWriter, (IConsiderIgnoreFragment)element, elementName, writeContext);
+                },
+                ["Continuation"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var continuationWriter = new ContinuationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    continuationWriter.Write(xmlWriter, (IContinuation)element, elementName, writeContext);
+                },
+                ["DestructionOccurrenceSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var destructionOccurrenceSpecificationWriter = new DestructionOccurrenceSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    destructionOccurrenceSpecificationWriter.Write(xmlWriter, (IDestructionOccurrenceSpecification)element, elementName, writeContext);
+                },
+                ["ExecutionOccurrenceSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var executionOccurrenceSpecificationWriter = new ExecutionOccurrenceSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    executionOccurrenceSpecificationWriter.Write(xmlWriter, (IExecutionOccurrenceSpecification)element, elementName, writeContext);
+                },
+                ["Gate"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var gateWriter = new GateWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    gateWriter.Write(xmlWriter, (IGate)element, elementName, writeContext);
+                },
+                ["GeneralOrdering"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var generalOrderingWriter = new GeneralOrderingWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    generalOrderingWriter.Write(xmlWriter, (IGeneralOrdering)element, elementName, writeContext);
+                },
+                ["Interaction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interactionWriter = new InteractionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    interactionWriter.Write(xmlWriter, (IInteraction)element, elementName, writeContext);
+                },
+                ["InteractionConstraint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interactionConstraintWriter = new InteractionConstraintWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    interactionConstraintWriter.Write(xmlWriter, (IInteractionConstraint)element, elementName, writeContext);
+                },
+                ["InteractionOperand"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interactionOperandWriter = new InteractionOperandWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    interactionOperandWriter.Write(xmlWriter, (IInteractionOperand)element, elementName, writeContext);
+                },
+                ["InteractionUse"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interactionUseWriter = new InteractionUseWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    interactionUseWriter.Write(xmlWriter, (IInteractionUse)element, elementName, writeContext);
+                },
+                ["Lifeline"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var lifelineWriter = new LifelineWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    lifelineWriter.Write(xmlWriter, (ILifeline)element, elementName, writeContext);
+                },
+                ["Message"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var messageWriter = new MessageWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    messageWriter.Write(xmlWriter, (IMessage)element, elementName, writeContext);
+                },
+                ["MessageOccurrenceSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var messageOccurrenceSpecificationWriter = new MessageOccurrenceSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    messageOccurrenceSpecificationWriter.Write(xmlWriter, (IMessageOccurrenceSpecification)element, elementName, writeContext);
+                },
+                ["OccurrenceSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var occurrenceSpecificationWriter = new OccurrenceSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    occurrenceSpecificationWriter.Write(xmlWriter, (IOccurrenceSpecification)element, elementName, writeContext);
+                },
+                ["PartDecomposition"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var partDecompositionWriter = new PartDecompositionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    partDecompositionWriter.Write(xmlWriter, (IPartDecomposition)element, elementName, writeContext);
+                },
+                ["StateInvariant"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var stateInvariantWriter = new StateInvariantWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    stateInvariantWriter.Write(xmlWriter, (IStateInvariant)element, elementName, writeContext);
+                },
+                ["InformationFlow"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var informationFlowWriter = new InformationFlowWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    informationFlowWriter.Write(xmlWriter, (IInformationFlow)element, elementName, writeContext);
+                },
+                ["InformationItem"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var informationItemWriter = new InformationItemWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    informationItemWriter.Write(xmlWriter, (IInformationItem)element, elementName, writeContext);
+                },
+                ["Artifact"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var artifactWriter = new ArtifactWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    artifactWriter.Write(xmlWriter, (IArtifact)element, elementName, writeContext);
+                },
+                ["CommunicationPath"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var communicationPathWriter = new CommunicationPathWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    communicationPathWriter.Write(xmlWriter, (ICommunicationPath)element, elementName, writeContext);
+                },
+                ["Deployment"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var deploymentWriter = new DeploymentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    deploymentWriter.Write(xmlWriter, (IDeployment)element, elementName, writeContext);
+                },
+                ["DeploymentSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var deploymentSpecificationWriter = new DeploymentSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    deploymentSpecificationWriter.Write(xmlWriter, (IDeploymentSpecification)element, elementName, writeContext);
+                },
+                ["Device"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var deviceWriter = new DeviceWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    deviceWriter.Write(xmlWriter, (IDevice)element, elementName, writeContext);
+                },
+                ["ExecutionEnvironment"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var executionEnvironmentWriter = new ExecutionEnvironmentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    executionEnvironmentWriter.Write(xmlWriter, (IExecutionEnvironment)element, elementName, writeContext);
+                },
+                ["Manifestation"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var manifestationWriter = new ManifestationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    manifestationWriter.Write(xmlWriter, (IManifestation)element, elementName, writeContext);
+                },
+                ["Node"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var nodeWriter = new NodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    nodeWriter.Write(xmlWriter, (INode)element, elementName, writeContext);
+                },
+                ["Abstraction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var abstractionWriter = new AbstractionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    abstractionWriter.Write(xmlWriter, (IAbstraction)element, elementName, writeContext);
+                },
+                ["Comment"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var commentWriter = new CommentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    commentWriter.Write(xmlWriter, (IComment)element, elementName, writeContext);
+                },
+                ["Constraint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var constraintWriter = new ConstraintWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    constraintWriter.Write(xmlWriter, (IConstraint)element, elementName, writeContext);
+                },
+                ["Dependency"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var dependencyWriter = new DependencyWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    dependencyWriter.Write(xmlWriter, (IDependency)element, elementName, writeContext);
+                },
+                ["ElementImport"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var elementImportWriter = new ElementImportWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    elementImportWriter.Write(xmlWriter, (IElementImport)element, elementName, writeContext);
+                },
+                ["PackageImport"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var packageImportWriter = new PackageImportWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    packageImportWriter.Write(xmlWriter, (IPackageImport)element, elementName, writeContext);
+                },
+                ["Realization"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var realizationWriter = new RealizationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    realizationWriter.Write(xmlWriter, (IRealization)element, elementName, writeContext);
+                },
+                ["TemplateBinding"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var templateBindingWriter = new TemplateBindingWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    templateBindingWriter.Write(xmlWriter, (ITemplateBinding)element, elementName, writeContext);
+                },
+                ["TemplateParameter"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var templateParameterWriter = new TemplateParameterWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    templateParameterWriter.Write(xmlWriter, (ITemplateParameter)element, elementName, writeContext);
+                },
+                ["TemplateParameterSubstitution"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var templateParameterSubstitutionWriter = new TemplateParameterSubstitutionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    templateParameterSubstitutionWriter.Write(xmlWriter, (ITemplateParameterSubstitution)element, elementName, writeContext);
+                },
+                ["TemplateSignature"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var templateSignatureWriter = new TemplateSignatureWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    templateSignatureWriter.Write(xmlWriter, (ITemplateSignature)element, elementName, writeContext);
+                },
+                ["Usage"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var usageWriter = new UsageWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    usageWriter.Write(xmlWriter, (IUsage)element, elementName, writeContext);
+                },
+                ["AnyReceiveEvent"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var anyReceiveEventWriter = new AnyReceiveEventWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    anyReceiveEventWriter.Write(xmlWriter, (IAnyReceiveEvent)element, elementName, writeContext);
+                },
+                ["CallEvent"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var callEventWriter = new CallEventWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    callEventWriter.Write(xmlWriter, (ICallEvent)element, elementName, writeContext);
+                },
+                ["ChangeEvent"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var changeEventWriter = new ChangeEventWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    changeEventWriter.Write(xmlWriter, (IChangeEvent)element, elementName, writeContext);
+                },
+                ["FunctionBehavior"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var functionBehaviorWriter = new FunctionBehaviorWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    functionBehaviorWriter.Write(xmlWriter, (IFunctionBehavior)element, elementName, writeContext);
+                },
+                ["OpaqueBehavior"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var opaqueBehaviorWriter = new OpaqueBehaviorWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    opaqueBehaviorWriter.Write(xmlWriter, (IOpaqueBehavior)element, elementName, writeContext);
+                },
+                ["SignalEvent"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var signalEventWriter = new SignalEventWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    signalEventWriter.Write(xmlWriter, (ISignalEvent)element, elementName, writeContext);
+                },
+                ["TimeEvent"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var timeEventWriter = new TimeEventWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    timeEventWriter.Write(xmlWriter, (ITimeEvent)element, elementName, writeContext);
+                },
+                ["Trigger"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var triggerWriter = new TriggerWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    triggerWriter.Write(xmlWriter, (ITrigger)element, elementName, writeContext);
+                },
+                ["Substitution"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var substitutionWriter = new SubstitutionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    substitutionWriter.Write(xmlWriter, (ISubstitution)element, elementName, writeContext);
+                },
+                ["ClassifierTemplateParameter"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var classifierTemplateParameterWriter = new ClassifierTemplateParameterWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    classifierTemplateParameterWriter.Write(xmlWriter, (IClassifierTemplateParameter)element, elementName, writeContext);
+                },
+                ["Generalization"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var generalizationWriter = new GeneralizationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    generalizationWriter.Write(xmlWriter, (IGeneralization)element, elementName, writeContext);
+                },
+                ["GeneralizationSet"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var generalizationSetWriter = new GeneralizationSetWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    generalizationSetWriter.Write(xmlWriter, (IGeneralizationSet)element, elementName, writeContext);
+                },
+                ["InstanceSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var instanceSpecificationWriter = new InstanceSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    instanceSpecificationWriter.Write(xmlWriter, (IInstanceSpecification)element, elementName, writeContext);
+                },
+                ["InstanceValue"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var instanceValueWriter = new InstanceValueWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    instanceValueWriter.Write(xmlWriter, (IInstanceValue)element, elementName, writeContext);
+                },
+                ["Operation"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var operationWriter = new OperationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    operationWriter.Write(xmlWriter, (IOperation)element, elementName, writeContext);
+                },
+                ["OperationTemplateParameter"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var operationTemplateParameterWriter = new OperationTemplateParameterWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    operationTemplateParameterWriter.Write(xmlWriter, (IOperationTemplateParameter)element, elementName, writeContext);
+                },
+                ["Parameter"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var parameterWriter = new ParameterWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    parameterWriter.Write(xmlWriter, (IParameter)element, elementName, writeContext);
+                },
+                ["ParameterSet"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var parameterSetWriter = new ParameterSetWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    parameterSetWriter.Write(xmlWriter, (IParameterSet)element, elementName, writeContext);
+                },
+                ["Property"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var propertyWriter = new PropertyWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    propertyWriter.Write(xmlWriter, (IProperty)element, elementName, writeContext);
+                },
+                ["RedefinableTemplateSignature"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var redefinableTemplateSignatureWriter = new RedefinableTemplateSignatureWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    redefinableTemplateSignatureWriter.Write(xmlWriter, (IRedefinableTemplateSignature)element, elementName, writeContext);
+                },
+                ["Slot"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var slotWriter = new SlotWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    slotWriter.Write(xmlWriter, (ISlot)element, elementName, writeContext);
+                },
+                ["ValueSpecificationAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var valueSpecificationActionWriter = new ValueSpecificationActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    valueSpecificationActionWriter.Write(xmlWriter, (IValueSpecificationAction)element, elementName, writeContext);
+                },
+                ["AcceptCallAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var acceptCallActionWriter = new AcceptCallActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    acceptCallActionWriter.Write(xmlWriter, (IAcceptCallAction)element, elementName, writeContext);
+                },
+                ["AcceptEventAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var acceptEventActionWriter = new AcceptEventActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    acceptEventActionWriter.Write(xmlWriter, (IAcceptEventAction)element, elementName, writeContext);
+                },
+                ["ActionInputPin"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var actionInputPinWriter = new ActionInputPinWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    actionInputPinWriter.Write(xmlWriter, (IActionInputPin)element, elementName, writeContext);
+                },
+                ["AddStructuralFeatureValueAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var addStructuralFeatureValueActionWriter = new AddStructuralFeatureValueActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    addStructuralFeatureValueActionWriter.Write(xmlWriter, (IAddStructuralFeatureValueAction)element, elementName, writeContext);
+                },
+                ["AddVariableValueAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var addVariableValueActionWriter = new AddVariableValueActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    addVariableValueActionWriter.Write(xmlWriter, (IAddVariableValueAction)element, elementName, writeContext);
+                },
+                ["BroadcastSignalAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var broadcastSignalActionWriter = new BroadcastSignalActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    broadcastSignalActionWriter.Write(xmlWriter, (IBroadcastSignalAction)element, elementName, writeContext);
+                },
+                ["CallBehaviorAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var callBehaviorActionWriter = new CallBehaviorActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    callBehaviorActionWriter.Write(xmlWriter, (ICallBehaviorAction)element, elementName, writeContext);
+                },
+                ["CallOperationAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var callOperationActionWriter = new CallOperationActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    callOperationActionWriter.Write(xmlWriter, (ICallOperationAction)element, elementName, writeContext);
+                },
+                ["Clause"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var clauseWriter = new ClauseWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    clauseWriter.Write(xmlWriter, (IClause)element, elementName, writeContext);
+                },
+                ["ClearAssociationAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var clearAssociationActionWriter = new ClearAssociationActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    clearAssociationActionWriter.Write(xmlWriter, (IClearAssociationAction)element, elementName, writeContext);
+                },
+                ["ClearStructuralFeatureAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var clearStructuralFeatureActionWriter = new ClearStructuralFeatureActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    clearStructuralFeatureActionWriter.Write(xmlWriter, (IClearStructuralFeatureAction)element, elementName, writeContext);
+                },
+                ["ClearVariableAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var clearVariableActionWriter = new ClearVariableActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    clearVariableActionWriter.Write(xmlWriter, (IClearVariableAction)element, elementName, writeContext);
+                },
+                ["ConditionalNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var conditionalNodeWriter = new ConditionalNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    conditionalNodeWriter.Write(xmlWriter, (IConditionalNode)element, elementName, writeContext);
+                },
+                ["CreateLinkAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var createLinkActionWriter = new CreateLinkActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    createLinkActionWriter.Write(xmlWriter, (ICreateLinkAction)element, elementName, writeContext);
+                },
+                ["CreateLinkObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var createLinkObjectActionWriter = new CreateLinkObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    createLinkObjectActionWriter.Write(xmlWriter, (ICreateLinkObjectAction)element, elementName, writeContext);
+                },
+                ["CreateObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var createObjectActionWriter = new CreateObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    createObjectActionWriter.Write(xmlWriter, (ICreateObjectAction)element, elementName, writeContext);
+                },
+                ["DestroyLinkAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var destroyLinkActionWriter = new DestroyLinkActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    destroyLinkActionWriter.Write(xmlWriter, (IDestroyLinkAction)element, elementName, writeContext);
+                },
+                ["DestroyObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var destroyObjectActionWriter = new DestroyObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    destroyObjectActionWriter.Write(xmlWriter, (IDestroyObjectAction)element, elementName, writeContext);
+                },
+                ["ExpansionNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var expansionNodeWriter = new ExpansionNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    expansionNodeWriter.Write(xmlWriter, (IExpansionNode)element, elementName, writeContext);
+                },
+                ["ExpansionRegion"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var expansionRegionWriter = new ExpansionRegionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    expansionRegionWriter.Write(xmlWriter, (IExpansionRegion)element, elementName, writeContext);
+                },
+                ["InputPin"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var inputPinWriter = new InputPinWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    inputPinWriter.Write(xmlWriter, (IInputPin)element, elementName, writeContext);
+                },
+                ["LinkEndCreationData"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var linkEndCreationDataWriter = new LinkEndCreationDataWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    linkEndCreationDataWriter.Write(xmlWriter, (ILinkEndCreationData)element, elementName, writeContext);
+                },
+                ["LinkEndData"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var linkEndDataWriter = new LinkEndDataWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    linkEndDataWriter.Write(xmlWriter, (ILinkEndData)element, elementName, writeContext);
+                },
+                ["LinkEndDestructionData"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var linkEndDestructionDataWriter = new LinkEndDestructionDataWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    linkEndDestructionDataWriter.Write(xmlWriter, (ILinkEndDestructionData)element, elementName, writeContext);
+                },
+                ["LoopNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var loopNodeWriter = new LoopNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    loopNodeWriter.Write(xmlWriter, (ILoopNode)element, elementName, writeContext);
+                },
+                ["OpaqueAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var opaqueActionWriter = new OpaqueActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    opaqueActionWriter.Write(xmlWriter, (IOpaqueAction)element, elementName, writeContext);
+                },
+                ["OutputPin"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var outputPinWriter = new OutputPinWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    outputPinWriter.Write(xmlWriter, (IOutputPin)element, elementName, writeContext);
+                },
+                ["QualifierValue"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var qualifierValueWriter = new QualifierValueWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    qualifierValueWriter.Write(xmlWriter, (IQualifierValue)element, elementName, writeContext);
+                },
+                ["RaiseExceptionAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var raiseExceptionActionWriter = new RaiseExceptionActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    raiseExceptionActionWriter.Write(xmlWriter, (IRaiseExceptionAction)element, elementName, writeContext);
+                },
+                ["ReadExtentAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readExtentActionWriter = new ReadExtentActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    readExtentActionWriter.Write(xmlWriter, (IReadExtentAction)element, elementName, writeContext);
+                },
+                ["ReadIsClassifiedObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readIsClassifiedObjectActionWriter = new ReadIsClassifiedObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    readIsClassifiedObjectActionWriter.Write(xmlWriter, (IReadIsClassifiedObjectAction)element, elementName, writeContext);
+                },
+                ["ReadLinkAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readLinkActionWriter = new ReadLinkActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    readLinkActionWriter.Write(xmlWriter, (IReadLinkAction)element, elementName, writeContext);
+                },
+                ["ReadLinkObjectEndAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readLinkObjectEndActionWriter = new ReadLinkObjectEndActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    readLinkObjectEndActionWriter.Write(xmlWriter, (IReadLinkObjectEndAction)element, elementName, writeContext);
+                },
+                ["ReadLinkObjectEndQualifierAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readLinkObjectEndQualifierActionWriter = new ReadLinkObjectEndQualifierActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    readLinkObjectEndQualifierActionWriter.Write(xmlWriter, (IReadLinkObjectEndQualifierAction)element, elementName, writeContext);
+                },
+                ["ReadSelfAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readSelfActionWriter = new ReadSelfActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    readSelfActionWriter.Write(xmlWriter, (IReadSelfAction)element, elementName, writeContext);
+                },
+                ["ReadStructuralFeatureAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readStructuralFeatureActionWriter = new ReadStructuralFeatureActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    readStructuralFeatureActionWriter.Write(xmlWriter, (IReadStructuralFeatureAction)element, elementName, writeContext);
+                },
+                ["ReadVariableAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readVariableActionWriter = new ReadVariableActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    readVariableActionWriter.Write(xmlWriter, (IReadVariableAction)element, elementName, writeContext);
+                },
+                ["ReclassifyObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var reclassifyObjectActionWriter = new ReclassifyObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    reclassifyObjectActionWriter.Write(xmlWriter, (IReclassifyObjectAction)element, elementName, writeContext);
+                },
+                ["ReduceAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var reduceActionWriter = new ReduceActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    reduceActionWriter.Write(xmlWriter, (IReduceAction)element, elementName, writeContext);
+                },
+                ["RemoveStructuralFeatureValueAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var removeStructuralFeatureValueActionWriter = new RemoveStructuralFeatureValueActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    removeStructuralFeatureValueActionWriter.Write(xmlWriter, (IRemoveStructuralFeatureValueAction)element, elementName, writeContext);
+                },
+                ["RemoveVariableValueAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var removeVariableValueActionWriter = new RemoveVariableValueActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    removeVariableValueActionWriter.Write(xmlWriter, (IRemoveVariableValueAction)element, elementName, writeContext);
+                },
+                ["ReplyAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var replyActionWriter = new ReplyActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    replyActionWriter.Write(xmlWriter, (IReplyAction)element, elementName, writeContext);
+                },
+                ["SendObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var sendObjectActionWriter = new SendObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    sendObjectActionWriter.Write(xmlWriter, (ISendObjectAction)element, elementName, writeContext);
+                },
+                ["SendSignalAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var sendSignalActionWriter = new SendSignalActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    sendSignalActionWriter.Write(xmlWriter, (ISendSignalAction)element, elementName, writeContext);
+                },
+                ["SequenceNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var sequenceNodeWriter = new SequenceNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    sequenceNodeWriter.Write(xmlWriter, (ISequenceNode)element, elementName, writeContext);
+                },
+                ["StartClassifierBehaviorAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var startClassifierBehaviorActionWriter = new StartClassifierBehaviorActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    startClassifierBehaviorActionWriter.Write(xmlWriter, (IStartClassifierBehaviorAction)element, elementName, writeContext);
+                },
+                ["StartObjectBehaviorAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var startObjectBehaviorActionWriter = new StartObjectBehaviorActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    startObjectBehaviorActionWriter.Write(xmlWriter, (IStartObjectBehaviorAction)element, elementName, writeContext);
+                },
+                ["StructuredActivityNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var structuredActivityNodeWriter = new StructuredActivityNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    structuredActivityNodeWriter.Write(xmlWriter, (IStructuredActivityNode)element, elementName, writeContext);
+                },
+                ["TestIdentityAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var testIdentityActionWriter = new TestIdentityActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    testIdentityActionWriter.Write(xmlWriter, (ITestIdentityAction)element, elementName, writeContext);
+                },
+                ["UnmarshallAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var unmarshallActionWriter = new UnmarshallActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    unmarshallActionWriter.Write(xmlWriter, (IUnmarshallAction)element, elementName, writeContext);
+                },
+                ["ValuePin"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var valuePinWriter = new ValuePinWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    valuePinWriter.Write(xmlWriter, (IValuePin)element, elementName, writeContext);
+                },
+            };
+
+            this.writerAsyncCache = new Dictionary<string, Func<XmlWriter, IXmiElement, string, IXmiWriteContext, Task>>
+            {
+                ["Activity"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var activityWriter = new ActivityWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return activityWriter.WriteAsync(xmlWriter, (IActivity)element, elementName, writeContext);
+                },
+                ["ActivityFinalNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var activityFinalNodeWriter = new ActivityFinalNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return activityFinalNodeWriter.WriteAsync(xmlWriter, (IActivityFinalNode)element, elementName, writeContext);
+                },
+                ["ActivityParameterNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var activityParameterNodeWriter = new ActivityParameterNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return activityParameterNodeWriter.WriteAsync(xmlWriter, (IActivityParameterNode)element, elementName, writeContext);
+                },
+                ["ActivityPartition"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var activityPartitionWriter = new ActivityPartitionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return activityPartitionWriter.WriteAsync(xmlWriter, (IActivityPartition)element, elementName, writeContext);
+                },
+                ["CentralBufferNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var centralBufferNodeWriter = new CentralBufferNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return centralBufferNodeWriter.WriteAsync(xmlWriter, (ICentralBufferNode)element, elementName, writeContext);
+                },
+                ["ControlFlow"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var controlFlowWriter = new ControlFlowWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return controlFlowWriter.WriteAsync(xmlWriter, (IControlFlow)element, elementName, writeContext);
+                },
+                ["DataStoreNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var dataStoreNodeWriter = new DataStoreNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return dataStoreNodeWriter.WriteAsync(xmlWriter, (IDataStoreNode)element, elementName, writeContext);
+                },
+                ["DecisionNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var decisionNodeWriter = new DecisionNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return decisionNodeWriter.WriteAsync(xmlWriter, (IDecisionNode)element, elementName, writeContext);
+                },
+                ["ExceptionHandler"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var exceptionHandlerWriter = new ExceptionHandlerWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return exceptionHandlerWriter.WriteAsync(xmlWriter, (IExceptionHandler)element, elementName, writeContext);
+                },
+                ["FlowFinalNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var flowFinalNodeWriter = new FlowFinalNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return flowFinalNodeWriter.WriteAsync(xmlWriter, (IFlowFinalNode)element, elementName, writeContext);
+                },
+                ["ForkNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var forkNodeWriter = new ForkNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return forkNodeWriter.WriteAsync(xmlWriter, (IForkNode)element, elementName, writeContext);
+                },
+                ["InitialNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var initialNodeWriter = new InitialNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return initialNodeWriter.WriteAsync(xmlWriter, (IInitialNode)element, elementName, writeContext);
+                },
+                ["InterruptibleActivityRegion"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interruptibleActivityRegionWriter = new InterruptibleActivityRegionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return interruptibleActivityRegionWriter.WriteAsync(xmlWriter, (IInterruptibleActivityRegion)element, elementName, writeContext);
+                },
+                ["JoinNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var joinNodeWriter = new JoinNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return joinNodeWriter.WriteAsync(xmlWriter, (IJoinNode)element, elementName, writeContext);
+                },
+                ["MergeNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var mergeNodeWriter = new MergeNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return mergeNodeWriter.WriteAsync(xmlWriter, (IMergeNode)element, elementName, writeContext);
+                },
+                ["ObjectFlow"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var objectFlowWriter = new ObjectFlowWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return objectFlowWriter.WriteAsync(xmlWriter, (IObjectFlow)element, elementName, writeContext);
+                },
+                ["Variable"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var variableWriter = new VariableWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return variableWriter.WriteAsync(xmlWriter, (IVariable)element, elementName, writeContext);
+                },
+                ["Duration"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var durationWriter = new DurationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return durationWriter.WriteAsync(xmlWriter, (IDuration)element, elementName, writeContext);
+                },
+                ["DurationConstraint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var durationConstraintWriter = new DurationConstraintWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return durationConstraintWriter.WriteAsync(xmlWriter, (IDurationConstraint)element, elementName, writeContext);
+                },
+                ["DurationInterval"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var durationIntervalWriter = new DurationIntervalWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return durationIntervalWriter.WriteAsync(xmlWriter, (IDurationInterval)element, elementName, writeContext);
+                },
+                ["DurationObservation"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var durationObservationWriter = new DurationObservationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return durationObservationWriter.WriteAsync(xmlWriter, (IDurationObservation)element, elementName, writeContext);
+                },
+                ["Expression"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var expressionWriter = new ExpressionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return expressionWriter.WriteAsync(xmlWriter, (IExpression)element, elementName, writeContext);
+                },
+                ["Interval"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var intervalWriter = new IntervalWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return intervalWriter.WriteAsync(xmlWriter, (IInterval)element, elementName, writeContext);
+                },
+                ["IntervalConstraint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var intervalConstraintWriter = new IntervalConstraintWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return intervalConstraintWriter.WriteAsync(xmlWriter, (IIntervalConstraint)element, elementName, writeContext);
+                },
+                ["LiteralBoolean"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalBooleanWriter = new LiteralBooleanWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return literalBooleanWriter.WriteAsync(xmlWriter, (ILiteralBoolean)element, elementName, writeContext);
+                },
+                ["LiteralInteger"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalIntegerWriter = new LiteralIntegerWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return literalIntegerWriter.WriteAsync(xmlWriter, (ILiteralInteger)element, elementName, writeContext);
+                },
+                ["LiteralNull"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalNullWriter = new LiteralNullWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return literalNullWriter.WriteAsync(xmlWriter, (ILiteralNull)element, elementName, writeContext);
+                },
+                ["LiteralReal"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalRealWriter = new LiteralRealWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return literalRealWriter.WriteAsync(xmlWriter, (ILiteralReal)element, elementName, writeContext);
+                },
+                ["LiteralString"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalStringWriter = new LiteralStringWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return literalStringWriter.WriteAsync(xmlWriter, (ILiteralString)element, elementName, writeContext);
+                },
+                ["LiteralUnlimitedNatural"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var literalUnlimitedNaturalWriter = new LiteralUnlimitedNaturalWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return literalUnlimitedNaturalWriter.WriteAsync(xmlWriter, (ILiteralUnlimitedNatural)element, elementName, writeContext);
+                },
+                ["OpaqueExpression"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var opaqueExpressionWriter = new OpaqueExpressionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return opaqueExpressionWriter.WriteAsync(xmlWriter, (IOpaqueExpression)element, elementName, writeContext);
+                },
+                ["StringExpression"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var stringExpressionWriter = new StringExpressionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return stringExpressionWriter.WriteAsync(xmlWriter, (IStringExpression)element, elementName, writeContext);
+                },
+                ["TimeConstraint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var timeConstraintWriter = new TimeConstraintWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return timeConstraintWriter.WriteAsync(xmlWriter, (ITimeConstraint)element, elementName, writeContext);
+                },
+                ["TimeExpression"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var timeExpressionWriter = new TimeExpressionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return timeExpressionWriter.WriteAsync(xmlWriter, (ITimeExpression)element, elementName, writeContext);
+                },
+                ["TimeInterval"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var timeIntervalWriter = new TimeIntervalWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return timeIntervalWriter.WriteAsync(xmlWriter, (ITimeInterval)element, elementName, writeContext);
+                },
+                ["TimeObservation"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var timeObservationWriter = new TimeObservationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return timeObservationWriter.WriteAsync(xmlWriter, (ITimeObservation)element, elementName, writeContext);
+                },
+                ["Actor"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var actorWriter = new ActorWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return actorWriter.WriteAsync(xmlWriter, (IActor)element, elementName, writeContext);
+                },
+                ["Extend"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var extendWriter = new ExtendWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return extendWriter.WriteAsync(xmlWriter, (IExtend)element, elementName, writeContext);
+                },
+                ["ExtensionPoint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var extensionPointWriter = new ExtensionPointWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return extensionPointWriter.WriteAsync(xmlWriter, (IExtensionPoint)element, elementName, writeContext);
+                },
+                ["Include"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var includeWriter = new IncludeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return includeWriter.WriteAsync(xmlWriter, (IInclude)element, elementName, writeContext);
+                },
+                ["UseCase"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var useCaseWriter = new UseCaseWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return useCaseWriter.WriteAsync(xmlWriter, (IUseCase)element, elementName, writeContext);
+                },
+                ["Association"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var associationWriter = new AssociationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return associationWriter.WriteAsync(xmlWriter, (IAssociation)element, elementName, writeContext);
+                },
+                ["AssociationClass"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var associationClassWriter = new AssociationClassWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return associationClassWriter.WriteAsync(xmlWriter, (IAssociationClass)element, elementName, writeContext);
+                },
+                ["Class"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var classWriter = new ClassWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return classWriter.WriteAsync(xmlWriter, (IClass)element, elementName, writeContext);
+                },
+                ["Collaboration"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var collaborationWriter = new CollaborationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return collaborationWriter.WriteAsync(xmlWriter, (ICollaboration)element, elementName, writeContext);
+                },
+                ["CollaborationUse"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var collaborationUseWriter = new CollaborationUseWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return collaborationUseWriter.WriteAsync(xmlWriter, (ICollaborationUse)element, elementName, writeContext);
+                },
+                ["Component"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var componentWriter = new ComponentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return componentWriter.WriteAsync(xmlWriter, (IComponent)element, elementName, writeContext);
+                },
+                ["ComponentRealization"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var componentRealizationWriter = new ComponentRealizationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return componentRealizationWriter.WriteAsync(xmlWriter, (IComponentRealization)element, elementName, writeContext);
+                },
+                ["ConnectableElementTemplateParameter"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var connectableElementTemplateParameterWriter = new ConnectableElementTemplateParameterWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return connectableElementTemplateParameterWriter.WriteAsync(xmlWriter, (IConnectableElementTemplateParameter)element, elementName, writeContext);
+                },
+                ["Connector"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var connectorWriter = new ConnectorWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return connectorWriter.WriteAsync(xmlWriter, (IConnector)element, elementName, writeContext);
+                },
+                ["ConnectorEnd"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var connectorEndWriter = new ConnectorEndWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return connectorEndWriter.WriteAsync(xmlWriter, (IConnectorEnd)element, elementName, writeContext);
+                },
+                ["Port"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var portWriter = new PortWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return portWriter.WriteAsync(xmlWriter, (IPort)element, elementName, writeContext);
+                },
+                ["ConnectionPointReference"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var connectionPointReferenceWriter = new ConnectionPointReferenceWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return connectionPointReferenceWriter.WriteAsync(xmlWriter, (IConnectionPointReference)element, elementName, writeContext);
+                },
+                ["FinalState"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var finalStateWriter = new FinalStateWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return finalStateWriter.WriteAsync(xmlWriter, (IFinalState)element, elementName, writeContext);
+                },
+                ["ProtocolConformance"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var protocolConformanceWriter = new ProtocolConformanceWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return protocolConformanceWriter.WriteAsync(xmlWriter, (IProtocolConformance)element, elementName, writeContext);
+                },
+                ["ProtocolStateMachine"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var protocolStateMachineWriter = new ProtocolStateMachineWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return protocolStateMachineWriter.WriteAsync(xmlWriter, (IProtocolStateMachine)element, elementName, writeContext);
+                },
+                ["ProtocolTransition"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var protocolTransitionWriter = new ProtocolTransitionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return protocolTransitionWriter.WriteAsync(xmlWriter, (IProtocolTransition)element, elementName, writeContext);
+                },
+                ["Pseudostate"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var pseudostateWriter = new PseudostateWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return pseudostateWriter.WriteAsync(xmlWriter, (IPseudostate)element, elementName, writeContext);
+                },
+                ["Region"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var regionWriter = new RegionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return regionWriter.WriteAsync(xmlWriter, (IRegion)element, elementName, writeContext);
+                },
+                ["State"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var stateWriter = new StateWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return stateWriter.WriteAsync(xmlWriter, (IState)element, elementName, writeContext);
+                },
+                ["StateMachine"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var stateMachineWriter = new StateMachineWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return stateMachineWriter.WriteAsync(xmlWriter, (IStateMachine)element, elementName, writeContext);
+                },
+                ["Transition"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var transitionWriter = new TransitionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return transitionWriter.WriteAsync(xmlWriter, (ITransition)element, elementName, writeContext);
+                },
+                ["DataType"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var dataTypeWriter = new DataTypeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return dataTypeWriter.WriteAsync(xmlWriter, (IDataType)element, elementName, writeContext);
+                },
+                ["Enumeration"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var enumerationWriter = new EnumerationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return enumerationWriter.WriteAsync(xmlWriter, (IEnumeration)element, elementName, writeContext);
+                },
+                ["EnumerationLiteral"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var enumerationLiteralWriter = new EnumerationLiteralWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return enumerationLiteralWriter.WriteAsync(xmlWriter, (IEnumerationLiteral)element, elementName, writeContext);
+                },
+                ["Interface"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interfaceWriter = new InterfaceWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return interfaceWriter.WriteAsync(xmlWriter, (IInterface)element, elementName, writeContext);
+                },
+                ["InterfaceRealization"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interfaceRealizationWriter = new InterfaceRealizationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return interfaceRealizationWriter.WriteAsync(xmlWriter, (IInterfaceRealization)element, elementName, writeContext);
+                },
+                ["PrimitiveType"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var primitiveTypeWriter = new PrimitiveTypeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return primitiveTypeWriter.WriteAsync(xmlWriter, (IPrimitiveType)element, elementName, writeContext);
+                },
+                ["Reception"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var receptionWriter = new ReceptionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return receptionWriter.WriteAsync(xmlWriter, (IReception)element, elementName, writeContext);
+                },
+                ["Signal"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var signalWriter = new SignalWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return signalWriter.WriteAsync(xmlWriter, (ISignal)element, elementName, writeContext);
+                },
+                ["Extension"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var extensionWriter = new ExtensionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return extensionWriter.WriteAsync(xmlWriter, (IExtension)element, elementName, writeContext);
+                },
+                ["ExtensionEnd"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var extensionEndWriter = new ExtensionEndWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return extensionEndWriter.WriteAsync(xmlWriter, (IExtensionEnd)element, elementName, writeContext);
+                },
+                ["Image"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var imageWriter = new ImageWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return imageWriter.WriteAsync(xmlWriter, (IImage)element, elementName, writeContext);
+                },
+                ["Model"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var modelWriter = new ModelWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return modelWriter.WriteAsync(xmlWriter, (IModel)element, elementName, writeContext);
+                },
+                ["Package"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var packageWriter = new PackageWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return packageWriter.WriteAsync(xmlWriter, (IPackage)element, elementName, writeContext);
+                },
+                ["PackageMerge"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var packageMergeWriter = new PackageMergeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return packageMergeWriter.WriteAsync(xmlWriter, (IPackageMerge)element, elementName, writeContext);
+                },
+                ["Profile"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var profileWriter = new ProfileWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return profileWriter.WriteAsync(xmlWriter, (IProfile)element, elementName, writeContext);
+                },
+                ["ProfileApplication"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var profileApplicationWriter = new ProfileApplicationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return profileApplicationWriter.WriteAsync(xmlWriter, (IProfileApplication)element, elementName, writeContext);
+                },
+                ["Stereotype"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var stereotypeWriter = new StereotypeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return stereotypeWriter.WriteAsync(xmlWriter, (IStereotype)element, elementName, writeContext);
+                },
+                ["ActionExecutionSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var actionExecutionSpecificationWriter = new ActionExecutionSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return actionExecutionSpecificationWriter.WriteAsync(xmlWriter, (IActionExecutionSpecification)element, elementName, writeContext);
+                },
+                ["BehaviorExecutionSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var behaviorExecutionSpecificationWriter = new BehaviorExecutionSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return behaviorExecutionSpecificationWriter.WriteAsync(xmlWriter, (IBehaviorExecutionSpecification)element, elementName, writeContext);
+                },
+                ["CombinedFragment"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var combinedFragmentWriter = new CombinedFragmentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return combinedFragmentWriter.WriteAsync(xmlWriter, (ICombinedFragment)element, elementName, writeContext);
+                },
+                ["ConsiderIgnoreFragment"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var considerIgnoreFragmentWriter = new ConsiderIgnoreFragmentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return considerIgnoreFragmentWriter.WriteAsync(xmlWriter, (IConsiderIgnoreFragment)element, elementName, writeContext);
+                },
+                ["Continuation"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var continuationWriter = new ContinuationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return continuationWriter.WriteAsync(xmlWriter, (IContinuation)element, elementName, writeContext);
+                },
+                ["DestructionOccurrenceSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var destructionOccurrenceSpecificationWriter = new DestructionOccurrenceSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return destructionOccurrenceSpecificationWriter.WriteAsync(xmlWriter, (IDestructionOccurrenceSpecification)element, elementName, writeContext);
+                },
+                ["ExecutionOccurrenceSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var executionOccurrenceSpecificationWriter = new ExecutionOccurrenceSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return executionOccurrenceSpecificationWriter.WriteAsync(xmlWriter, (IExecutionOccurrenceSpecification)element, elementName, writeContext);
+                },
+                ["Gate"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var gateWriter = new GateWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return gateWriter.WriteAsync(xmlWriter, (IGate)element, elementName, writeContext);
+                },
+                ["GeneralOrdering"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var generalOrderingWriter = new GeneralOrderingWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return generalOrderingWriter.WriteAsync(xmlWriter, (IGeneralOrdering)element, elementName, writeContext);
+                },
+                ["Interaction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interactionWriter = new InteractionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return interactionWriter.WriteAsync(xmlWriter, (IInteraction)element, elementName, writeContext);
+                },
+                ["InteractionConstraint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interactionConstraintWriter = new InteractionConstraintWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return interactionConstraintWriter.WriteAsync(xmlWriter, (IInteractionConstraint)element, elementName, writeContext);
+                },
+                ["InteractionOperand"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interactionOperandWriter = new InteractionOperandWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return interactionOperandWriter.WriteAsync(xmlWriter, (IInteractionOperand)element, elementName, writeContext);
+                },
+                ["InteractionUse"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var interactionUseWriter = new InteractionUseWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return interactionUseWriter.WriteAsync(xmlWriter, (IInteractionUse)element, elementName, writeContext);
+                },
+                ["Lifeline"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var lifelineWriter = new LifelineWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return lifelineWriter.WriteAsync(xmlWriter, (ILifeline)element, elementName, writeContext);
+                },
+                ["Message"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var messageWriter = new MessageWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return messageWriter.WriteAsync(xmlWriter, (IMessage)element, elementName, writeContext);
+                },
+                ["MessageOccurrenceSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var messageOccurrenceSpecificationWriter = new MessageOccurrenceSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return messageOccurrenceSpecificationWriter.WriteAsync(xmlWriter, (IMessageOccurrenceSpecification)element, elementName, writeContext);
+                },
+                ["OccurrenceSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var occurrenceSpecificationWriter = new OccurrenceSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return occurrenceSpecificationWriter.WriteAsync(xmlWriter, (IOccurrenceSpecification)element, elementName, writeContext);
+                },
+                ["PartDecomposition"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var partDecompositionWriter = new PartDecompositionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return partDecompositionWriter.WriteAsync(xmlWriter, (IPartDecomposition)element, elementName, writeContext);
+                },
+                ["StateInvariant"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var stateInvariantWriter = new StateInvariantWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return stateInvariantWriter.WriteAsync(xmlWriter, (IStateInvariant)element, elementName, writeContext);
+                },
+                ["InformationFlow"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var informationFlowWriter = new InformationFlowWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return informationFlowWriter.WriteAsync(xmlWriter, (IInformationFlow)element, elementName, writeContext);
+                },
+                ["InformationItem"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var informationItemWriter = new InformationItemWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return informationItemWriter.WriteAsync(xmlWriter, (IInformationItem)element, elementName, writeContext);
+                },
+                ["Artifact"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var artifactWriter = new ArtifactWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return artifactWriter.WriteAsync(xmlWriter, (IArtifact)element, elementName, writeContext);
+                },
+                ["CommunicationPath"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var communicationPathWriter = new CommunicationPathWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return communicationPathWriter.WriteAsync(xmlWriter, (ICommunicationPath)element, elementName, writeContext);
+                },
+                ["Deployment"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var deploymentWriter = new DeploymentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return deploymentWriter.WriteAsync(xmlWriter, (IDeployment)element, elementName, writeContext);
+                },
+                ["DeploymentSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var deploymentSpecificationWriter = new DeploymentSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return deploymentSpecificationWriter.WriteAsync(xmlWriter, (IDeploymentSpecification)element, elementName, writeContext);
+                },
+                ["Device"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var deviceWriter = new DeviceWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return deviceWriter.WriteAsync(xmlWriter, (IDevice)element, elementName, writeContext);
+                },
+                ["ExecutionEnvironment"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var executionEnvironmentWriter = new ExecutionEnvironmentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return executionEnvironmentWriter.WriteAsync(xmlWriter, (IExecutionEnvironment)element, elementName, writeContext);
+                },
+                ["Manifestation"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var manifestationWriter = new ManifestationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return manifestationWriter.WriteAsync(xmlWriter, (IManifestation)element, elementName, writeContext);
+                },
+                ["Node"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var nodeWriter = new NodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return nodeWriter.WriteAsync(xmlWriter, (INode)element, elementName, writeContext);
+                },
+                ["Abstraction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var abstractionWriter = new AbstractionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return abstractionWriter.WriteAsync(xmlWriter, (IAbstraction)element, elementName, writeContext);
+                },
+                ["Comment"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var commentWriter = new CommentWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return commentWriter.WriteAsync(xmlWriter, (IComment)element, elementName, writeContext);
+                },
+                ["Constraint"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var constraintWriter = new ConstraintWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return constraintWriter.WriteAsync(xmlWriter, (IConstraint)element, elementName, writeContext);
+                },
+                ["Dependency"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var dependencyWriter = new DependencyWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return dependencyWriter.WriteAsync(xmlWriter, (IDependency)element, elementName, writeContext);
+                },
+                ["ElementImport"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var elementImportWriter = new ElementImportWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return elementImportWriter.WriteAsync(xmlWriter, (IElementImport)element, elementName, writeContext);
+                },
+                ["PackageImport"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var packageImportWriter = new PackageImportWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return packageImportWriter.WriteAsync(xmlWriter, (IPackageImport)element, elementName, writeContext);
+                },
+                ["Realization"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var realizationWriter = new RealizationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return realizationWriter.WriteAsync(xmlWriter, (IRealization)element, elementName, writeContext);
+                },
+                ["TemplateBinding"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var templateBindingWriter = new TemplateBindingWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return templateBindingWriter.WriteAsync(xmlWriter, (ITemplateBinding)element, elementName, writeContext);
+                },
+                ["TemplateParameter"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var templateParameterWriter = new TemplateParameterWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return templateParameterWriter.WriteAsync(xmlWriter, (ITemplateParameter)element, elementName, writeContext);
+                },
+                ["TemplateParameterSubstitution"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var templateParameterSubstitutionWriter = new TemplateParameterSubstitutionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return templateParameterSubstitutionWriter.WriteAsync(xmlWriter, (ITemplateParameterSubstitution)element, elementName, writeContext);
+                },
+                ["TemplateSignature"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var templateSignatureWriter = new TemplateSignatureWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return templateSignatureWriter.WriteAsync(xmlWriter, (ITemplateSignature)element, elementName, writeContext);
+                },
+                ["Usage"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var usageWriter = new UsageWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return usageWriter.WriteAsync(xmlWriter, (IUsage)element, elementName, writeContext);
+                },
+                ["AnyReceiveEvent"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var anyReceiveEventWriter = new AnyReceiveEventWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return anyReceiveEventWriter.WriteAsync(xmlWriter, (IAnyReceiveEvent)element, elementName, writeContext);
+                },
+                ["CallEvent"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var callEventWriter = new CallEventWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return callEventWriter.WriteAsync(xmlWriter, (ICallEvent)element, elementName, writeContext);
+                },
+                ["ChangeEvent"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var changeEventWriter = new ChangeEventWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return changeEventWriter.WriteAsync(xmlWriter, (IChangeEvent)element, elementName, writeContext);
+                },
+                ["FunctionBehavior"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var functionBehaviorWriter = new FunctionBehaviorWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return functionBehaviorWriter.WriteAsync(xmlWriter, (IFunctionBehavior)element, elementName, writeContext);
+                },
+                ["OpaqueBehavior"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var opaqueBehaviorWriter = new OpaqueBehaviorWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return opaqueBehaviorWriter.WriteAsync(xmlWriter, (IOpaqueBehavior)element, elementName, writeContext);
+                },
+                ["SignalEvent"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var signalEventWriter = new SignalEventWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return signalEventWriter.WriteAsync(xmlWriter, (ISignalEvent)element, elementName, writeContext);
+                },
+                ["TimeEvent"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var timeEventWriter = new TimeEventWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return timeEventWriter.WriteAsync(xmlWriter, (ITimeEvent)element, elementName, writeContext);
+                },
+                ["Trigger"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var triggerWriter = new TriggerWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return triggerWriter.WriteAsync(xmlWriter, (ITrigger)element, elementName, writeContext);
+                },
+                ["Substitution"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var substitutionWriter = new SubstitutionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return substitutionWriter.WriteAsync(xmlWriter, (ISubstitution)element, elementName, writeContext);
+                },
+                ["ClassifierTemplateParameter"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var classifierTemplateParameterWriter = new ClassifierTemplateParameterWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return classifierTemplateParameterWriter.WriteAsync(xmlWriter, (IClassifierTemplateParameter)element, elementName, writeContext);
+                },
+                ["Generalization"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var generalizationWriter = new GeneralizationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return generalizationWriter.WriteAsync(xmlWriter, (IGeneralization)element, elementName, writeContext);
+                },
+                ["GeneralizationSet"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var generalizationSetWriter = new GeneralizationSetWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return generalizationSetWriter.WriteAsync(xmlWriter, (IGeneralizationSet)element, elementName, writeContext);
+                },
+                ["InstanceSpecification"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var instanceSpecificationWriter = new InstanceSpecificationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return instanceSpecificationWriter.WriteAsync(xmlWriter, (IInstanceSpecification)element, elementName, writeContext);
+                },
+                ["InstanceValue"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var instanceValueWriter = new InstanceValueWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return instanceValueWriter.WriteAsync(xmlWriter, (IInstanceValue)element, elementName, writeContext);
+                },
+                ["Operation"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var operationWriter = new OperationWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return operationWriter.WriteAsync(xmlWriter, (IOperation)element, elementName, writeContext);
+                },
+                ["OperationTemplateParameter"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var operationTemplateParameterWriter = new OperationTemplateParameterWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return operationTemplateParameterWriter.WriteAsync(xmlWriter, (IOperationTemplateParameter)element, elementName, writeContext);
+                },
+                ["Parameter"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var parameterWriter = new ParameterWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return parameterWriter.WriteAsync(xmlWriter, (IParameter)element, elementName, writeContext);
+                },
+                ["ParameterSet"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var parameterSetWriter = new ParameterSetWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return parameterSetWriter.WriteAsync(xmlWriter, (IParameterSet)element, elementName, writeContext);
+                },
+                ["Property"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var propertyWriter = new PropertyWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return propertyWriter.WriteAsync(xmlWriter, (IProperty)element, elementName, writeContext);
+                },
+                ["RedefinableTemplateSignature"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var redefinableTemplateSignatureWriter = new RedefinableTemplateSignatureWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return redefinableTemplateSignatureWriter.WriteAsync(xmlWriter, (IRedefinableTemplateSignature)element, elementName, writeContext);
+                },
+                ["Slot"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var slotWriter = new SlotWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return slotWriter.WriteAsync(xmlWriter, (ISlot)element, elementName, writeContext);
+                },
+                ["ValueSpecificationAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var valueSpecificationActionWriter = new ValueSpecificationActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return valueSpecificationActionWriter.WriteAsync(xmlWriter, (IValueSpecificationAction)element, elementName, writeContext);
+                },
+                ["AcceptCallAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var acceptCallActionWriter = new AcceptCallActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return acceptCallActionWriter.WriteAsync(xmlWriter, (IAcceptCallAction)element, elementName, writeContext);
+                },
+                ["AcceptEventAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var acceptEventActionWriter = new AcceptEventActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return acceptEventActionWriter.WriteAsync(xmlWriter, (IAcceptEventAction)element, elementName, writeContext);
+                },
+                ["ActionInputPin"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var actionInputPinWriter = new ActionInputPinWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return actionInputPinWriter.WriteAsync(xmlWriter, (IActionInputPin)element, elementName, writeContext);
+                },
+                ["AddStructuralFeatureValueAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var addStructuralFeatureValueActionWriter = new AddStructuralFeatureValueActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return addStructuralFeatureValueActionWriter.WriteAsync(xmlWriter, (IAddStructuralFeatureValueAction)element, elementName, writeContext);
+                },
+                ["AddVariableValueAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var addVariableValueActionWriter = new AddVariableValueActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return addVariableValueActionWriter.WriteAsync(xmlWriter, (IAddVariableValueAction)element, elementName, writeContext);
+                },
+                ["BroadcastSignalAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var broadcastSignalActionWriter = new BroadcastSignalActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return broadcastSignalActionWriter.WriteAsync(xmlWriter, (IBroadcastSignalAction)element, elementName, writeContext);
+                },
+                ["CallBehaviorAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var callBehaviorActionWriter = new CallBehaviorActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return callBehaviorActionWriter.WriteAsync(xmlWriter, (ICallBehaviorAction)element, elementName, writeContext);
+                },
+                ["CallOperationAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var callOperationActionWriter = new CallOperationActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return callOperationActionWriter.WriteAsync(xmlWriter, (ICallOperationAction)element, elementName, writeContext);
+                },
+                ["Clause"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var clauseWriter = new ClauseWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return clauseWriter.WriteAsync(xmlWriter, (IClause)element, elementName, writeContext);
+                },
+                ["ClearAssociationAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var clearAssociationActionWriter = new ClearAssociationActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return clearAssociationActionWriter.WriteAsync(xmlWriter, (IClearAssociationAction)element, elementName, writeContext);
+                },
+                ["ClearStructuralFeatureAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var clearStructuralFeatureActionWriter = new ClearStructuralFeatureActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return clearStructuralFeatureActionWriter.WriteAsync(xmlWriter, (IClearStructuralFeatureAction)element, elementName, writeContext);
+                },
+                ["ClearVariableAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var clearVariableActionWriter = new ClearVariableActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return clearVariableActionWriter.WriteAsync(xmlWriter, (IClearVariableAction)element, elementName, writeContext);
+                },
+                ["ConditionalNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var conditionalNodeWriter = new ConditionalNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return conditionalNodeWriter.WriteAsync(xmlWriter, (IConditionalNode)element, elementName, writeContext);
+                },
+                ["CreateLinkAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var createLinkActionWriter = new CreateLinkActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return createLinkActionWriter.WriteAsync(xmlWriter, (ICreateLinkAction)element, elementName, writeContext);
+                },
+                ["CreateLinkObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var createLinkObjectActionWriter = new CreateLinkObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return createLinkObjectActionWriter.WriteAsync(xmlWriter, (ICreateLinkObjectAction)element, elementName, writeContext);
+                },
+                ["CreateObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var createObjectActionWriter = new CreateObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return createObjectActionWriter.WriteAsync(xmlWriter, (ICreateObjectAction)element, elementName, writeContext);
+                },
+                ["DestroyLinkAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var destroyLinkActionWriter = new DestroyLinkActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return destroyLinkActionWriter.WriteAsync(xmlWriter, (IDestroyLinkAction)element, elementName, writeContext);
+                },
+                ["DestroyObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var destroyObjectActionWriter = new DestroyObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return destroyObjectActionWriter.WriteAsync(xmlWriter, (IDestroyObjectAction)element, elementName, writeContext);
+                },
+                ["ExpansionNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var expansionNodeWriter = new ExpansionNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return expansionNodeWriter.WriteAsync(xmlWriter, (IExpansionNode)element, elementName, writeContext);
+                },
+                ["ExpansionRegion"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var expansionRegionWriter = new ExpansionRegionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return expansionRegionWriter.WriteAsync(xmlWriter, (IExpansionRegion)element, elementName, writeContext);
+                },
+                ["InputPin"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var inputPinWriter = new InputPinWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return inputPinWriter.WriteAsync(xmlWriter, (IInputPin)element, elementName, writeContext);
+                },
+                ["LinkEndCreationData"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var linkEndCreationDataWriter = new LinkEndCreationDataWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return linkEndCreationDataWriter.WriteAsync(xmlWriter, (ILinkEndCreationData)element, elementName, writeContext);
+                },
+                ["LinkEndData"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var linkEndDataWriter = new LinkEndDataWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return linkEndDataWriter.WriteAsync(xmlWriter, (ILinkEndData)element, elementName, writeContext);
+                },
+                ["LinkEndDestructionData"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var linkEndDestructionDataWriter = new LinkEndDestructionDataWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return linkEndDestructionDataWriter.WriteAsync(xmlWriter, (ILinkEndDestructionData)element, elementName, writeContext);
+                },
+                ["LoopNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var loopNodeWriter = new LoopNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return loopNodeWriter.WriteAsync(xmlWriter, (ILoopNode)element, elementName, writeContext);
+                },
+                ["OpaqueAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var opaqueActionWriter = new OpaqueActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return opaqueActionWriter.WriteAsync(xmlWriter, (IOpaqueAction)element, elementName, writeContext);
+                },
+                ["OutputPin"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var outputPinWriter = new OutputPinWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return outputPinWriter.WriteAsync(xmlWriter, (IOutputPin)element, elementName, writeContext);
+                },
+                ["QualifierValue"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var qualifierValueWriter = new QualifierValueWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return qualifierValueWriter.WriteAsync(xmlWriter, (IQualifierValue)element, elementName, writeContext);
+                },
+                ["RaiseExceptionAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var raiseExceptionActionWriter = new RaiseExceptionActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return raiseExceptionActionWriter.WriteAsync(xmlWriter, (IRaiseExceptionAction)element, elementName, writeContext);
+                },
+                ["ReadExtentAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readExtentActionWriter = new ReadExtentActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return readExtentActionWriter.WriteAsync(xmlWriter, (IReadExtentAction)element, elementName, writeContext);
+                },
+                ["ReadIsClassifiedObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readIsClassifiedObjectActionWriter = new ReadIsClassifiedObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return readIsClassifiedObjectActionWriter.WriteAsync(xmlWriter, (IReadIsClassifiedObjectAction)element, elementName, writeContext);
+                },
+                ["ReadLinkAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readLinkActionWriter = new ReadLinkActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return readLinkActionWriter.WriteAsync(xmlWriter, (IReadLinkAction)element, elementName, writeContext);
+                },
+                ["ReadLinkObjectEndAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readLinkObjectEndActionWriter = new ReadLinkObjectEndActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return readLinkObjectEndActionWriter.WriteAsync(xmlWriter, (IReadLinkObjectEndAction)element, elementName, writeContext);
+                },
+                ["ReadLinkObjectEndQualifierAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readLinkObjectEndQualifierActionWriter = new ReadLinkObjectEndQualifierActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return readLinkObjectEndQualifierActionWriter.WriteAsync(xmlWriter, (IReadLinkObjectEndQualifierAction)element, elementName, writeContext);
+                },
+                ["ReadSelfAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readSelfActionWriter = new ReadSelfActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return readSelfActionWriter.WriteAsync(xmlWriter, (IReadSelfAction)element, elementName, writeContext);
+                },
+                ["ReadStructuralFeatureAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readStructuralFeatureActionWriter = new ReadStructuralFeatureActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return readStructuralFeatureActionWriter.WriteAsync(xmlWriter, (IReadStructuralFeatureAction)element, elementName, writeContext);
+                },
+                ["ReadVariableAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var readVariableActionWriter = new ReadVariableActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return readVariableActionWriter.WriteAsync(xmlWriter, (IReadVariableAction)element, elementName, writeContext);
+                },
+                ["ReclassifyObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var reclassifyObjectActionWriter = new ReclassifyObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return reclassifyObjectActionWriter.WriteAsync(xmlWriter, (IReclassifyObjectAction)element, elementName, writeContext);
+                },
+                ["ReduceAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var reduceActionWriter = new ReduceActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return reduceActionWriter.WriteAsync(xmlWriter, (IReduceAction)element, elementName, writeContext);
+                },
+                ["RemoveStructuralFeatureValueAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var removeStructuralFeatureValueActionWriter = new RemoveStructuralFeatureValueActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return removeStructuralFeatureValueActionWriter.WriteAsync(xmlWriter, (IRemoveStructuralFeatureValueAction)element, elementName, writeContext);
+                },
+                ["RemoveVariableValueAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var removeVariableValueActionWriter = new RemoveVariableValueActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return removeVariableValueActionWriter.WriteAsync(xmlWriter, (IRemoveVariableValueAction)element, elementName, writeContext);
+                },
+                ["ReplyAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var replyActionWriter = new ReplyActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return replyActionWriter.WriteAsync(xmlWriter, (IReplyAction)element, elementName, writeContext);
+                },
+                ["SendObjectAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var sendObjectActionWriter = new SendObjectActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return sendObjectActionWriter.WriteAsync(xmlWriter, (ISendObjectAction)element, elementName, writeContext);
+                },
+                ["SendSignalAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var sendSignalActionWriter = new SendSignalActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return sendSignalActionWriter.WriteAsync(xmlWriter, (ISendSignalAction)element, elementName, writeContext);
+                },
+                ["SequenceNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var sequenceNodeWriter = new SequenceNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return sequenceNodeWriter.WriteAsync(xmlWriter, (ISequenceNode)element, elementName, writeContext);
+                },
+                ["StartClassifierBehaviorAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var startClassifierBehaviorActionWriter = new StartClassifierBehaviorActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return startClassifierBehaviorActionWriter.WriteAsync(xmlWriter, (IStartClassifierBehaviorAction)element, elementName, writeContext);
+                },
+                ["StartObjectBehaviorAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var startObjectBehaviorActionWriter = new StartObjectBehaviorActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return startObjectBehaviorActionWriter.WriteAsync(xmlWriter, (IStartObjectBehaviorAction)element, elementName, writeContext);
+                },
+                ["StructuredActivityNode"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var structuredActivityNodeWriter = new StructuredActivityNodeWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return structuredActivityNodeWriter.WriteAsync(xmlWriter, (IStructuredActivityNode)element, elementName, writeContext);
+                },
+                ["TestIdentityAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var testIdentityActionWriter = new TestIdentityActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return testIdentityActionWriter.WriteAsync(xmlWriter, (ITestIdentityAction)element, elementName, writeContext);
+                },
+                ["UnmarshallAction"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var unmarshallActionWriter = new UnmarshallActionWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return unmarshallActionWriter.WriteAsync(xmlWriter, (IUnmarshallAction)element, elementName, writeContext);
+                },
+                ["ValuePin"] = (xmlWriter, element, elementName, writeContext) =>
+                {
+                    var valuePinWriter = new ValuePinWriter(this, this.xmiWriterSettings, this.loggerFactory);
+                    return valuePinWriter.WriteAsync(xmlWriter, (IValuePin)element, elementName, writeContext);
+                },
+            };
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> using the appropriate
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> based on the concrete type of the <see cref="IXmiElement"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// thrown when the concrete type of the <see cref="IXmiElement"/> is not supported and no
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> was found
+        /// </exception>
+        public void Write(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            var typeName = element.GetType().Name;
+
+            if (!this.writerCache.TryGetValue(typeName, out var writer))
+            {
+                throw new InvalidOperationException($"No writer found for type {typeName}");
+            }
+
+            writer(xmlWriter, element, elementName, writeContext);
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a contained element. When
+        /// the <see cref="IXmiElement"/> is not part of the document that is being written, an href reference element
+        /// is written instead.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public void WriteContainedElement(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (writeContext.IsLocal(element))
+            {
+                this.Write(xmlWriter, element, elementName, writeContext);
+            }
+            else
+            {
+                this.WriteHrefElement(xmlWriter, element, elementName, writeContext);
+            }
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a reference element. When the
+        /// <see cref="IXmiElement"/> is part of the document that is being written an xmi:idref element is written,
+        /// otherwise an href reference element is written.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is referenced
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public void WriteReferenceElement(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (writeContext.IsLocal(element))
+            {
+                xmlWriter.WriteStartElement(elementName);
+                xmlWriter.WriteAttributeString("xmi", "idref", this.xmiWriterSettings.XmiNamespaceUri, element.XmiId);
+                xmlWriter.WriteEndElement();
+            }
+            else
+            {
+                this.WriteHrefElement(xmlWriter, element, elementName, writeContext);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> using the appropriate
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> based on the concrete type of the <see cref="IXmiElement"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// thrown when the concrete type of the <see cref="IXmiElement"/> is not supported and no
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> was found
+        /// </exception>
+        public Task WriteAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            var typeName = element.GetType().Name;
+
+            if (!this.writerAsyncCache.TryGetValue(typeName, out var writer))
+            {
+                throw new InvalidOperationException($"No writer found for type {typeName}");
+            }
+
+            return writer(xmlWriter, element, elementName, writeContext);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a contained element. When
+        /// the <see cref="IXmiElement"/> is not part of the document that is being written, an href reference element
+        /// is written instead.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public Task WriteContainedElementAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (writeContext.IsLocal(element))
+            {
+                return this.WriteAsync(xmlWriter, element, elementName, writeContext);
+            }
+
+            return this.WriteHrefElementAsync(xmlWriter, element, elementName, writeContext);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a reference element. When the
+        /// <see cref="IXmiElement"/> is part of the document that is being written an xmi:idref element is written,
+        /// otherwise an href reference element is written.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is referenced
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task WriteReferenceElementAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (writeContext.IsLocal(element))
+            {
+                await xmlWriter.WriteStartElementAsync(null, elementName, null);
+                await xmlWriter.WriteAttributeStringAsync("xmi", "idref", this.xmiWriterSettings.XmiNamespaceUri, element.XmiId);
+                await xmlWriter.WriteEndElementAsync();
+            }
+            else
+            {
+                await this.WriteHrefElementAsync(xmlWriter, element, elementName, writeContext);
+            }
+        }
+
+        /// <summary>
+        /// Writes an href reference element for the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is referenced
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        private void WriteHrefElement(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            xmlWriter.WriteStartElement(elementName);
+            xmlWriter.WriteAttributeString("xmi", "type", this.xmiWriterSettings.XmiNamespaceUri, $"uml:{element.GetType().Name}");
+            xmlWriter.WriteAttributeString("href", writeContext.QueryHref(element));
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes an href reference element for the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is referenced
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        private async Task WriteHrefElementAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext)
+        {
+            await xmlWriter.WriteStartElementAsync(null, elementName, null);
+            await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.xmiWriterSettings.XmiNamespaceUri, $"uml:{element.GetType().Name}");
+            await xmlWriter.WriteAttributeStringAsync(null, "href", null, writeContext.QueryHref(element));
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// --------THIS IS AN AUTOMATICALLY GENERATED FILE. ANY MANUAL CHANGES WILL BE OVERWRITTEN!--------
+// ------------------------------------------------------------------------------------------------

--- a/uml4net.xmi/IXmiWriterScope.cs
+++ b/uml4net.xmi/IXmiWriterScope.cs
@@ -1,0 +1,29 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="IXmiWriterScope.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi
+{
+    using System;
+
+    /// <summary>
+    /// Represents a scope for managing the lifecycle of services used during the XMI writing process.
+    /// </summary>
+    public interface IXmiWriterScope : IDisposable;
+}

--- a/uml4net.xmi/Settings/DefaultWriterSettings.cs
+++ b/uml4net.xmi/Settings/DefaultWriterSettings.cs
@@ -1,0 +1,49 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="DefaultWriterSettings.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Settings
+{
+    /// <summary>
+    /// Represents the default settings for the XMI writer.
+    /// </summary>
+    public class DefaultWriterSettings : IXmiWriterSettings
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ExternalReferenceResolutionKind"/> that specifies how references to elements
+        /// that are not contained by the selected <see cref="uml4net.Packages.IPackage"/> are serialized.
+        /// </summary>
+        public ExternalReferenceResolutionKind ExternalReferenceResolution { get; set; } = ExternalReferenceResolutionKind.Href;
+
+        /// <summary>
+        /// Gets or sets the namespace URI used for the uml namespace declaration on the root element.
+        /// </summary>
+        public string UmlNamespaceUri { get; set; } = "http://www.omg.org/spec/UML/20131001";
+
+        /// <summary>
+        /// Gets or sets the namespace URI used for the xmi namespace declaration on the root element.
+        /// </summary>
+        public string XmiNamespaceUri { get; set; } = "http://www.omg.org/spec/XMI/20131001";
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the written XML is indented.
+        /// </summary>
+        public bool Indent { get; set; } = true;
+    }
+}

--- a/uml4net.xmi/Settings/ExternalReferenceResolutionKind.cs
+++ b/uml4net.xmi/Settings/ExternalReferenceResolutionKind.cs
@@ -1,0 +1,48 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="ExternalReferenceResolutionKind.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Settings
+{
+    /// <summary>
+    /// Specifies how references to elements that are not contained by the selected <see cref="uml4net.Packages.IPackage"/>
+    /// are serialized when writing an XMI document.
+    /// </summary>
+    public enum ExternalReferenceResolutionKind
+    {
+        /// <summary>
+        /// References to external elements are serialized as href references to the document that
+        /// contains the referenced element, such as <code>href="PrimitiveTypes.xmi#Boolean"</code>.
+        /// The written document only contains the selected package.
+        /// </summary>
+        Href = 0,
+
+        /// <summary>
+        /// The top-level root packages that contain externally referenced elements are included in the
+        /// written document, resulting in a self-contained document in which all references can be
+        /// resolved by identifier.
+        /// </summary>
+        /// <remarks>
+        /// Individual referenced elements cannot be re-contained without invalidating the containment
+        /// hierarchy of the source model; therefore, the complete containment tree of the root package that
+        /// owns each externally referenced element is included in the written document.
+        /// </remarks>
+        Include = 1
+    }
+}

--- a/uml4net.xmi/Settings/IXmiWriterSettings.cs
+++ b/uml4net.xmi/Settings/IXmiWriterSettings.cs
@@ -1,0 +1,49 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="IXmiWriterSettings.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Settings
+{
+    /// <summary>
+    /// The <see cref="IXmiWriterSettings"/> interface defines settings the <see cref="Writers.XmiWriter"/> requires in order to properly write
+    /// </summary>
+    public interface IXmiWriterSettings
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ExternalReferenceResolutionKind"/> that specifies how references to elements
+        /// that are not contained by the selected <see cref="uml4net.Packages.IPackage"/> are serialized.
+        /// </summary>
+        ExternalReferenceResolutionKind ExternalReferenceResolution { get; set; }
+
+        /// <summary>
+        /// Gets or sets the namespace URI used for the uml namespace declaration on the root element.
+        /// </summary>
+        string UmlNamespaceUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the namespace URI used for the xmi namespace declaration on the root element.
+        /// </summary>
+        string XmiNamespaceUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the written XML is indented.
+        /// </summary>
+        bool Indent { get; set; }
+    }
+}

--- a/uml4net.xmi/Writers/IReferenceClosureCalculator.cs
+++ b/uml4net.xmi/Writers/IReferenceClosureCalculator.cs
@@ -1,0 +1,51 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="IReferenceClosureCalculator.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using uml4net.Packages;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The <see cref="IReferenceClosureCalculator"/> interface defines the calculation of an <see cref="XmiWritePlan"/>
+    /// for a selected <see cref="IPackage"/>, which determines the elements that are serialized inside an
+    /// XMI document and the root packages that the document contains.
+    /// </summary>
+    public interface IReferenceClosureCalculator
+    {
+        /// <summary>
+        /// Calculates the <see cref="XmiWritePlan"/> for the provided <see cref="IPackage"/>.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is selected to be written
+        /// </param>
+        /// <param name="externalReferenceResolution">
+        /// The <see cref="ExternalReferenceResolutionKind"/> that specifies how references to elements that are
+        /// not contained by the <paramref name="package"/> are treated
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written
+        /// </param>
+        /// <returns>
+        /// The calculated <see cref="XmiWritePlan"/>
+        /// </returns>
+        XmiWritePlan CalculateWritePlan(IPackage package, ExternalReferenceResolutionKind externalReferenceResolution, string documentName);
+    }
+}

--- a/uml4net.xmi/Writers/IXmiElementWriter.cs
+++ b/uml4net.xmi/Writers/IXmiElementWriter.cs
@@ -1,0 +1,69 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="IXmiElementWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    /// <summary>
+    /// The interface definition of an XMI element writer
+    /// </summary>
+    /// <typeparam name="TXmiElement">The type of the XMI element to be written.</typeparam>
+    public interface IXmiElementWriter<in TXmiElement> where TXmiElement : IXmiElement
+    {
+        /// <summary>
+        /// Writes the provided <typeparamref name="TXmiElement"/> to the <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <typeparamref name="TXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        void Write(XmlWriter xmlWriter, TXmiElement element, string elementName, IXmiWriteContext writeContext);
+
+        /// <summary>
+        /// Asynchronously writes the provided <typeparamref name="TXmiElement"/> to the <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <typeparamref name="TXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        Task WriteAsync(XmlWriter xmlWriter, TXmiElement element, string elementName, IXmiWriteContext writeContext);
+    }
+}

--- a/uml4net.xmi/Writers/IXmiElementWriterFacade.cs
+++ b/uml4net.xmi/Writers/IXmiElementWriterFacade.cs
@@ -1,0 +1,163 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="IXmiElementWriterFacade.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    /// <summary>
+    /// The purpose of the <see cref="IXmiElementWriterFacade"/> is to write an <see cref="IXmiElement"/> to an
+    /// <see cref="XmlWriter"/> using the appropriate <see cref="IXmiElementWriter{TXmiElement}"/> based on the
+    /// concrete type of the <see cref="IXmiElement"/>
+    /// </summary>
+    public interface IXmiElementWriterFacade
+    {
+        /// <summary>
+        /// Writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> using the appropriate
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> based on the concrete type of the <see cref="IXmiElement"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// thrown when the concrete type of the <see cref="IXmiElement"/> is not supported and no
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> was found
+        /// </exception>
+        void Write(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext);
+
+        /// <summary>
+        /// Writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a contained element. When
+        /// the <see cref="IXmiElement"/> is not part of the document that is being written, an href reference element
+        /// is written instead.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        void WriteContainedElement(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext);
+
+        /// <summary>
+        /// Writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a reference element. When the
+        /// <see cref="IXmiElement"/> is part of the document that is being written an xmi:idref element is written,
+        /// otherwise an href reference element is written.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is referenced
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        void WriteReferenceElement(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext);
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> using the appropriate
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> based on the concrete type of the <see cref="IXmiElement"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// thrown when the concrete type of the <see cref="IXmiElement"/> is not supported and no
+        /// <see cref="IXmiElementWriter{TXmiElement}"/> was found
+        /// </exception>
+        Task WriteAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext);
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a contained element. When
+        /// the <see cref="IXmiElement"/> is not part of the document that is being written, an href reference element
+        /// is written instead.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        Task WriteContainedElementAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext);
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IXmiElement"/> to the <see cref="XmlWriter"/> as a reference element. When the
+        /// <see cref="IXmiElement"/> is part of the document that is being written an xmi:idref element is written,
+        /// otherwise an href reference element is written.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is referenced
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        Task WriteReferenceElementAsync(XmlWriter xmlWriter, IXmiElement element, string elementName, IXmiWriteContext writeContext);
+    }
+}

--- a/uml4net.xmi/Writers/IXmiWriteContext.cs
+++ b/uml4net.xmi/Writers/IXmiWriteContext.cs
@@ -1,0 +1,57 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="IXmiWriteContext.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    /// <summary>
+    /// The <see cref="IXmiWriteContext"/> interface defines the state of a single write operation that is
+    /// shared by all <see cref="XmiElementWriter{TXmiElement}"/> instances while writing an XMI document.
+    /// </summary>
+    public interface IXmiWriteContext
+    {
+        /// <summary>
+        /// Gets the name of the document that is being written.
+        /// </summary>
+        string DocumentName { get; }
+
+        /// <summary>
+        /// Queries whether the provided <see cref="IXmiElement"/> is serialized inside the document that is being written.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be checked
+        /// </param>
+        /// <returns>
+        /// true when the <paramref name="element"/> is part of the document that is being written, false otherwise
+        /// </returns>
+        bool IsLocal(IXmiElement element);
+
+        /// <summary>
+        /// Queries the href reference to the provided <see cref="IXmiElement"/>, which is the concatenation
+        /// of the <see cref="IXmiElement.DocumentName"/> and the <see cref="IXmiElement.XmiId"/> separated by a pound sign #
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> for which the href reference is queried
+        /// </param>
+        /// <returns>
+        /// the href reference to the <paramref name="element"/>
+        /// </returns>
+        string QueryHref(IXmiElement element);
+    }
+}

--- a/uml4net.xmi/Writers/IXmiWriter.cs
+++ b/uml4net.xmi/Writers/IXmiWriter.cs
@@ -1,0 +1,98 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="IXmiWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using uml4net.Packages;
+
+    /// <summary>
+    /// The purpose of the <see cref="IXmiWriter"/> is to provide a means to write (serialize)
+    /// a UML 2.5.1 model to XMI
+    /// </summary>
+    public interface IXmiWriter : IDisposable
+    {
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/> to a UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        void Write(IPackage package, string fileUri);
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/> to a UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        void Write(IPackage package, Stream stream, string documentName);
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/> to a UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        Task WriteAsync(IPackage package, string fileUri, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/> to a UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        Task WriteAsync(IPackage package, Stream stream, string documentName, CancellationToken cancellationToken = default);
+    }
+}

--- a/uml4net.xmi/Writers/ReferenceClosureCalculator.cs
+++ b/uml4net.xmi/Writers/ReferenceClosureCalculator.cs
@@ -1,0 +1,481 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="ReferenceClosureCalculator.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
+
+    using Microsoft.Extensions.Logging;
+
+    using uml4net.Classification;
+    using uml4net.CommonStructure;
+    using uml4net.Decorators;
+    using uml4net.Packages;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="ReferenceClosureCalculator"/> is to calculate the <see cref="XmiWritePlan"/>
+    /// for a selected <see cref="IPackage"/>, which determines the elements that are serialized inside an
+    /// XMI document and the root packages that the document contains.
+    /// </summary>
+    public class ReferenceClosureCalculator : IReferenceClosureCalculator
+    {
+        /// <summary>
+        /// The cache of <see cref="TypeProperties"/> per concrete <see cref="IXmiElement"/> type.
+        /// </summary>
+        private static readonly ConcurrentDictionary<Type, TypeProperties> TypePropertiesCache = new ConcurrentDictionary<Type, TypeProperties>();
+
+        /// <summary>
+        /// The <see cref="ILogger"/> used to log
+        /// </summary>
+        private readonly ILogger<ReferenceClosureCalculator> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReferenceClosureCalculator"/> class.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger{T}"/></param>
+        public ReferenceClosureCalculator(ILogger<ReferenceClosureCalculator> logger)
+        {
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Calculates the <see cref="XmiWritePlan"/> for the provided <see cref="IPackage"/>.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is selected to be written
+        /// </param>
+        /// <param name="externalReferenceResolution">
+        /// The <see cref="ExternalReferenceResolutionKind"/> that specifies how references to elements that are
+        /// not contained by the <paramref name="package"/> are treated
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written
+        /// </param>
+        /// <returns>
+        /// The calculated <see cref="XmiWritePlan"/>
+        /// </returns>
+        public XmiWritePlan CalculateWritePlan(IPackage package, ExternalReferenceResolutionKind externalReferenceResolution, string documentName)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (documentName == null)
+            {
+                throw new ArgumentNullException(nameof(documentName));
+            }
+
+            var localElements = new HashSet<IXmiElement>(ReferenceEqualityComparer.Instance);
+            var localIdentifiers = new HashSet<string>();
+            var elementsMissingXmiId = new List<IXmiElement>();
+            var rootPackages = new List<IPackage> { package };
+
+            this.CollectContainmentTree(package, localElements, localIdentifiers, elementsMissingXmiId);
+
+            if (externalReferenceResolution == ExternalReferenceResolutionKind.Include)
+            {
+                var packagesToProcess = new Queue<IPackage>();
+                packagesToProcess.Enqueue(package);
+
+                while (packagesToProcess.Count > 0)
+                {
+                    var packageToProcess = packagesToProcess.Dequeue();
+
+                    foreach (var externalElement in this.QueryExternalReferencedElements(packageToProcess, localElements))
+                    {
+                        var rootPackage = QueryRootPackage(externalElement);
+
+                        if (rootPackage == null)
+                        {
+                            this.logger.LogWarning("The externally referenced element with id [{XmiId}] is not contained by a root package and is written as an href reference", externalElement.XmiId);
+                            continue;
+                        }
+
+                        if (localElements.Contains(rootPackage))
+                        {
+                            continue;
+                        }
+
+                        this.CollectContainmentTree(rootPackage, localElements, localIdentifiers, elementsMissingXmiId);
+                        rootPackages.Add(rootPackage);
+                        packagesToProcess.Enqueue(rootPackage);
+                    }
+                }
+
+                var includedPackages = rootPackages.Skip(1).OrderBy(x => x.Name, StringComparer.Ordinal).ToList();
+                rootPackages = new List<IPackage> { package };
+                rootPackages.AddRange(includedPackages);
+            }
+
+            return new XmiWritePlan(rootPackages, localIdentifiers, elementsMissingXmiId);
+        }
+
+        /// <summary>
+        /// Collects the complete containment tree of the provided <see cref="IXmiElement"/> into the provided sets.
+        /// </summary>
+        /// <param name="root">
+        /// The <see cref="IXmiElement"/> from which the containment tree is walked
+        /// </param>
+        /// <param name="localElements">
+        /// The set of elements that are serialized inside the document that is being written
+        /// </param>
+        /// <param name="localIdentifiers">
+        /// The <see cref="IXmiElement.FullyQualifiedIdentifier"/>s of the elements that are serialized inside the document
+        /// </param>
+        /// <param name="elementsMissingXmiId">
+        /// The elements that are part of the document but do not have an <see cref="IXmiElement.XmiId"/>
+        /// </param>
+        private void CollectContainmentTree(IXmiElement root, HashSet<IXmiElement> localElements, HashSet<string> localIdentifiers, List<IXmiElement> elementsMissingXmiId)
+        {
+            var elementsToProcess = new Stack<IXmiElement>();
+            elementsToProcess.Push(root);
+
+            while (elementsToProcess.Count > 0)
+            {
+                var element = elementsToProcess.Pop();
+
+                if (!localElements.Add(element))
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(element.XmiId))
+                {
+                    elementsMissingXmiId.Add(element);
+                }
+                else
+                {
+                    localIdentifiers.Add(element.FullyQualifiedIdentifier);
+                }
+
+                foreach (var containmentProperty in QueryTypeProperties(element.GetType()).ContainmentProperties)
+                {
+                    foreach (var containedElement in QueryPropertyValues(containmentProperty, element))
+                    {
+                        elementsToProcess.Push(containedElement);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Queries the elements that are referenced from the containment tree of the provided <see cref="IPackage"/>
+        /// but are not part of the provided set of local elements.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> whose containment tree is inspected
+        /// </param>
+        /// <param name="localElements">
+        /// The set of elements that are serialized inside the document that is being written
+        /// </param>
+        /// <returns>
+        /// The externally referenced <see cref="IXmiElement"/>s
+        /// </returns>
+        private IEnumerable<IXmiElement> QueryExternalReferencedElements(IPackage package, HashSet<IXmiElement> localElements)
+        {
+            var externalElements = new HashSet<IXmiElement>(ReferenceEqualityComparer.Instance);
+            var visitedElements = new HashSet<IXmiElement>(ReferenceEqualityComparer.Instance);
+            var elementsToProcess = new Stack<IXmiElement>();
+            elementsToProcess.Push(package);
+
+            while (elementsToProcess.Count > 0)
+            {
+                var element = elementsToProcess.Pop();
+
+                if (!visitedElements.Add(element))
+                {
+                    continue;
+                }
+
+                var typeProperties = QueryTypeProperties(element.GetType());
+
+                foreach (var containmentProperty in typeProperties.ContainmentProperties)
+                {
+                    foreach (var containedElement in QueryPropertyValues(containmentProperty, element))
+                    {
+                        elementsToProcess.Push(containedElement);
+                    }
+                }
+
+                foreach (var referenceProperty in typeProperties.ReferenceProperties)
+                {
+                    foreach (var referencedElement in QueryPropertyValues(referenceProperty, element))
+                    {
+                        if (!localElements.Contains(referencedElement))
+                        {
+                            externalElements.Add(referencedElement);
+                        }
+                    }
+                }
+            }
+
+            return externalElements;
+        }
+
+        /// <summary>
+        /// Queries the top-level root <see cref="IPackage"/> that contains the provided <see cref="IXmiElement"/>
+        /// by walking up the <see cref="IElement.Possessor"/> chain.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> for which the root package is queried
+        /// </param>
+        /// <returns>
+        /// The root <see cref="IPackage"/>, or null when the <paramref name="element"/> is not contained by a root package
+        /// </returns>
+        private static IPackage QueryRootPackage(IXmiElement element)
+        {
+            if (!(element is IElement current))
+            {
+                return null;
+            }
+
+            while (current.Possessor != null)
+            {
+                current = current.Possessor;
+            }
+
+            return current as IPackage;
+        }
+
+        /// <summary>
+        /// Queries the <see cref="IXmiElement"/> values of the provided property on the provided element.
+        /// </summary>
+        /// <param name="propertyInfo">
+        /// The <see cref="PropertyInfo"/> of the property whose values are queried
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> on which the property values are queried
+        /// </param>
+        /// <returns>
+        /// The <see cref="IXmiElement"/> values of the property
+        /// </returns>
+        private static IEnumerable<IXmiElement> QueryPropertyValues(PropertyInfo propertyInfo, IXmiElement element)
+        {
+            var value = propertyInfo.GetValue(element);
+
+            switch (value)
+            {
+                case null:
+                    yield break;
+
+                case IXmiElement xmiElement:
+                    yield return xmiElement;
+                    break;
+
+                case IEnumerable enumerable:
+                    foreach (var item in enumerable.OfType<IXmiElement>())
+                    {
+                        yield return item;
+                    }
+
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Queries the <see cref="TypeProperties"/> for the provided type from the cache, classifying the
+        /// properties of the type when the type has not been classified before.
+        /// </summary>
+        /// <param name="type">
+        /// The concrete <see cref="IXmiElement"/> type whose properties are classified
+        /// </param>
+        /// <returns>
+        /// The <see cref="TypeProperties"/> of the provided type
+        /// </returns>
+        private static TypeProperties QueryTypeProperties(Type type)
+        {
+            return TypePropertiesCache.GetOrAdd(type, ClassifyTypeProperties);
+        }
+
+        /// <summary>
+        /// Classifies the properties of the provided type into containment properties and reference properties,
+        /// mirroring the classification that is used by the generated readers and writers.
+        /// </summary>
+        /// <param name="type">
+        /// The concrete <see cref="IXmiElement"/> type whose properties are classified
+        /// </param>
+        /// <returns>
+        /// The <see cref="TypeProperties"/> of the provided type
+        /// </returns>
+        private static TypeProperties ClassifyTypeProperties(Type type)
+        {
+            var containmentProperties = new List<PropertyInfo>();
+            var referenceProperties = new List<PropertyInfo>();
+
+            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var propertyInfo in properties)
+            {
+                var propertyAttribute = propertyInfo.GetCustomAttribute<PropertyAttribute>();
+
+                if (propertyAttribute == null || propertyAttribute.IsDerived || propertyAttribute.IsDerivedUnion || propertyAttribute.IsReadOnly)
+                {
+                    continue;
+                }
+
+                if (!QueryIsXmiElementProperty(propertyInfo))
+                {
+                    continue;
+                }
+
+                if (propertyAttribute.Aggregation == AggregationKind.Composite && !QueryIsCompositeSerializedAsReference(propertyInfo, properties))
+                {
+                    containmentProperties.Add(propertyInfo);
+                }
+                else
+                {
+                    referenceProperties.Add(propertyInfo);
+                }
+            }
+
+            return new TypeProperties(containmentProperties, referenceProperties);
+        }
+
+        /// <summary>
+        /// Queries whether the provided property holds one or more <see cref="IXmiElement"/> values.
+        /// </summary>
+        /// <param name="propertyInfo">
+        /// The <see cref="PropertyInfo"/> of the property that is checked
+        /// </param>
+        /// <returns>
+        /// true when the property holds <see cref="IXmiElement"/> values, false otherwise
+        /// </returns>
+        private static bool QueryIsXmiElementProperty(PropertyInfo propertyInfo)
+        {
+            var propertyType = propertyInfo.PropertyType;
+
+            if (propertyType.IsGenericType && propertyType.GenericTypeArguments.Length == 1)
+            {
+                propertyType = propertyType.GenericTypeArguments[0];
+            }
+
+            return typeof(IXmiElement).IsAssignableFrom(propertyType);
+        }
+
+        /// <summary>
+        /// Queries whether the provided composite property is serialized as a reference, which is the case when
+        /// the property has subsetted properties that are all non-derived. This mirrors the behavior of the
+        /// generated readers and writers.
+        /// </summary>
+        /// <param name="propertyInfo">
+        /// The <see cref="PropertyInfo"/> of the composite property that is checked
+        /// </param>
+        /// <param name="properties">
+        /// All public instance properties of the type that declares the <paramref name="propertyInfo"/>
+        /// </param>
+        /// <returns>
+        /// true when the composite property is serialized as a reference, false when it is serialized as contained content
+        /// </returns>
+        private static bool QueryIsCompositeSerializedAsReference(PropertyInfo propertyInfo, PropertyInfo[] properties)
+        {
+            var subsettedPropertyAttributes = propertyInfo.GetCustomAttributes<SubsettedPropertyAttribute>().ToList();
+
+            if (subsettedPropertyAttributes.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (var subsettedPropertyAttribute in subsettedPropertyAttributes)
+            {
+                var subsettedProperty = properties
+                    .Select(x => x.GetCustomAttribute<PropertyAttribute>())
+                    .FirstOrDefault(x => x != null && x.XmiId == subsettedPropertyAttribute.PropertyName);
+
+                if (subsettedProperty == null || subsettedProperty.IsDerived || subsettedProperty.IsDerivedUnion || subsettedProperty.IsReadOnly)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// The <see cref="TypeProperties"/> class captures the classified containment and reference properties of a type.
+        /// </summary>
+        private class TypeProperties
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TypeProperties"/> class.
+            /// </summary>
+            /// <param name="containmentProperties">
+            /// The properties through which the containment tree is walked
+            /// </param>
+            /// <param name="referenceProperties">
+            /// The properties that reference other <see cref="IXmiElement"/>s
+            /// </param>
+            public TypeProperties(List<PropertyInfo> containmentProperties, List<PropertyInfo> referenceProperties)
+            {
+                this.ContainmentProperties = containmentProperties;
+                this.ReferenceProperties = referenceProperties;
+            }
+
+            /// <summary>
+            /// Gets the properties through which the containment tree is walked.
+            /// </summary>
+            public List<PropertyInfo> ContainmentProperties { get; }
+
+            /// <summary>
+            /// Gets the properties that reference other <see cref="IXmiElement"/>s.
+            /// </summary>
+            public List<PropertyInfo> ReferenceProperties { get; }
+        }
+
+        /// <summary>
+        /// An <see cref="IEqualityComparer{T}"/> that compares <see cref="IXmiElement"/>s by reference.
+        /// </summary>
+        private class ReferenceEqualityComparer : IEqualityComparer<IXmiElement>
+        {
+            /// <summary>
+            /// Gets the singleton instance of the <see cref="ReferenceEqualityComparer"/>.
+            /// </summary>
+            public static readonly ReferenceEqualityComparer Instance = new ReferenceEqualityComparer();
+
+            /// <summary>
+            /// Determines whether the provided <see cref="IXmiElement"/>s are the same instance.
+            /// </summary>
+            /// <param name="x">The first <see cref="IXmiElement"/> to compare</param>
+            /// <param name="y">The second <see cref="IXmiElement"/> to compare</param>
+            /// <returns>true when both are the same instance, false otherwise</returns>
+            public bool Equals(IXmiElement x, IXmiElement y)
+            {
+                return ReferenceEquals(x, y);
+            }
+
+            /// <summary>
+            /// Returns the identity-based hash code of the provided <see cref="IXmiElement"/>.
+            /// </summary>
+            /// <param name="obj">The <see cref="IXmiElement"/> for which the hash code is returned</param>
+            /// <returns>the identity-based hash code</returns>
+            public int GetHashCode(IXmiElement obj)
+            {
+                return RuntimeHelpers.GetHashCode(obj);
+            }
+        }
+    }
+}

--- a/uml4net.xmi/Writers/ReferenceClosureCalculator.cs
+++ b/uml4net.xmi/Writers/ReferenceClosureCalculator.cs
@@ -95,44 +95,68 @@ namespace uml4net.xmi.Writers
             var elementsMissingXmiId = new List<IXmiElement>();
             var rootPackages = new List<IPackage> { package };
 
-            this.CollectContainmentTree(package, localElements, localIdentifiers, elementsMissingXmiId);
+            CollectContainmentTree(package, localElements, localIdentifiers, elementsMissingXmiId);
 
             if (externalReferenceResolution == ExternalReferenceResolutionKind.Include)
             {
-                var packagesToProcess = new Queue<IPackage>();
-                packagesToProcess.Enqueue(package);
-
-                while (packagesToProcess.Count > 0)
-                {
-                    var packageToProcess = packagesToProcess.Dequeue();
-
-                    foreach (var externalElement in this.QueryExternalReferencedElements(packageToProcess, localElements))
-                    {
-                        var rootPackage = QueryRootPackage(externalElement);
-
-                        if (rootPackage == null)
-                        {
-                            this.logger.LogWarning("The externally referenced element with id [{XmiId}] is not contained by a root package and is written as an href reference", externalElement.XmiId);
-                            continue;
-                        }
-
-                        if (localElements.Contains(rootPackage))
-                        {
-                            continue;
-                        }
-
-                        this.CollectContainmentTree(rootPackage, localElements, localIdentifiers, elementsMissingXmiId);
-                        rootPackages.Add(rootPackage);
-                        packagesToProcess.Enqueue(rootPackage);
-                    }
-                }
-
-                var includedPackages = rootPackages.Skip(1).OrderBy(x => x.Name, StringComparer.Ordinal).ToList();
-                rootPackages = new List<IPackage> { package };
-                rootPackages.AddRange(includedPackages);
+                this.IncludeExternalRootPackages(package, rootPackages, localElements, localIdentifiers, elementsMissingXmiId);
             }
 
             return new XmiWritePlan(rootPackages, localIdentifiers, elementsMissingXmiId);
+        }
+
+        /// <summary>
+        /// Walks the external references of the selected <paramref name="package"/> and includes the root packages
+        /// that contain those references into the <paramref name="rootPackages"/>, ordered by name.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is selected to be written
+        /// </param>
+        /// <param name="rootPackages">
+        /// The list of root packages that are written to the document; the selected <paramref name="package"/> is the first entry
+        /// </param>
+        /// <param name="localElements">
+        /// The set of elements that are serialized inside the document that is being written
+        /// </param>
+        /// <param name="localIdentifiers">
+        /// The <see cref="IXmiElement.FullyQualifiedIdentifier"/>s of the elements that are serialized inside the document
+        /// </param>
+        /// <param name="elementsMissingXmiId">
+        /// The elements that are part of the document but do not have an <see cref="IXmiElement.XmiId"/>
+        /// </param>
+        private void IncludeExternalRootPackages(IPackage package, List<IPackage> rootPackages, HashSet<IXmiElement> localElements, HashSet<string> localIdentifiers, List<IXmiElement> elementsMissingXmiId)
+        {
+            var packagesToProcess = new Queue<IPackage>();
+            packagesToProcess.Enqueue(package);
+
+            while (packagesToProcess.Count > 0)
+            {
+                var packageToProcess = packagesToProcess.Dequeue();
+
+                foreach (var externalElement in QueryExternalReferencedElements(packageToProcess, localElements))
+                {
+                    var rootPackage = QueryRootPackage(externalElement);
+
+                    if (rootPackage == null)
+                    {
+                        this.logger.LogWarning("The externally referenced element with id [{XmiId}] is not contained by a root package and is written as an href reference", externalElement.XmiId);
+                        continue;
+                    }
+
+                    if (localElements.Contains(rootPackage))
+                    {
+                        continue;
+                    }
+
+                    CollectContainmentTree(rootPackage, localElements, localIdentifiers, elementsMissingXmiId);
+                    rootPackages.Add(rootPackage);
+                    packagesToProcess.Enqueue(rootPackage);
+                }
+            }
+
+            var includedPackages = rootPackages.Skip(1).OrderBy(x => x.Name, StringComparer.Ordinal).ToList();
+            rootPackages.RemoveRange(1, rootPackages.Count - 1);
+            rootPackages.AddRange(includedPackages);
         }
 
         /// <summary>
@@ -150,7 +174,7 @@ namespace uml4net.xmi.Writers
         /// <param name="elementsMissingXmiId">
         /// The elements that are part of the document but do not have an <see cref="IXmiElement.XmiId"/>
         /// </param>
-        private void CollectContainmentTree(IXmiElement root, HashSet<IXmiElement> localElements, HashSet<string> localIdentifiers, List<IXmiElement> elementsMissingXmiId)
+        private static void CollectContainmentTree(IXmiElement root, HashSet<IXmiElement> localElements, HashSet<string> localIdentifiers, List<IXmiElement> elementsMissingXmiId)
         {
             var elementsToProcess = new Stack<IXmiElement>();
             elementsToProcess.Push(root);
@@ -173,12 +197,9 @@ namespace uml4net.xmi.Writers
                     localIdentifiers.Add(element.FullyQualifiedIdentifier);
                 }
 
-                foreach (var containmentProperty in QueryTypeProperties(element.GetType()).ContainmentProperties)
+                foreach (var containedElement in QueryPropertyValues(QueryTypeProperties(element.GetType()).ContainmentProperties, element))
                 {
-                    foreach (var containedElement in QueryPropertyValues(containmentProperty, element))
-                    {
-                        elementsToProcess.Push(containedElement);
-                    }
+                    elementsToProcess.Push(containedElement);
                 }
             }
         }
@@ -196,7 +217,7 @@ namespace uml4net.xmi.Writers
         /// <returns>
         /// The externally referenced <see cref="IXmiElement"/>s
         /// </returns>
-        private IEnumerable<IXmiElement> QueryExternalReferencedElements(IPackage package, HashSet<IXmiElement> localElements)
+        private static IEnumerable<IXmiElement> QueryExternalReferencedElements(IPackage package, HashSet<IXmiElement> localElements)
         {
             var externalElements = new HashSet<IXmiElement>(ReferenceEqualityComparer.Instance);
             var visitedElements = new HashSet<IXmiElement>(ReferenceEqualityComparer.Instance);
@@ -214,23 +235,14 @@ namespace uml4net.xmi.Writers
 
                 var typeProperties = QueryTypeProperties(element.GetType());
 
-                foreach (var containmentProperty in typeProperties.ContainmentProperties)
+                foreach (var containedElement in QueryPropertyValues(typeProperties.ContainmentProperties, element))
                 {
-                    foreach (var containedElement in QueryPropertyValues(containmentProperty, element))
-                    {
-                        elementsToProcess.Push(containedElement);
-                    }
+                    elementsToProcess.Push(containedElement);
                 }
 
-                foreach (var referenceProperty in typeProperties.ReferenceProperties)
+                foreach (var referencedElement in QueryPropertyValues(typeProperties.ReferenceProperties, element).Where(x => !localElements.Contains(x)))
                 {
-                    foreach (var referencedElement in QueryPropertyValues(referenceProperty, element))
-                    {
-                        if (!localElements.Contains(referencedElement))
-                        {
-                            externalElements.Add(referencedElement);
-                        }
-                    }
+                    externalElements.Add(referencedElement);
                 }
             }
 
@@ -260,6 +272,29 @@ namespace uml4net.xmi.Writers
             }
 
             return current as IPackage;
+        }
+
+        /// <summary>
+        /// Queries the <see cref="IXmiElement"/> values of the provided properties on the provided element.
+        /// </summary>
+        /// <param name="propertyInfos">
+        /// The <see cref="PropertyInfo"/>s of the properties whose values are queried
+        /// </param>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> on which the property values are queried
+        /// </param>
+        /// <returns>
+        /// The <see cref="IXmiElement"/> values of the properties
+        /// </returns>
+        private static IEnumerable<IXmiElement> QueryPropertyValues(IEnumerable<PropertyInfo> propertyInfos, IXmiElement element)
+        {
+            foreach (var propertyInfo in propertyInfos)
+            {
+                foreach (var value in QueryPropertyValues(propertyInfo, element))
+                {
+                    yield return value;
+                }
+            }
         }
 
         /// <summary>
@@ -418,7 +453,7 @@ namespace uml4net.xmi.Writers
         /// <summary>
         /// The <see cref="TypeProperties"/> class captures the classified containment and reference properties of a type.
         /// </summary>
-        private class TypeProperties
+        private sealed class TypeProperties
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="TypeProperties"/> class.
@@ -449,7 +484,7 @@ namespace uml4net.xmi.Writers
         /// <summary>
         /// An <see cref="IEqualityComparer{T}"/> that compares <see cref="IXmiElement"/>s by reference.
         /// </summary>
-        private class ReferenceEqualityComparer : IEqualityComparer<IXmiElement>
+        private sealed class ReferenceEqualityComparer : IEqualityComparer<IXmiElement>
         {
             /// <summary>
             /// Gets the singleton instance of the <see cref="ReferenceEqualityComparer"/>.

--- a/uml4net.xmi/Writers/XmiElementWriter.cs
+++ b/uml4net.xmi/Writers/XmiElementWriter.cs
@@ -1,0 +1,190 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiElementWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+
+    using uml4net;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The abstract super class from which each XMI writer needs to derive
+    /// </summary>
+    /// <typeparam name="TXmiElement">The type of the XMI element to be written.</typeparam>
+    public abstract class XmiElementWriter<TXmiElement> where TXmiElement : IXmiElement
+    {
+        /// <summary>
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </summary>
+        protected readonly ILoggerFactory LoggerFactory;
+
+        /// <summary>
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </summary>
+        protected readonly IXmiElementWriterFacade XmiElementWriterFacade;
+
+        /// <summary>
+        /// The injected <see cref="IXmiWriterSettings" /> that provides XMI writer settings
+        /// </summary>
+        protected readonly IXmiWriterSettings XmiWriterSettings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmiElementWriter{T}"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write contained and referenced
+        /// <see cref="IXmiElement"/>s
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The injected <see cref="IXmiWriterSettings" /> that provides XMI writer settings
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        protected XmiElementWriter(IXmiElementWriterFacade xmiElementWriterFacade, IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+        {
+            this.XmiElementWriterFacade = xmiElementWriterFacade;
+            this.XmiWriterSettings = xmiWriterSettings;
+            this.LoggerFactory = loggerFactory;
+        }
+
+        /// <summary>
+        /// Writes the provided <typeparamref name="TXmiElement"/> to the <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <typeparamref name="TXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        public abstract void Write(XmlWriter xmlWriter, TXmiElement element, string elementName, IXmiWriteContext writeContext);
+
+        /// <summary>
+        /// Asynchronously writes the provided <typeparamref name="TXmiElement"/> to the <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="element">
+        /// The <typeparamref name="TXmiElement"/> that is to be written
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <param name="writeContext">
+        /// The <see cref="IXmiWriteContext"/> that captures the state of the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public abstract Task WriteAsync(XmlWriter xmlWriter, TXmiElement element, string elementName, IXmiWriteContext writeContext);
+
+        /// <summary>
+        /// Writes the start element to the <see cref="XmlWriter"/>. The <paramref name="elementName"/> may be
+        /// a qualified name such as <code>uml:Package</code>, in which case the appropriate namespace is used,
+        /// or a plain property name such as <code>packagedElement</code>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        protected void WriteStartElement(XmlWriter xmlWriter, string elementName)
+        {
+            var separatorIndex = elementName.IndexOf(':');
+
+            if (separatorIndex > 0)
+            {
+                var prefix = elementName.Substring(0, separatorIndex);
+                var localName = elementName.Substring(separatorIndex + 1);
+                var namespaceUri = prefix == "xmi" ? this.XmiWriterSettings.XmiNamespaceUri : this.XmiWriterSettings.UmlNamespaceUri;
+
+                xmlWriter.WriteStartElement(prefix, localName, namespaceUri);
+            }
+            else
+            {
+                xmlWriter.WriteStartElement(elementName);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes the start element to the <see cref="XmlWriter"/>. The <paramref name="elementName"/> may be
+        /// a qualified name such as <code>uml:Package</code>, in which case the appropriate namespace is used,
+        /// or a plain property name such as <code>packagedElement</code>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="elementName">
+        /// The name of the XML element that is written
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        protected Task WriteStartElementAsync(XmlWriter xmlWriter, string elementName)
+        {
+            var separatorIndex = elementName.IndexOf(':');
+
+            if (separatorIndex > 0)
+            {
+                var prefix = elementName.Substring(0, separatorIndex);
+                var localName = elementName.Substring(separatorIndex + 1);
+                var namespaceUri = prefix == "xmi" ? this.XmiWriterSettings.XmiNamespaceUri : this.XmiWriterSettings.UmlNamespaceUri;
+
+                return xmlWriter.WriteStartElementAsync(prefix, localName, namespaceUri);
+            }
+
+            return xmlWriter.WriteStartElementAsync(null, elementName, null);
+        }
+
+        /// <summary>
+        /// Returns the provided value with the first letter converted to lower case, which is used to
+        /// serialize enumeration literals.
+        /// </summary>
+        /// <param name="value">
+        /// the value that is to be converted
+        /// </param>
+        /// <returns>
+        /// the converted value
+        /// </returns>
+        protected static string LowerCaseFirstLetter(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            return char.ToLowerInvariant(value[0]) + value.Substring(1);
+        }
+    }
+}

--- a/uml4net.xmi/Writers/XmiWriteContext.cs
+++ b/uml4net.xmi/Writers/XmiWriteContext.cs
@@ -1,0 +1,98 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiWriteContext.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The <see cref="XmiWriteContext"/> represents the state of a single write operation that is
+    /// shared by all <see cref="XmiElementWriter{TXmiElement}"/> instances while writing an XMI document.
+    /// </summary>
+    public class XmiWriteContext : IXmiWriteContext
+    {
+        /// <summary>
+        /// The <see cref="IXmiElement.FullyQualifiedIdentifier"/>s of the elements that are serialized
+        /// inside the document that is being written.
+        /// </summary>
+        private readonly HashSet<string> localIdentifiers;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmiWriteContext"/> class.
+        /// </summary>
+        /// <param name="documentName">
+        /// The name of the document that is being written
+        /// </param>
+        /// <param name="localIdentifiers">
+        /// The <see cref="IXmiElement.FullyQualifiedIdentifier"/>s of the elements that are serialized
+        /// inside the document that is being written
+        /// </param>
+        public XmiWriteContext(string documentName, HashSet<string> localIdentifiers)
+        {
+            this.DocumentName = documentName ?? throw new ArgumentNullException(nameof(documentName));
+            this.localIdentifiers = localIdentifiers ?? throw new ArgumentNullException(nameof(localIdentifiers));
+        }
+
+        /// <summary>
+        /// Gets the name of the document that is being written.
+        /// </summary>
+        public string DocumentName { get; }
+
+        /// <summary>
+        /// Queries whether the provided <see cref="IXmiElement"/> is serialized inside the document that is being written.
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that is to be checked
+        /// </param>
+        /// <returns>
+        /// true when the <paramref name="element"/> is part of the document that is being written, false otherwise
+        /// </returns>
+        public bool IsLocal(IXmiElement element)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            return this.localIdentifiers.Contains(element.FullyQualifiedIdentifier);
+        }
+
+        /// <summary>
+        /// Queries the href reference to the provided <see cref="IXmiElement"/>, which is the concatenation
+        /// of the <see cref="IXmiElement.DocumentName"/> and the <see cref="IXmiElement.XmiId"/> separated by a pound sign #
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> for which the href reference is queried
+        /// </param>
+        /// <returns>
+        /// the href reference to the <paramref name="element"/>
+        /// </returns>
+        public string QueryHref(IXmiElement element)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            return $"{element.DocumentName}#{element.XmiId}";
+        }
+    }
+}

--- a/uml4net.xmi/Writers/XmiWritePlan.cs
+++ b/uml4net.xmi/Writers/XmiWritePlan.cs
@@ -1,0 +1,71 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiWritePlan.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.Collections.Generic;
+
+    using uml4net.Packages;
+
+    /// <summary>
+    /// The <see cref="XmiWritePlan"/> represents the result of a reference closure calculation and captures
+    /// which <see cref="IPackage"/>s are written as root packages of the XMI document and which elements
+    /// are serialized inside the document.
+    /// </summary>
+    public class XmiWritePlan
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmiWritePlan"/> class.
+        /// </summary>
+        /// <param name="rootPackages">
+        /// The <see cref="IPackage"/>s that are written as root packages of the XMI document
+        /// </param>
+        /// <param name="localIdentifiers">
+        /// The <see cref="IXmiElement.FullyQualifiedIdentifier"/>s of the elements that are serialized inside the XMI document
+        /// </param>
+        /// <param name="elementsMissingXmiId">
+        /// The elements that are part of the document but do not have an <see cref="IXmiElement.XmiId"/>
+        /// </param>
+        public XmiWritePlan(IReadOnlyList<IPackage> rootPackages, HashSet<string> localIdentifiers, IReadOnlyList<IXmiElement> elementsMissingXmiId)
+        {
+            this.RootPackages = rootPackages ?? throw new ArgumentNullException(nameof(rootPackages));
+            this.LocalIdentifiers = localIdentifiers ?? throw new ArgumentNullException(nameof(localIdentifiers));
+            this.ElementsMissingXmiId = elementsMissingXmiId ?? throw new ArgumentNullException(nameof(elementsMissingXmiId));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IPackage"/>s that are written as root packages of the XMI document. The selected
+        /// package comes first, followed by the packages that are included as a result of
+        /// <see cref="uml4net.xmi.Settings.ExternalReferenceResolutionKind.Include"/>.
+        /// </summary>
+        public IReadOnlyList<IPackage> RootPackages { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IXmiElement.FullyQualifiedIdentifier"/>s of the elements that are serialized inside the XMI document.
+        /// </summary>
+        public HashSet<string> LocalIdentifiers { get; }
+
+        /// <summary>
+        /// Gets the elements that are part of the document but do not have an <see cref="IXmiElement.XmiId"/>.
+        /// </summary>
+        public IReadOnlyList<IXmiElement> ElementsMissingXmiId { get; }
+    }
+}

--- a/uml4net.xmi/Writers/XmiWriter.cs
+++ b/uml4net.xmi/Writers/XmiWriter.cs
@@ -1,0 +1,352 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net.Packages;
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="XmiWriter"/> is to provide a means to write (serialize)
+    /// a UML 2.5.1 model to XMI
+    /// </summary>
+    public class XmiWriter : IXmiWriter
+    {
+        /// <summary>
+        /// The (injected) <see cref="ILogger{XmiWriter}"/> used to perform logging
+        /// </summary>
+        private readonly ILogger<XmiWriter> logger;
+
+        /// <summary>
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </summary>
+        protected readonly ILoggerFactory LoggerFactory;
+
+        /// <summary>
+        /// The <see cref="IXmiWriterScope"/>
+        /// </summary>
+        private readonly IXmiWriterScope scope;
+
+        /// <summary>
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write the root packages
+        /// </summary>
+        protected readonly IXmiElementWriterFacade XmiElementWriterFacade;
+
+        /// <summary>
+        /// The (injected) <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </summary>
+        protected readonly IXmiWriterSettings XmiWriterSettings;
+
+        /// <summary>
+        /// The (injected) <see cref="IReferenceClosureCalculator"/> used to calculate the <see cref="XmiWritePlan"/>
+        /// </summary>
+        private readonly IReferenceClosureCalculator referenceClosureCalculator;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmiWriter"/> class.
+        /// </summary>
+        /// <param name="xmiElementWriterFacade">
+        /// The (injected) <see cref="IXmiElementWriterFacade"/> used to write the root packages
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        /// <param name="scope">
+        /// The <see cref="IXmiWriterScope"/> used for managing the lifecycle of services used during the XMI writing process.
+        /// </param>
+        /// <param name="xmiWriterSettings">
+        /// The injected <see cref="IXmiWriterSettings"/> that provides writing settings for XMI
+        /// </param>
+        /// <param name="referenceClosureCalculator">
+        /// The (injected) <see cref="IReferenceClosureCalculator"/> used to calculate the <see cref="XmiWritePlan"/>
+        /// </param>
+        public XmiWriter(IXmiElementWriterFacade xmiElementWriterFacade, ILoggerFactory loggerFactory, IXmiWriterScope scope,
+            IXmiWriterSettings xmiWriterSettings, IReferenceClosureCalculator referenceClosureCalculator)
+        {
+            this.XmiElementWriterFacade = xmiElementWriterFacade;
+            this.XmiWriterSettings = xmiWriterSettings;
+            this.LoggerFactory = loggerFactory;
+            this.logger = this.LoggerFactory == null ? NullLogger<XmiWriter>.Instance : this.LoggerFactory.CreateLogger<XmiWriter>();
+            this.scope = scope;
+            this.referenceClosureCalculator = referenceClosureCalculator;
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/> to a UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        public void Write(IPackage package, string fileUri)
+        {
+            if (string.IsNullOrEmpty(fileUri))
+            {
+                throw new ArgumentException(nameof(fileUri));
+            }
+
+            using var fileStream = File.Create(fileUri);
+
+            var sw = Stopwatch.StartNew();
+
+            this.logger.LogInformation("start serializing to {Path}", fileUri);
+
+            this.Write(package, fileStream, new FileInfo(fileUri).Name);
+
+            this.logger.LogInformation("File {Path} serialized in {Time} [ms]", fileUri, sw.ElapsedMilliseconds);
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/> to a UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        public void Write(IPackage package, Stream stream, string documentName)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            if (string.IsNullOrEmpty(documentName))
+            {
+                throw new ArgumentException(nameof(documentName));
+            }
+
+            var writeContext = this.CreateWriteContext(package, documentName, out var xmiWritePlan);
+
+            using var xmlWriter = XmlWriter.Create(stream, this.CreateXmlWriterSettings(isAsync: false));
+
+            xmlWriter.WriteStartDocument();
+            xmlWriter.WriteStartElement("xmi", "XMI", this.XmiWriterSettings.XmiNamespaceUri);
+            xmlWriter.WriteAttributeString("xmlns", "uml", null, this.XmiWriterSettings.UmlNamespaceUri);
+
+            foreach (var rootPackage in xmiWritePlan.RootPackages)
+            {
+                this.XmiElementWriterFacade.Write(xmlWriter, rootPackage, $"uml:{rootPackage.GetType().Name}", writeContext);
+            }
+
+            xmlWriter.WriteEndElement();
+            xmlWriter.WriteEndDocument();
+            xmlWriter.Flush();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/> to a UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task WriteAsync(IPackage package, string fileUri, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(fileUri))
+            {
+                throw new ArgumentException(nameof(fileUri));
+            }
+
+            using var fileStream = File.Create(fileUri);
+
+            var sw = Stopwatch.StartNew();
+
+            this.logger.LogInformation("start serializing to {Path}", fileUri);
+
+            await this.WriteAsync(package, fileStream, new FileInfo(fileUri).Name, cancellationToken);
+
+            this.logger.LogInformation("File {Path} serialized in {Time} [ms]", fileUri, sw.ElapsedMilliseconds);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/> to a UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task WriteAsync(IPackage package, Stream stream, string documentName, CancellationToken cancellationToken = default)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            if (string.IsNullOrEmpty(documentName))
+            {
+                throw new ArgumentException(nameof(documentName));
+            }
+
+            var writeContext = this.CreateWriteContext(package, documentName, out var xmiWritePlan);
+
+            using var xmlWriter = XmlWriter.Create(stream, this.CreateXmlWriterSettings(isAsync: true));
+
+            await xmlWriter.WriteStartDocumentAsync();
+            await xmlWriter.WriteStartElementAsync("xmi", "XMI", this.XmiWriterSettings.XmiNamespaceUri);
+            await xmlWriter.WriteAttributeStringAsync("xmlns", "uml", null, this.XmiWriterSettings.UmlNamespaceUri);
+
+            foreach (var rootPackage in xmiWritePlan.RootPackages)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                await this.XmiElementWriterFacade.WriteAsync(xmlWriter, rootPackage, $"uml:{rootPackage.GetType().Name}", writeContext);
+            }
+
+            await xmlWriter.WriteEndElementAsync();
+            await xmlWriter.WriteEndDocumentAsync();
+            await xmlWriter.FlushAsync();
+        }
+
+        /// <summary>
+        /// Creates the <see cref="IXmiWriteContext"/> for the provided <see cref="IPackage"/> based on the
+        /// <see cref="XmiWritePlan"/> that is calculated by the <see cref="IReferenceClosureCalculator"/>.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="xmiWritePlan">
+        /// The calculated <see cref="XmiWritePlan"/>
+        /// </param>
+        /// <returns>
+        /// The created <see cref="IXmiWriteContext"/>
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// thrown when elements that are part of the document do not have an <see cref="IXmiElement.XmiId"/>
+        /// </exception>
+        private IXmiWriteContext CreateWriteContext(IPackage package, string documentName, out XmiWritePlan xmiWritePlan)
+        {
+            xmiWritePlan = this.referenceClosureCalculator.CalculateWritePlan(package, this.XmiWriterSettings.ExternalReferenceResolution, documentName);
+
+            if (xmiWritePlan.ElementsMissingXmiId.Count > 0)
+            {
+                var offenders = string.Join(", ", xmiWritePlan.ElementsMissingXmiId.Select(x => x.GetType().Name));
+
+                throw new InvalidOperationException($"The model cannot be written since the following elements do not have an XmiId: {offenders}");
+            }
+
+            return new XmiWriteContext(documentName, xmiWritePlan.LocalIdentifiers);
+        }
+
+        /// <summary>
+        /// Creates the <see cref="XmlWriterSettings"/> used to create an <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="isAsync">
+        /// A value indicating whether asynchronous <see cref="XmlWriter"/> methods can be used
+        /// </param>
+        /// <returns>
+        /// The created <see cref="XmlWriterSettings"/>
+        /// </returns>
+        private XmlWriterSettings CreateXmlWriterSettings(bool isAsync)
+        {
+            return new XmlWriterSettings
+            {
+                Async = isAsync,
+                Indent = this.XmiWriterSettings.Indent,
+                IndentChars = "  ",
+                NewLineChars = "\n",
+                NewLineHandling = NewLineHandling.Replace,
+                OmitXmlDeclaration = false,
+                Encoding = new UTF8Encoding(false)
+            };
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <param name="disposing">
+        /// A value indicating whether this class is being disposed of
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.scope.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~XmiWriter()
+        {
+            this.Dispose(false);
+        }
+    }
+}

--- a/uml4net.xmi/XmiWriterBuilder.cs
+++ b/uml4net.xmi/XmiWriterBuilder.cs
@@ -1,0 +1,110 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiWriterBuilder.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi
+{
+    using Autofac;
+
+    using Microsoft.Extensions.Logging;
+
+    using uml4net.xmi.Settings;
+    using uml4net.xmi.Writers;
+
+    /// <summary>
+    /// Provides builder methods to configure and create an instance of <see cref="IXmiWriter" />.
+    /// </summary>
+    public static class XmiWriterBuilder
+    {
+        /// <summary>
+        /// Delegate for configuring IXmiWriterSettings.
+        /// </summary>
+        /// <param name="settings">The settings instance to configure.</param>
+        public delegate void ConfigureXmiWriterSettings(IXmiWriterSettings settings);
+
+        /// <summary>
+        /// Creates a new instance of <see cref="XmiWriterScope" /> used to configure services for an XMI writer.
+        /// </summary>
+        /// <returns>
+        /// A new <see cref="XmiWriterScope" /> to configure and build the XMI writer.
+        /// </returns>
+        public static XmiWriterScope Create()
+        {
+            return new XmiWriterScope();
+        }
+
+        /// <summary>
+        /// Configures the <see cref="XmiWriterScope" /> using a builder delegate to set properties of the
+        /// <see cref="IXmiWriterSettings" /> instance.
+        /// </summary>
+        /// <param name="scope">The <see cref="XmiWriterScope" /> being configured.</param>
+        /// <param name="configure">The delegate to configure the <see cref="IXmiWriterSettings" />.</param>
+        /// <returns>
+        /// The configured <see cref="XmiWriterScope" /> instance.
+        /// </returns>
+        public static XmiWriterScope UsingSettings(this XmiWriterScope scope, ConfigureXmiWriterSettings configure)
+        {
+            var settings = new DefaultWriterSettings();
+            configure(settings);
+            scope.ContainerBuilder.RegisterInstance(settings).As<IXmiWriterSettings>();
+            return scope;
+        }
+
+        /// <summary>
+        /// Configures the <see cref="XmiWriterScope" /> to use the provided <see cref="IXmiWriterSettings" /> instance.
+        /// </summary>
+        /// <param name="scope">The <see cref="XmiWriterScope" /> being configured.</param>
+        /// <param name="settings">The <see cref="IXmiWriterSettings" /> to be used by the XMI writer.</param>
+        /// <returns>
+        /// The configured <see cref="XmiWriterScope" /> instance.
+        /// </returns>
+        public static XmiWriterScope UsingSettings(this XmiWriterScope scope, IXmiWriterSettings settings)
+        {
+            scope.ContainerBuilder.RegisterInstance(settings).As<IXmiWriterSettings>();
+            return scope;
+        }
+
+        /// <summary>
+        /// Configures the <see cref="XmiWriterScope" /> to use the provided <see cref="ILoggerFactory" /> for logging.
+        /// </summary>
+        /// <param name="scope">The <see cref="XmiWriterScope" /> being configured.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory" /> to be used for logging.</param>
+        /// <returns>
+        /// The configured <see cref="XmiWriterScope" /> instance.
+        /// </returns>
+        public static XmiWriterScope WithLogger(this XmiWriterScope scope, ILoggerFactory loggerFactory)
+        {
+            scope.ContainerBuilder.RegisterInstance(loggerFactory).As<ILoggerFactory>().SingleInstance();
+            return scope;
+        }
+
+        /// <summary>
+        /// Builds and configures the <see cref="IXmiWriter" /> based on the services added to the <see cref="XmiWriterScope" />.
+        /// </summary>
+        /// <param name="scope">The <see cref="XmiWriterScope" /> being used to build the XMI writer.</param>
+        /// <returns>
+        /// A fully configured instance of <see cref="IXmiWriter" />.
+        /// </returns>
+        public static IXmiWriter Build(this XmiWriterScope scope)
+        {
+            scope.CreateScope();
+            return scope.Scope.Resolve<IXmiWriter>();
+        }
+    }
+}

--- a/uml4net.xmi/XmiWriterScope.cs
+++ b/uml4net.xmi/XmiWriterScope.cs
@@ -1,0 +1,111 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiWriterScope.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi
+{
+    using System;
+
+    using Autofac;
+
+    using Microsoft.Extensions.Logging;
+
+    using uml4net.xmi.Settings;
+    using uml4net.xmi.Writers;
+
+    /// <summary>
+    /// Represents the scope for configuring and managing services used by the XMI writer.
+    /// </summary>
+    public class XmiWriterScope : IXmiWriterScope
+    {
+        /// <summary>
+        /// Gets the Autofac container builder for configuring services.
+        /// </summary>
+        internal ContainerBuilder ContainerBuilder { get; } = new();
+
+        /// <summary>
+        /// Gets the Autofac container for resolving services.
+        /// </summary>
+        internal IContainer Container { get; private set; }
+
+        /// <summary>
+        /// Gets the service scope which provides a scoped lifetime for services.
+        /// </summary>
+        internal ILifetimeScope Scope { get; private set; }
+
+        /// <summary>
+        /// Builds the service provider and service scope from the configured service collection.
+        /// </summary>
+        internal void CreateScope()
+        {
+            this.Container = this.ContainerBuilder.Build();
+            this.Scope = this.Container.BeginLifetimeScope();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmiWriterScope"/> class and configures default services.
+        /// </summary>
+        internal XmiWriterScope()
+        {
+            // Overridable services
+            this.ContainerBuilder.RegisterType<DefaultWriterSettings>().As<IXmiWriterSettings>();
+
+            // Required services
+            this.ContainerBuilder.RegisterGeneric(typeof(Logger<>)).As(typeof(ILogger<>));
+            this.ContainerBuilder.RegisterInstance(this).As<IXmiWriterScope>().SingleInstance();
+
+            this.ContainerBuilder.RegisterType<ReferenceClosureCalculator>().As<IReferenceClosureCalculator>().SingleInstance();
+
+            // Writers
+            this.ContainerBuilder.RegisterType<XmiElementWriterFacade>().As<IXmiElementWriterFacade>().SingleInstance();
+            this.ContainerBuilder.RegisterType<XmiWriter>().As<IXmiWriter>();
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <param name="disposing">
+        /// A value indicating whether this class is being disposed of
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.Container?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~XmiWriterScope()
+        {
+            this.Dispose(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements #194: an XMI writer for `uml4net.xmi` that serializes a UML model (or a selected `Package`) back to XMI, mirroring the existing XMI reader architecture exactly.

- `XmiWriterBuilder` / `XmiWriterScope` / `XmiWriter` follow the same Autofac-based pattern as `XmiReaderBuilder` / `XmiReaderScope` / `XmiReader`.
- Sync and async `Write` APIs, writing to a file path or a `Stream`.
- External reference handling is selectable via `IXmiWriterSettings.ExternalReferenceResolution`:
  - `Href` (default) — references outside the selected package are written as `href` links to the original document.
  - `Include` — the containing root packages of external references are pulled into the output, producing a self-contained document.
- `ReferenceClosureCalculator` computes the containment/reference closure at runtime from the same `[Property]`/`[SubsettedProperty]` metadata used by the reader, including replicating the composite-serialized-as-reference case (e.g. `Behavior.postcondition`).
- 193 generated element writers + `XmiElementWriterFacade` in `uml4net.xmi/AutoGenXmiWriters/`, generated from new Handlebars templates/helpers in `uml4net.CodeGenerator` / `uml4net.HandleBars`, regenerable via the `[Explicit]` test `XmiWriterGeneratorTestFixture.Regenerate_AutoGenXmiWriters_of_uml4net_xmi`.
- README and CLAUDE.md updated to document the writer.

## Testing

- Full solution test suite green (431 tests) including new round-trip tests (`UML.xmi`, `SysML.uml`) proving read → write → re-read produces an equivalent object graph, sync/async byte-identical output, and Include-mode self-containment.
- New-code coverage on hand-written writer classes is ≥94% (gate is 80%).