### PR TITLE
[Fix] preserve the complete raw content of an xmi:Extension

### DIFF
--- a/uml4net.xmi.Extensions.EnterpriseArchitect.Tests/Extender/EnterpriseArchitectExtenderReaderTestFixture.cs
+++ b/uml4net.xmi.Extensions.EnterpriseArchitect.Tests/Extender/EnterpriseArchitectExtenderReaderTestFixture.cs
@@ -97,6 +97,31 @@ namespace uml4net.xmi.Extensions.EnterpriseArchitect.Tests.Extender
             }
         }
 
+        [Test]
+        public void VerifyThatTheRawXmiOfTheEnterpriseArchitectExtensionIsPreserved()
+        {
+            var rootPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Resources");
+
+            var reader = XmiReaderBuilder.Create()
+                .UsingSettings(x => x.LocalReferenceBasePath = rootPath)
+                .WithExtender<EnterpriseArchitectExtenderReader>()
+                .WithExtensionContentReaderFacade<ExtensionContentReaderFacade>()
+                .WithLogger(this.loggerFactory)
+                .Build();
+
+            var xmiReaderResult = reader.Read(Path.Combine(TestContext.CurrentContext.TestDirectory, "Resources", "EAExport.xmi"));
+
+            var contentRawXmi = xmiReaderResult.XmiRoot.Extensions.Single().ContentRawXmi;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(contentRawXmi, Does.Contain("<elements>"));
+                Assert.That(contentRawXmi, Does.Contain("<connectors>"));
+                Assert.That(contentRawXmi, Does.Contain("<primitivetypes>"));
+                Assert.That(contentRawXmi, Does.Contain("<profiles>"));
+            }
+        }
+
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {

--- a/uml4net.xmi.Tests/Readers/XmiExtensionReaderTestFixture.cs
+++ b/uml4net.xmi.Tests/Readers/XmiExtensionReaderTestFixture.cs
@@ -1,0 +1,204 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiExtensionReaderTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Tests.Readers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using uml4net.xmi.Extender;
+    using uml4net.xmi.Readers;
+    using uml4net.xmi.Settings;
+
+    [TestFixture]
+    public class XmiExtensionReaderTestFixture
+    {
+        private const string XmiNamespace = "http://www.omg.org/spec/XMI/20131001";
+
+        private const string ExtensionWithMultipleChildren = """
+            <xmi:Extension xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmi:id="EAID_EXTENSION" xmi:uuid="EAUUID_EXTENSION" extender="Enterprise Architect" extenderID="6.5">
+              <elements><element name="element-1" /></elements>
+              <connectors><connector name="connector-1" /></connectors>
+              <profiles><profile name="profile-1" /></profiles>
+            </xmi:Extension>
+            """;
+
+        private Mock<IExtenderReaderRegistry> extenderReaderRegistry;
+
+        private Mock<IExtenderReader> extenderReader;
+
+        private IXmiReaderSettings xmiReaderSettings;
+
+        private NameSpaceResolver nameSpaceResolver;
+
+        private XmiExtensionReader xmiExtensionReader;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.extenderReader = new Mock<IExtenderReader>();
+            this.extenderReader.Setup(x => x.ReadContent(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(() => new List<object> { new object() });
+
+            this.extenderReaderRegistry = new Mock<IExtenderReaderRegistry>();
+
+            this.xmiReaderSettings = new DefaultSettings();
+
+            this.nameSpaceResolver = new NameSpaceResolver();
+            this.nameSpaceResolver.ResolveAndSetNamespace(XmiNamespace);
+
+            this.xmiExtensionReader = new XmiExtensionReader(this.xmiReaderSettings, this.nameSpaceResolver,
+                this.extenderReaderRegistry.Object, NullLoggerFactory.Instance);
+        }
+
+        [Test]
+        public void Verify_that_null_arguments_throw_exception()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(() => this.xmiExtensionReader.Read(null, "document.xmi", XmiNamespace),
+                    Throws.TypeOf<ArgumentNullException>());
+
+                Assert.That(() => this.xmiExtensionReader.Read(CreateXmlReader(ExtensionWithMultipleChildren), "", XmiNamespace),
+                    Throws.TypeOf<ArgumentException>());
+
+                Assert.That(() => this.xmiExtensionReader.Read(CreateXmlReader(ExtensionWithMultipleChildren), "document.xmi", ""),
+                    Throws.TypeOf<ArgumentException>());
+            }
+        }
+
+        [Test]
+        public void Verify_that_the_attributes_of_the_Extension_are_read()
+        {
+            this.extenderReaderRegistry.Setup(x => x.Resolve("Enterprise Architect", "6.5")).Returns(this.extenderReader.Object);
+
+            var xmiExtension = this.xmiExtensionReader.Read(CreateXmlReader(ExtensionWithMultipleChildren), "document.xmi", XmiNamespace);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(xmiExtension.Id, Is.EqualTo("EAID_EXTENSION"));
+                Assert.That(xmiExtension.Uuid, Is.EqualTo("EAUUID_EXTENSION"));
+                Assert.That(xmiExtension.Extender, Is.EqualTo("Enterprise Architect"));
+                Assert.That(xmiExtension.ExtenderId, Is.EqualTo("6.5"));
+                Assert.That(xmiExtension.DocumentName, Is.EqualTo("document.xmi"));
+            }
+        }
+
+        [Test]
+        public void Verify_that_ContentRawXmi_accumulates_all_top_level_children()
+        {
+            this.extenderReaderRegistry.Setup(x => x.Resolve("Enterprise Architect", "6.5")).Returns(this.extenderReader.Object);
+
+            var xmiExtension = this.xmiExtensionReader.Read(CreateXmlReader(ExtensionWithMultipleChildren), "document.xmi", XmiNamespace);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(xmiExtension.ContentRawXmi, Does.Contain("<elements>"));
+                Assert.That(xmiExtension.ContentRawXmi, Does.Contain("<connectors>"));
+                Assert.That(xmiExtension.ContentRawXmi, Does.Contain("<profiles>"));
+
+                Assert.That(xmiExtension.Content, Has.Count.EqualTo(3));
+            }
+
+            this.extenderReader.Verify(x => x.ReadContent(It.IsAny<string>(), "document.xmi"), Times.Exactly(3));
+        }
+
+        [Test]
+        public void Verify_that_each_top_level_child_is_provided_to_the_ExtenderReader()
+        {
+            this.extenderReaderRegistry.Setup(x => x.Resolve("Enterprise Architect", "6.5")).Returns(this.extenderReader.Object);
+
+            var providedContent = new List<string>();
+
+            this.extenderReader.Setup(x => x.ReadContent(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string>((extensionXmi, _) => providedContent.Add(extensionXmi))
+                .Returns(() => new List<object>());
+
+            this.xmiExtensionReader.Read(CreateXmlReader(ExtensionWithMultipleChildren), "document.xmi", XmiNamespace);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(providedContent, Has.Count.EqualTo(3));
+                Assert.That(providedContent[0], Does.StartWith("<elements>"));
+                Assert.That(providedContent[1], Does.StartWith("<connectors>"));
+                Assert.That(providedContent[2], Does.StartWith("<profiles>"));
+            }
+        }
+
+        [Test]
+        public void Verify_that_ContentRawXmi_is_read_when_no_ExtenderReader_is_registered()
+        {
+            this.extenderReaderRegistry.Setup(x => x.Resolve(It.IsAny<string>(), It.IsAny<string>())).Returns((IExtenderReader)null);
+
+            var xmiExtension = this.xmiExtensionReader.Read(CreateXmlReader(ExtensionWithMultipleChildren), "document.xmi", XmiNamespace);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(xmiExtension.ContentRawXmi, Does.Contain("<elements>"));
+                Assert.That(xmiExtension.ContentRawXmi, Does.Contain("<connectors>"));
+                Assert.That(xmiExtension.ContentRawXmi, Does.Contain("<profiles>"));
+
+                Assert.That(xmiExtension.Content, Is.Empty);
+            }
+        }
+
+        [Test]
+        public void Verify_that_ContentRawXmi_is_null_when_the_Extension_is_empty()
+        {
+            const string emptyExtension = """
+                <xmi:Extension xmlns:xmi="http://www.omg.org/spec/XMI/20131001" extender="Enterprise Architect" extenderID="6.5" />
+                """;
+
+            this.extenderReaderRegistry.Setup(x => x.Resolve("Enterprise Architect", "6.5")).Returns(this.extenderReader.Object);
+
+            var xmiExtension = this.xmiExtensionReader.Read(CreateXmlReader(emptyExtension), "document.xmi", XmiNamespace);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(xmiExtension.ContentRawXmi, Is.Null);
+                Assert.That(xmiExtension.Content, Is.Empty);
+            }
+        }
+
+        [Test]
+        public void Verify_that_an_unexpected_xmi_type_throws_exception()
+        {
+            const string extensionWithUnexpectedType = """
+                <xmi:Extension xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmi:type="uml:Class" extender="Enterprise Architect" extenderID="6.5" />
+                """;
+
+            Assert.That(() => this.xmiExtensionReader.Read(CreateXmlReader(extensionWithUnexpectedType), "document.xmi", XmiNamespace),
+                Throws.TypeOf<XmlException>());
+        }
+
+        private static XmlReader CreateXmlReader(string xml)
+        {
+            return XmlReader.Create(new StringReader(xml));
+        }
+    }
+}

--- a/uml4net.xmi/Readers/XmiExtensionReader.cs
+++ b/uml4net.xmi/Readers/XmiExtensionReader.cs
@@ -22,6 +22,7 @@ namespace uml4net.xmi.Readers
 {
     using System;
     using System.IO;
+    using System.Text;
     using System.Xml;
 
     using Microsoft.Extensions.Logging;
@@ -150,30 +151,42 @@ namespace uml4net.xmi.Readers
 
                 if (extenderReader == null)
                 {
-                    this.logger.LogInformation("The ExtenderReader for {Extender}:{ExtenderID} does not exist, the Extension cannot be processed", xmiExtension.Extender, xmiExtension.ExtenderId);
-                    xmlReader.Skip();
+                    this.logger.LogInformation("The ExtenderReader for {Extender}:{ExtenderID} does not exist, the content of the Extension is preserved as raw XMI but is not further processed", xmiExtension.Extender, xmiExtension.ExtenderId);
                 }
-                else
+
+                var contentRawXmiBuilder = new StringBuilder();
+
+                while (xmlReader.Read())
                 {
-                    while (xmlReader.Read())
+                    if (xmlReader.NodeType != XmlNodeType.Element)
                     {
-                        if (xmlReader.NodeType == XmlNodeType.Element)
-                        {
-                            using var subtreeReader = xmlReader.ReadSubtree();
-
-                            subtreeReader.Read();
-
-                            var stringWriter = new StringWriter();
-
-                            using (var xmlWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings { OmitXmlDeclaration = true }))
-                            {
-                                xmlWriter.WriteNode(subtreeReader, true);
-                            }
-
-                            xmiExtension.ContentRawXmi = stringWriter.ToString();
-                            xmiExtension.Content.AddRange(extenderReader.ReadContent(xmiExtension.ContentRawXmi, documentName));
-                        }
+                        continue;
                     }
+
+                    using var subtreeReader = xmlReader.ReadSubtree();
+
+                    subtreeReader.Read();
+
+                    var stringWriter = new StringWriter();
+
+                    using (var xmlWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings { OmitXmlDeclaration = true }))
+                    {
+                        xmlWriter.WriteNode(subtreeReader, true);
+                    }
+
+                    var rawXmi = stringWriter.ToString();
+
+                    contentRawXmiBuilder.Append(rawXmi);
+
+                    if (extenderReader != null)
+                    {
+                        xmiExtension.Content.AddRange(extenderReader.ReadContent(rawXmi, documentName));
+                    }
+                }
+
+                if (contentRawXmiBuilder.Length > 0)
+                {
+                    xmiExtension.ContentRawXmi = contentRawXmiBuilder.ToString();
                 }
             }
 


### PR DESCRIPTION
Fixes #201

## Problem

`XmiExtensionReader.Read` assigned `XmiExtension.ContentRawXmi` inside its child loop, so each
top-level child of an `xmi:Extension` overwrote the previous one. An `xmi:Extension` normally holds
several top-level children — a real Enterprise Architect export has `<elements>`, `<connectors>`,
`<primitivetypes>` and `<profiles>` as siblings — so after the read only the **last** child's raw
XMI remained. The structured `Content` collection was unaffected; only the raw string was lossy.

Separately, when the registry resolved no `IExtenderReader` for the extension's
`extender`/`extenderID`, the reader called `xmlReader.Skip()` and captured nothing at all, so
extensions were discarded entirely for consumers of `uml4net.xmi` that do not register a
tool-specific reader.

## Change

- The raw XMI of every top-level child is accumulated into a `StringBuilder` and assigned once,
  after the loop.
- `ContentRawXmi` is left `null` when the extension has no content, preserving the existing
  semantics for callers doing a `!= null` check.
- The content is now captured even when no `IExtenderReader` is registered; the structured
  `Content` collection stays empty in that case. Dropping the `Skip()` is safe because every call
  site wraps this reader in a `ReadSubtree()` inside a `using`, so the outer reader is advanced past
  the subtree either way.
- The structured `Content` collection is otherwise unchanged: `ReadContent` is still invoked once
  per top-level child with exactly that child's raw XMI (previously the same string, just routed
  through the property).

The fix lives in the single shared `XmiExtensionReader`, so nested per-element extensions benefit
too, with no change to any of the generated `AutoGenXmiReaders` files.

This unblocks #200, whose approach is to re-emit `ContentRawXmi` verbatim on write.

## Tests

New `uml4net.xmi.Tests/Readers/XmiExtensionReaderTestFixture.cs` (7 tests) covering argument
guards, the extension attributes, raw-content accumulation across multiple children, per-child
delegation to the `IExtenderReader`, capture when no reader is registered, the empty-extension case,
and the unexpected-`xmi:type` guard.

`EnterpriseArchitectExtenderReaderTestFixture` gains
`VerifyThatTheRawXmiOfTheEnterpriseArchitectExtensionIsPreserved`, asserting against the real
`EAExport.xmi` that all four top-level blocks survive.

Both new behaviour tests were verified to **fail** against the pre-fix code and pass with it:

| Test | pre-fix | post-fix |
|---|---|---|
| `Verify_that_ContentRawXmi_accumulates_all_top_level_children` | Failed | Passed |
| `Verify_that_ContentRawXmi_is_read_when_no_ExtenderReader_is_registered` | Failed | Passed |
| `VerifyThatTheRawXmiOfTheEnterpriseArchitectExtensionIsPreserved` | Failed | Passed |

Full suite green: 444 passed, 0 failed across all 8 test projects. This includes the fixtures that
read extension-bearing XMI **without** an extender registered and therefore exercise the changed
path — `EnterpriseArchitectModelTestFixture` (`EAExport.xmi`) and `EAPropertyExtensionsTestFixture`
(`EnterpriseArchitectAggregation.xmi`) — as well as `uml4net.Reporting.Tests`, which reads
`EAExport.xmi` with the EA extender registered.
