### PR TITLE
[Improvement] update GitHub Actions to latest versions and pin to full commit SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  # Every action in .github/workflows is pinned to a full commit SHA (SonarQube rule S7637).
+  # Dependabot understands those pins and bumps both the SHA and the trailing "# vX.Y.Z"
+  # comment, which is what keeps the pins from going stale.
+  #
+  # NuGet is deliberately not managed here: the nuget-reference-check workflow already
+  # reports outdated, deprecated and vulnerable packages, and it intentionally ignores
+  # Microsoft.Extensions.Logging.Abstractions (pinned to a low floor - see
+  # Directory.Packages.props). A second, unaware NuGet updater would fight that.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "development"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[Update]"
+    labels:
+      - "dependencies"
+      - "maintenance"

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -10,17 +10,17 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 17
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'
           overwrite-settings: false
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -21,13 +21,13 @@ jobs:
   
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       # Override language selection by uncommenting this and choosing your languages
       with:
         languages: csharp
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v5.1.0
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: 10.0.x
     - name: Install dependencies
@@ -36,4 +36,4 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/nuget-reference-check.yml
+++ b/.github/workflows/nuget-reference-check.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
     - name: Setup .NET Environment
-      uses: actions/setup-dotnet@v5.1.0
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: 10.0.x
 
@@ -89,7 +89,7 @@ jobs:
         
     - name: Create GitHub Issue if issues found
       if: steps.outdated.outputs.outdated == 'true' || steps.deprecated.outputs.deprecated == 'true' || steps.vulnerable.outputs.vulnerable == 'true'
-      uses: actions/github-script@v6
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/nuget-release.yml
+++ b/.github/workflows/nuget-release.yml
@@ -18,7 +18,7 @@ jobs:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ env.DEFAULT_BRANCH }}
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: '10.0.x'
 
@@ -190,7 +190,7 @@ jobs:
           git push origin "refs/tags/${VERSION}"
 
       - name: Create draft GitHub release (attach EXE)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           draft: true
           prerelease: ${{ env.PRERELEASE }}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/uml4net/pulls) open
- [x] I have verified that I am following the uml4net [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/uml4net/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable) — CI-only change, no C# code touched

### Description

Inspects all GitHub Actions workflows, updates every action to its latest release, and pins each one to a full commit SHA.

#### Fixes the open SonarCloud security issue

SonarCloud reported exactly one open issue with a SECURITY impact:

| Rule | Location | Message |
|------|----------|---------|
| `githubactions:S7637` (MAJOR) | `.github/workflows/nuget-release.yml:193` | Use full commit SHA hash for this dependency. |

The offender was `softprops/action-gh-release@v2`. A mutable tag can be repointed upstream at any time, and this workflow runs with `contents: write` plus `NUGET_API_KEY` in scope. It is now pinned to a SHA. S7637 only flags actions outside its trusted-owner list (`actions`, `github`), which is why it was the sole hit — but all actions are pinned here for uniform supply-chain hardening.

#### Version bumps

| Action | Before | After | SHA |
|---|---|---|---|
| `actions/checkout` | v6.0.2 | v7.0.1 | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| `actions/setup-java` | v5.2.0 | v5.6.0 | `03ad4de0992f5dab5e18fcb136590ce7c4a0ac95` |
| `actions/setup-dotnet` | v5.1.0 | v6.0.0 | `a98b56852c35b8e3190ac28c8c2271da59106c68` |
| `github/codeql-action/{init,analyze}` | v3 | v4.37.3 | `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` |
| `softprops/action-gh-release` | v2 | v3.0.2 | `3d0d9888cb7fd7b750713d6e236d1fcb99157228` |
| `actions/github-script` | v6 | v9.0.0 | `3a2844b7e9c422d3c10d287c895573f7108da1b3` |

Every SHA was verified to dereference back to its claimed tag via the GitHub API.

#### Breaking-change review

All the major bumps are safe for this repo:

- **checkout v7** — ESM migration, plus a block on checking out fork PRs under `pull_request_target` / `workflow_run`. Neither trigger is used here.
- **setup-dotnet v6 / gh-release v3 / codeql-action v4** — Node 24 runtime. All jobs run on `ubuntu-latest`, whose runner supports Node 24.
- **codeql-action v3 -> v4** — v3 is deprecated as of December 2026, so this bump is required regardless. v4 drops the `add-snippets` input, which is not used here.
- **github-script v6 -> v9** — the breaking changes are that `require('@actions/github')` no longer resolves (ESM-only) and `getOctokit` is now an injected parameter. The inline script in `nuget-reference-check.yml` uses only `github.rest.issues.*`, `context` and `require('fs')`; `require` is still injected in v9, and the script declares no `getOctokit` binding. **The script body is unchanged.**

#### Adds `.github/dependabot.yml`

SHA pins go stale without automation, and the repo had no Dependabot config. Adds a weekly `github-actions` update targeting `development` — Dependabot understands SHA-pinned `uses:` and bumps the SHA and the trailing `# vX.Y.Z` comment together.

Scoped to `github-actions` only: NuGet is already covered by `nuget-reference-check.yml`, which deliberately ignores `Microsoft.Extensions.Logging.Abstractions` (pinned to a low floor, see `Directory.Packages.props`). A second, unaware NuGet updater would fight that.

#### Verification

- `Build & Test & SonarQube`, `Code scanning - action` and `nuget package reference check` all run on `pull_request`, so this PR exercises checkout, setup-java, setup-dotnet, codeql-action v4 and github-script v9 end to end.
- `softprops/action-gh-release` is only reachable via `workflow_dispatch` on `nuget-release.yml`, so it is **not** exercised by this PR. It is a version bump with no input-schema change (`draft`, `prerelease`, `name`, `tag_name`, `body_path`, `files` are all unchanged in v3).