### PR TITLE
[Improvement] resolve open SonarQube reliability and maintainability findings

### DIFF
--- a/uml4net.Reporting.Tests/Drawing/AssociationDiagramRendererTestFixture.cs
+++ b/uml4net.Reporting.Tests/Drawing/AssociationDiagramRendererTestFixture.cs
@@ -25,6 +25,8 @@ namespace uml4net.Reporting.Tests.Drawing
     using System.Linq;
 
     using Microsoft.Extensions.Logging;
+    using Microsoft.Msagl.Core.Geometry;
+    using Microsoft.Msagl.Core.Geometry.Curves;
 
     using NUnit.Framework;
 
@@ -296,6 +298,64 @@ namespace uml4net.Reporting.Tests.Drawing
             var svg = this.associationDiagramRenderer.SvgRenderForClass(targetClass, this.payload);
 
             Assert.That(svg, Does.Contain("stroke-width=\"12\""));
+        }
+
+        [Test]
+        public void Verify_that_GetPenultimatePoint_returns_the_point_before_the_end_for_a_polyline()
+        {
+            var polyline = new Polyline(new Point(0, 0), new Point(10, 10), new Point(20, 30));
+
+            var penultimatePoint = AssociationDiagramRenderer.GetPenultimatePoint(polyline);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(penultimatePoint.X, Is.EqualTo(10));
+                Assert.That(penultimatePoint.Y, Is.EqualTo(10));
+            }
+        }
+
+        [Test]
+        public void Verify_that_GetPenultimatePoint_returns_the_start_for_a_polyline_with_a_single_point()
+        {
+            var polyline = new Polyline(new Point(7, 9));
+
+            var penultimatePoint = AssociationDiagramRenderer.GetPenultimatePoint(polyline);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(penultimatePoint.X, Is.EqualTo(7));
+                Assert.That(penultimatePoint.Y, Is.EqualTo(9));
+            }
+        }
+
+        [Test]
+        public void Verify_that_GetPenultimatePoint_returns_the_start_of_the_last_segment_for_a_compound_curve()
+        {
+            var curve = new Curve();
+            curve.AddSegment(new LineSegment(new Point(0, 0), new Point(10, 10)));
+            curve.AddSegment(new LineSegment(new Point(10, 10), new Point(25, 40)));
+
+            var penultimatePoint = AssociationDiagramRenderer.GetPenultimatePoint(curve);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(penultimatePoint.X, Is.EqualTo(10));
+                Assert.That(penultimatePoint.Y, Is.EqualTo(10));
+            }
+        }
+
+        [Test]
+        public void Verify_that_GetPenultimatePoint_returns_the_start_for_an_unsupported_curve()
+        {
+            var lineSegment = new LineSegment(new Point(3, 4), new Point(15, 16));
+
+            var penultimatePoint = AssociationDiagramRenderer.GetPenultimatePoint(lineSegment);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(penultimatePoint.X, Is.EqualTo(3));
+                Assert.That(penultimatePoint.Y, Is.EqualTo(4));
+            }
         }
 
         /// <summary>

--- a/uml4net.Reporting/Drawing/AssociationDiagramRenderer.cs
+++ b/uml4net.Reporting/Drawing/AssociationDiagramRenderer.cs
@@ -615,7 +615,11 @@ namespace uml4net.Reporting.Drawing
         /// <returns>
         /// The penultimate <see cref="Microsoft.Msagl.Core.Geometry.Point"/>
         /// </returns>
-        private static Microsoft.Msagl.Core.Geometry.Point GetPenultimatePoint(ICurve curve)
+        /// <remarks>
+        /// internal rather than private so that the individual curve shapes it handles can be verified
+        /// directly; the layout engine does not deterministically produce all of them
+        /// </remarks>
+        internal static Microsoft.Msagl.Core.Geometry.Point GetPenultimatePoint(ICurve curve)
         {
             switch (curve)
             {

--- a/uml4net.Reporting/Drawing/AssociationDiagramRenderer.cs
+++ b/uml4net.Reporting/Drawing/AssociationDiagramRenderer.cs
@@ -81,7 +81,7 @@ namespace uml4net.Reporting.Drawing
         {
             var classSet = new HashSet<IClass>(payload.Classes);
 
-            var associationEdges = this.CollectAssociationEdges(targetClass, payload.Classes, classSet);
+            var associationEdges = CollectAssociationEdges(targetClass, payload.Classes, classSet);
 
             if (associationEdges.Count == 0)
             {
@@ -122,7 +122,7 @@ namespace uml4net.Reporting.Drawing
         /// <returns>
         /// A list of <see cref="AssociationEdgeInfo"/> representing all associations
         /// </returns>
-        private List<AssociationEdgeInfo> CollectAssociationEdges(IClass targetClass, IEnumerable<IClass> allClasses, HashSet<IClass> classSet)
+        private static List<AssociationEdgeInfo> CollectAssociationEdges(IClass targetClass, IEnumerable<IClass> allClasses, HashSet<IClass> classSet)
         {
             var edges = new List<AssociationEdgeInfo>();
 
@@ -537,8 +537,8 @@ namespace uml4net.Reporting.Drawing
 
             group.Children.Add(title);
             var endPoint = curve.End;
-            var penultimatePoint = this.GetPenultimatePoint(curve);
-            var (labelOffsetX, labelOffsetY, anchor) = this.ComputeLabelOffset(endPoint, penultimatePoint);
+            var penultimatePoint = GetPenultimatePoint(curve);
+            var (labelOffsetX, labelOffsetY, anchor) = ComputeLabelOffset(endPoint, penultimatePoint);
 
             if (!string.IsNullOrEmpty(multiplicity))
             {
@@ -615,7 +615,7 @@ namespace uml4net.Reporting.Drawing
         /// <returns>
         /// The penultimate <see cref="Microsoft.Msagl.Core.Geometry.Point"/>
         /// </returns>
-        private Microsoft.Msagl.Core.Geometry.Point GetPenultimatePoint(ICurve curve)
+        private static Microsoft.Msagl.Core.Geometry.Point GetPenultimatePoint(ICurve curve)
         {
             switch (curve)
             {
@@ -644,7 +644,7 @@ namespace uml4net.Reporting.Drawing
         /// <returns>
         /// A tuple of (offsetX, offsetY, textAnchor) for positioning the label
         /// </returns>
-        private (double OffsetX, double OffsetY, SvgTextAnchor Anchor) ComputeLabelOffset(
+        private static (double OffsetX, double OffsetY, SvgTextAnchor Anchor) ComputeLabelOffset(
             Microsoft.Msagl.Core.Geometry.Point endPoint,
             Microsoft.Msagl.Core.Geometry.Point penultimatePoint)
         {

--- a/uml4net.Reporting/Properties/AssemblyInfo.cs
+++ b/uml4net.Reporting/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="Starion Group S.A.">
+//
+//   Copyright 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("uml4net.Reporting.Tests")]

--- a/uml4net.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
+++ b/uml4net.Tools.Tests/Commands/HtmlReportCommandTestFixture.cs
@@ -184,5 +184,32 @@ namespace uml4net.Tools.Tests.Commands
             await Assert.ThatAsync(() => this.handler.InvokeAsync(parseResult, this.cts.Token),
                 Throws.TypeOf<OperationCanceledException>());
         }
+
+        [Test]
+        public async Task Verify_that_when_operation_is_cancelled_while_running_OperationCanceledException_is_thrown()
+        {
+            var args = new[]
+            {
+                "html-report",
+                "--no-logo",
+                "--input-model", Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "UML.xmi"),
+                "--output-report", Path.Combine(TestContext.CurrentContext.TestDirectory, "html-report.html"),
+                "--root-package-xmi-id", "_0",
+                "--root-package-name", "UML"
+            };
+
+            var parseResult = this.rootCommand.Parse(args);
+
+            // the first delay inside the status block is awaited for 500ms, so cancelling after 100ms
+            // cancels while the handler is running rather than before it has started
+            this.cts.CancelAfter(100);
+
+            await Assert.ThatAsync(() => this.handler.InvokeAsync(parseResult, this.cts.Token),
+                Throws.InstanceOf<OperationCanceledException>());
+
+            // cancellation must abort before the report is generated, and must not be swallowed
+            // and turned into a -1 result by the general exception handler
+            this.htmlReportGenerator.Verify(x => x.GenerateReport(It.IsAny<FileInfo>(), It.IsAny<DirectoryInfo>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<FileInfo>(), It.IsAny<String>()), Times.Never);
+        }
     }
 }

--- a/uml4net.Tools/Commands/ReportHandler.cs
+++ b/uml4net.Tools/Commands/ReportHandler.cs
@@ -160,7 +160,7 @@ namespace uml4net.Tools.Commands
                 await AnsiConsole.Status()
                     .AutoRefresh(true)
                     .SpinnerStyle(Style.Parse("green bold"))
-                    .Start($"Preparing Warp Engines for {this.ReportGenerator.QueryReportType()} reporting...", ctx =>
+                    .StartAsync($"Preparing Warp Engines for {this.ReportGenerator.QueryReportType()} reporting...", async ctx =>
                     {
                         AnsiConsole.WriteLine();
                         AnsiConsole.MarkupLine("[yellow]Initializing report parameters...[/]");
@@ -170,12 +170,12 @@ namespace uml4net.Tools.Commands
                         AnsiConsole.MarkupLine($"[green] --auto-open-report: {Markup.Escape(this.autoOpenReport.ToString(CultureInfo.CurrentCulture))}[/]");
                         AnsiConsole.MarkupLine($"[green] --use-strict-reading: {Markup.Escape(this.useStrictReading.ToString(CultureInfo.CurrentCulture))}[/]");
                         AnsiConsole.WriteLine();
-                        Task.Delay(500);
+                        await Task.Delay(500, cancellationToken);
 
                         ctx.Status("[yellow]Generating UML Model report...[/]");
                         AnsiConsole.WriteLine();
-                        Task.Delay(1000);
-                        
+                        await Task.Delay(1000, cancellationToken);
+
                         this.ReportGenerator.GenerateReport(this.inputModel, this.inputModel.Directory, this.rootPackageXmiId, this.rootPackageName, this.useStrictReading, this.pathMap, this.outputReport);
 
                         AnsiConsole.MarkupLine($"[grey]LOG:[/] UML {this.ReportGenerator.QueryReportType()} report generated at [bold]{this.outputReport.FullName}[/]");
@@ -184,10 +184,21 @@ namespace uml4net.Tools.Commands
                         this.ExecuteAutoOpen(ctx);
 
                         ctx.Status("[green]Dropping to impulse speed[/]");
-                        Task.Delay(500);
-                        
-                        return Task.FromResult(0);
+                        await Task.Delay(500, cancellationToken);
+
+                        return 0;
                     });
+            }
+            catch (OperationCanceledException)
+            {
+                // now that the cancellationToken is passed to the awaited delays, cancellation surfaces
+                // from within the status block; it is not a failure to report, so it is rethrown to keep
+                // the cancellation contract of InvokeAsync rather than being swallowed as a generic error
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine("[yellow]The operation was cancelled[/]");
+                AnsiConsole.WriteLine();
+
+                throw;
             }
             catch (IOException ex)
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/uml4net/pulls) open
- [x] I have verified that I am following the uml4net [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/uml4net/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change

### Description

A batch of SonarQube fixes, clearing **all open RELIABILITY issues** and the `csharpsquid:S2325` MAINTAINABILITY issues, plus a coverage gap uncovered along the way.

| Rule | Impact | Count | Location |
|------|--------|-------|----------|
| `csharpsquid:S8949` | RELIABILITY (MAJOR) | 3 | `uml4net.Tools/Commands/ReportHandler.cs` |
| `csharpsquid:S2325` | MAINTAINABILITY (MINOR) | 3 | `uml4net.Reporting/Drawing/AssociationDiagramRenderer.cs` |

---

#### 1. Pass the cancellation token to the awaited delays (`S8949`)

All three RELIABILITY issues were `Task.Delay(...)` calls inside the `AnsiConsole.Status(...)` block of `ReportHandler`. The lambda was synchronous — it returned `Task.FromResult(0)` — so the delays could not be awaited and **their returned tasks were discarded**. They therefore delayed by nothing at all; the cosmetic spinner pacing they were written for never actually happened.

Passing the token requires awaiting them, so `Status.Start(...)` becomes `Status.StartAsync(...)`, the lambda becomes `async ctx => ...`, the three delays become `await Task.Delay(n, cancellationToken)`, and the lambda returns `0`.

> [!IMPORTANT]
> **Behaviour change.** Because the delays are now genuinely awaited, the 500 / 1000 / 500 ms pacing is real. A report run is roughly **two seconds slower** than before, and `uml4net.Tools.Tests` goes to ~38s. This is the intended consequence of honouring the delays rather than discarding them; the alternative considered was deleting the three dead calls outright.

**Cancellation is no longer swallowed.** With the token honoured, cancellation now surfaces from *inside* the `try`, where the general `catch (Exception ex)` would have caught it, printed *"An exception occurred … please report an issue"*, and returned `-1` — turning a normal user cancellation into what looks like a bug report request. A dedicated `catch (OperationCanceledException)` is added ahead of it, which prints a cancellation notice and rethrows, preserving the `InvokeAsync` cancellation contract the existing tests assert.

#### 2. Make instance-independent renderer methods static (`S2325`)

`CollectAssociationEdges`, `GetPenultimatePoint` and `ComputeLabelOffset` in `AssociationDiagramRenderer` are private helpers that derive their result purely from their arguments and never touch instance state. They are now `static`, and their three call sites drop the `this.` qualifier. No logic changed.

#### 3. Cover the curve shapes handled by `GetPenultimatePoint`

Coverage-checking the above showed the `Polyline` branch of `GetPenultimatePoint` had **no test at all**. The MSAGL layout engine does not deterministically emit polyline edge curves, so the branch cannot be reached reliably through `SvgRenderForClass`.

> [!NOTE]
> **Visibility change.** To make the branch testable, `GetPenultimatePoint` is widened from `private` to `internal`, and `uml4net.Reporting` gains a `Properties/AssemblyInfo.cs` with `[assembly: InternalsVisibleTo("uml4net.Reporting.Tests")]` — following the pattern `uml4net` already uses for `uml4net.Tests`. The method stays `static`, so the `S2325` fix above is unaffected. A `<remarks>` on the method records why it is internal.

Four tests are added, one per shape the switch handles — all of them rather than just `Polyline`, because the polyline line is a ternary needing both outcomes for branch coverage:

| Case | Input | Expected |
|---|---|---|
| Polyline, ≥2 points | `(0,0) (10,10) (20,30)` | `(10,10)` |
| Polyline, 1 point | `(7,9)` | `(7,9)` — falls to `curve.Start` |
| Compound `Curve` | two `LineSegment`s | `(10,10)` — last segment's start |
| Unsupported | bare `LineSegment` | `(3,4)` — default branch |

`GetPenultimatePoint` goes from 6/8 lines to **8/8 lines and 8/8 branches**.

---

### Test coverage

A test for mid-run cancellation is added to `HtmlReportCommandTestFixture`. The existing cancellation tests all cancel *before* invoking, so they are caught by the guard at the top of `InvokeAsync` and never reach the new code. The new test cancels at 100 ms — inside the first 500 ms delay — and asserts both that `OperationCanceledException` propagates and that `GenerateReport` is never called. Without the new catch block this test fails, so it genuinely covers the new path.

### Verification

- Full solution builds with 0 errors and **no new warnings** (the 11 present are all pre-existing).
- Full suite green: **436 tests** across all 8 projects.
- `uml4net.Reporting` coverage: 86.48% line / 75.11% branch.
