### PR TITLE
[Feature] write the xmi:Extension content to an XMI document

### DIFF
--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ActivityWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ActivityWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Activity with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Activity with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Activity");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -400,6 +403,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -445,14 +450,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Activity with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Activity with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Activity");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -725,6 +733,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/AssociationWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/AssociationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Association with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Association with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Association");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -290,6 +293,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -335,14 +340,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Association with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Association with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Association");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -505,6 +513,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ClassWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ClassWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Class with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Class with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Class");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -320,6 +323,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -365,14 +370,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Class with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Class with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Class");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -565,6 +573,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ConnectorWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ConnectorWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Connector with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Connector with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Connector");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Connector with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Connector with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Connector");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationConstraintWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationConstraintWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DurationConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DurationConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationConstraint");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -200,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -245,14 +250,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DurationConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DurationConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationConstraint");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +333,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationObservationWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationObservationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DurationObservation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DurationObservation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationObservation");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -185,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -230,14 +235,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DurationObservation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DurationObservation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationObservation");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +303,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExceptionHandlerWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExceptionHandlerWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExceptionHandler with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExceptionHandler with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExceptionHandler");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -175,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -220,14 +225,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExceptionHandler with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExceptionHandler with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExceptionHandler");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +283,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ProtectedNode, "protectedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExpressionWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExpressionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Expression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Expression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Expression");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -195,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -240,14 +245,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Expression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Expression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Expression");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +323,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/GeneralizationWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/GeneralizationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Generalization with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Generalization with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Generalization");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -169,6 +172,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specific, "specific", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -215,14 +220,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Generalization with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Generalization with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Generalization");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -265,6 +273,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specific, "specific", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralIntegerWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralIntegerWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralInteger with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralInteger with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralInteger");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralInteger with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralInteger with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralInteger");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralRealWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralRealWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralReal with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralReal with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralReal");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralReal with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralReal with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralReal");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralUnlimitedNatural with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralUnlimitedNatural with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralUnlimitedNatural");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralUnlimitedNatural with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralUnlimitedNatural with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralUnlimitedNatural");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/OpaqueExpressionWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/OpaqueExpressionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OpaqueExpression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OpaqueExpression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueExpression");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OpaqueExpression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OpaqueExpression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueExpression");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/PropertyWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/PropertyWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Property with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Property with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Property");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +328,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -370,14 +375,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Property with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Property with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Property");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -575,6 +583,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/StateMachineWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/StateMachineWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StateMachine with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StateMachine with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateMachine");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -375,6 +378,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -420,14 +425,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StateMachine with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StateMachine with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateMachine");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -675,6 +683,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/TimeConstraintWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/TimeConstraintWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeConstraint");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -200,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -245,14 +250,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeConstraint");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +333,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.CodeGenerator/Templates/xmi-writer-template.hbs
+++ b/uml4net.CodeGenerator/Templates/xmi-writer-template.hbs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the {{this.Name}} with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the {{this.Name}} with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:{{this.Name}}");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -140,6 +143,8 @@ namespace uml4net.xmi.Writers
             {{ #each (Class.QueryAllNonDerivedNonReadOnlyProperties this) as | property | }}
             {{ #Property.WriteXmlElementForXmiWriter property ../ }}
             {{/each}}
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -186,14 +191,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the {{this.Name}} with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the {{this.Name}} with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:{{this.Name}}");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -207,6 +215,8 @@ namespace uml4net.xmi.Writers
             {{ #each (Class.QueryAllNonDerivedNonReadOnlyProperties this) as | property | }}
             {{ #Property.WriteXmlElementForXmiWriter property ../ true }}
             {{/each}}
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi.Extensions.EnterpriseArchitect.Tests/Extender/EnterpriseArchitectExtensionRoundTripTestFixture.cs
+++ b/uml4net.xmi.Extensions.EnterpriseArchitect.Tests/Extender/EnterpriseArchitectExtensionRoundTripTestFixture.cs
@@ -1,0 +1,246 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="EnterpriseArchitectExtensionRoundTripTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Extensions.EnterpriseArchitect.Tests.Extender
+{
+    using System.IO;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using NUnit.Framework;
+
+    using uml4net.Packages;
+    using uml4net.xmi.Extensions.EnterpriseArchitect.Extender;
+    using uml4net.xmi.Extensions.EnterpriseArchitect.Structure;
+    using uml4net.xmi.Extensions.EnterpriseArchitect.Structure.Readers;
+    using uml4net.xmi.Readers;
+    using uml4net.xmi.Settings;
+    using uml4net.xmi.Writers;
+
+    using Path = System.IO.Path;
+
+    /// <summary>
+    /// Verifies that an Enterprise Architect model, including its <c>xmi:Extension</c> content,
+    /// survives a read - write - read cycle
+    /// </summary>
+    [TestFixture]
+    public class EnterpriseArchitectExtensionRoundTripTestFixture
+    {
+        private ReferenceClosureCalculator referenceClosureCalculator;
+
+        private string rootPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.rootPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Resources");
+
+            this.referenceClosureCalculator = new ReferenceClosureCalculator(NullLogger<ReferenceClosureCalculator>.Instance);
+        }
+
+        [Test]
+        public void Verify_that_an_EnterpriseArchitect_model_and_its_Extension_round_trip()
+        {
+            var originalResult = this.ReadEnterpriseArchitectModel(Path.Combine(this.rootPath, "EAExport.xmi"));
+
+            var originalRoot = originalResult.QueryRoot(null, "EA_Model") as IPackage;
+            var originalExtension = originalResult.XmiRoot.Extensions.Single();
+
+            Assert.That(originalRoot, Is.Not.Null, "the EA_Model root package was expected to be read");
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            writer.Write(originalRoot, stream, "EAExport.xmi", originalResult.XmiRoot.Extensions);
+
+            stream.Position = 0;
+
+            var rereadResult = this.ReadEnterpriseArchitectModel(stream);
+
+            var rereadRoot = rereadResult.QueryRoot(null, "EA_Model") as IPackage;
+            var rereadExtension = rereadResult.XmiRoot.Extensions.Single();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(rereadRoot, Is.Not.Null, "the EA_Model root package was expected to be read back");
+
+                Assert.That(rereadExtension.Extender, Is.EqualTo(originalExtension.Extender));
+                Assert.That(rereadExtension.ExtenderId, Is.EqualTo(originalExtension.ExtenderId));
+
+                Assert.That(rereadExtension.ContentRawXmi, Is.EqualTo(originalExtension.ContentRawXmi),
+                    "the raw content of the xmi:Extension was expected to survive the round trip unchanged");
+            }
+
+            this.AssertContainmentTreesAreEquivalent(originalRoot, rereadRoot, "EAExport.xmi");
+        }
+
+        [Test]
+        public void Verify_that_the_structured_Extension_content_round_trips()
+        {
+            var originalResult = this.ReadEnterpriseArchitectModel(Path.Combine(this.rootPath, "EAExport.xmi"));
+
+            var originalRoot = originalResult.QueryRoot(null, "EA_Model") as IPackage;
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            writer.Write(originalRoot, stream, "EAExport.xmi", originalResult.XmiRoot.Extensions);
+
+            stream.Position = 0;
+
+            var rereadResult = this.ReadEnterpriseArchitectModel(stream);
+
+            var originalElements = QueryExtensionElementNames(originalResult);
+            var rereadElements = QueryExtensionElementNames(rereadResult);
+
+            var originalConnectors = QueryExtensionConnectorCount(originalResult);
+            var rereadConnectors = QueryExtensionConnectorCount(rereadResult);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(originalElements, Is.Not.Empty, "the EA extension was expected to contain elements");
+                Assert.That(rereadElements, Is.EqualTo(originalElements),
+                    "the structured EA extension elements were expected to survive the round trip");
+
+                Assert.That(originalConnectors, Is.GreaterThan(0), "the EA extension was expected to contain connectors");
+                Assert.That(rereadConnectors, Is.EqualTo(originalConnectors),
+                    "the structured EA extension connectors were expected to survive the round trip");
+            }
+        }
+
+        [Test]
+        public void Verify_that_the_written_document_contains_the_Extension_as_a_sibling_of_the_model()
+        {
+            var originalResult = this.ReadEnterpriseArchitectModel(Path.Combine(this.rootPath, "EAExport.xmi"));
+
+            var originalRoot = originalResult.QueryRoot(null, "EA_Model") as IPackage;
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            writer.Write(originalRoot, stream, "EAExport.xmi", originalResult.XmiRoot.Extensions);
+
+            stream.Position = 0;
+
+            var document = XDocument.Load(stream);
+
+            var xmiNamespace = XNamespace.Get("http://www.omg.org/spec/XMI/20131001");
+
+            var children = document.Root.Elements().ToList();
+
+            var extensionElement = children.SingleOrDefault(x => x.Name == xmiNamespace + "Extension");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(extensionElement, Is.Not.Null, "an xmi:Extension was expected as a child of xmi:XMI");
+                Assert.That(extensionElement.Attribute("extender")?.Value, Is.EqualTo("Enterprise Architect"));
+                Assert.That(extensionElement.Attribute("extenderID")?.Value, Is.EqualTo("6.5"));
+
+                Assert.That(children.Last(), Is.EqualTo(extensionElement),
+                    "the xmi:Extension was expected to be written after the model content");
+
+                Assert.That(extensionElement.Elements().Select(x => x.Name.LocalName),
+                    Is.EquivalentTo(new[] { "elements", "connectors", "primitivetypes", "profiles" }));
+            }
+        }
+
+        /// <summary>
+        /// Queries the names of the <see cref="Element"/>s that are contained by the extensions of the
+        /// provided <see cref="XmiReaderResult"/>
+        /// </summary>
+        private static string[] QueryExtensionElementNames(XmiReaderResult xmiReaderResult)
+        {
+            return xmiReaderResult.XmiRoot.Extensions
+                .SelectMany(x => x.Content)
+                .OfType<Element>()
+                .Select(x => x.Name)
+                .OrderBy(x => x, System.StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Queries the number of <see cref="Connector"/>s that are contained by the extensions of the
+        /// provided <see cref="XmiReaderResult"/>
+        /// </summary>
+        private static int QueryExtensionConnectorCount(XmiReaderResult xmiReaderResult)
+        {
+            return xmiReaderResult.XmiRoot.Extensions
+                .SelectMany(x => x.Content)
+                .OfType<Connector>()
+                .Count();
+        }
+
+        /// <summary>
+        /// Asserts that the containment trees of the provided packages contain the same elements
+        /// </summary>
+        private void AssertContainmentTreesAreEquivalent(IPackage originalRoot, IPackage rereadRoot, string documentName)
+        {
+            var originalPlan = this.referenceClosureCalculator.CalculateWritePlan(originalRoot, ExternalReferenceResolutionKind.Href, documentName);
+            var rereadPlan = this.referenceClosureCalculator.CalculateWritePlan(rereadRoot, ExternalReferenceResolutionKind.Href, documentName);
+
+            var missing = originalPlan.LocalIdentifiers.Except(rereadPlan.LocalIdentifiers).Take(10).ToList();
+            var extra = rereadPlan.LocalIdentifiers.Except(originalPlan.LocalIdentifiers).Take(10).ToList();
+
+            Assert.That(rereadPlan.LocalIdentifiers.SetEquals(originalPlan.LocalIdentifiers), Is.True,
+                $"the containment trees are not equivalent; missing: [{string.Join(", ", missing)}]; extra: [{string.Join(", ", extra)}]");
+        }
+
+        /// <summary>
+        /// Reads the Enterprise Architect model from the provided path
+        /// </summary>
+        private XmiReaderResult ReadEnterpriseArchitectModel(string path)
+        {
+            return this.CreateReader().Read(path);
+        }
+
+        /// <summary>
+        /// Reads the Enterprise Architect model from the provided <see cref="Stream"/>
+        /// </summary>
+        private XmiReaderResult ReadEnterpriseArchitectModel(Stream stream)
+        {
+            return this.CreateReader().Read(stream, "EAExport.xmi");
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IXmiReader"/> that is able to read Enterprise Architect extensions
+        /// </summary>
+        private IXmiReader CreateReader()
+        {
+            return XmiReaderBuilder.Create()
+                .UsingSettings(x => x.LocalReferenceBasePath = this.rootPath)
+                .WithExtender<EnterpriseArchitectExtenderReader>()
+                .WithExtensionContentReaderFacade<ExtensionContentReaderFacade>()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+        }
+    }
+}

--- a/uml4net.xmi.Extensions.EnterpriseArchitect/Extender/EnterpriseArchitectExtenderReader.cs
+++ b/uml4net.xmi.Extensions.EnterpriseArchitect/Extender/EnterpriseArchitectExtenderReader.cs
@@ -285,10 +285,7 @@ namespace uml4net.xmi.Extensions.EnterpriseArchitect.Extender
                
                 if (!string.IsNullOrWhiteSpace(documentedElement.Documentation?.Value))
                 {
-                    element.OwnedComment.Add(new Comment()
-                    {
-                        Body = documentedElement.Documentation.Value
-                    });
+                    AddOwnedComment(element, documentedElement.Documentation.Value);
                 }
             }
 
@@ -296,10 +293,7 @@ namespace uml4net.xmi.Extensions.EnterpriseArchitect.Extender
             {
                 if (!string.IsNullOrEmpty(element.Properties?.Documentation) && element.ExtendedElement is uml4net.CommonStructure.IElement extendedElement)
                 {
-                    extendedElement.OwnedComment.Add(new Comment()
-                    {
-                        Body = element.Properties.Documentation
-                    });
+                    AddOwnedComment(extendedElement, element.Properties.Documentation);
                 }
             }
 
@@ -309,10 +303,7 @@ namespace uml4net.xmi.Extensions.EnterpriseArchitect.Extender
             {
                 if (!string.IsNullOrWhiteSpace(connector.Documentation?.Value) && connector.ExtendedElement is uml4net.CommonStructure.IElement extendedConnector)
                 {
-                    extendedConnector.OwnedComment.Add(new Comment()
-                    {
-                        Body = connector.Documentation?.Value
-                    });
+                    AddOwnedComment(extendedConnector, connector.Documentation.Value);
                 }
 
                 if (connector.ExtendedElement is  uml4net.StructuredClassifiers.IAssociation association)
@@ -323,14 +314,46 @@ namespace uml4net.xmi.Extensions.EnterpriseArchitect.Extender
 
                         if (!string.IsNullOrWhiteSpace(connectorEnd.Documentation.Value))
                         {
-                            property.OwnedComment.Add(new Comment()
-                            {
-                                Body = connectorEnd.Documentation.Value
-                            });
+                            AddOwnedComment(property, connectorEnd.Documentation.Value);
                         }
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Adds a <see cref="Comment"/> with the provided <paramref name="body"/> to the
+        /// <paramref name="owner"/>
+        /// </summary>
+        /// <param name="owner">
+        /// The <see cref="uml4net.CommonStructure.IElement"/> that owns the <see cref="Comment"/>
+        /// </param>
+        /// <param name="body">
+        /// The body of the <see cref="Comment"/>, which is the Enterprise Architect documentation
+        /// </param>
+        /// <remarks>
+        /// The <see cref="IXmiElement.XmiId"/> and <see cref="IXmiElement.DocumentName"/> are derived from the
+        /// <paramref name="owner"/>: an <see cref="IXmiElement.XmiId"/> is required to be able to write the
+        /// <see cref="Comment"/> to an XMI document and to uniquely identify it in the
+        /// <see cref="IXmiElementCache"/>.
+        /// </remarks>
+        private static void AddOwnedComment(uml4net.CommonStructure.IElement owner, string body)
+        {
+            if (owner.OwnedComment.Any(x => x.Body == body))
+            {
+                // The documentation has already been applied. This is the case when the model was read from a
+                // document to which the Enterprise Architect documentation had previously been written as an
+                // ownedComment, while the xmi:Extension that carries that same documentation is present as well.
+                // Applying it again would duplicate the Comment on every read - write cycle.
+                return;
+            }
+
+            owner.OwnedComment.Add(new Comment
+            {
+                XmiId = $"{owner.XmiId}-_ownedComment.{owner.OwnedComment.Count}",
+                DocumentName = owner.DocumentName,
+                Body = body
+            });
         }
     }
 }

--- a/uml4net.xmi.Tests/Writers/XmiExtensionRoundTripTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/XmiExtensionRoundTripTestFixture.cs
@@ -1,0 +1,181 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiExtensionRoundTripTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Tests.Writers
+{
+    using System.IO;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using NUnit.Framework;
+
+    using uml4net.Packages;
+    using uml4net.xmi.Readers;
+    using uml4net.xmi.Settings;
+    using uml4net.xmi.Writers;
+
+    /// <summary>
+    /// Verifies that the <c>xmi:Extension</c> of an Enterprise Architect document survives a
+    /// read - write - read cycle when no <c>IExtenderReader</c> is registered, which is the default
+    /// for consumers of the uml4net.xmi library.
+    /// </summary>
+    [TestFixture]
+    public class XmiExtensionRoundTripTestFixture
+    {
+        private ReferenceClosureCalculator referenceClosureCalculator;
+
+        private string rootPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.rootPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData");
+
+            this.referenceClosureCalculator = new ReferenceClosureCalculator(NullLogger<ReferenceClosureCalculator>.Instance);
+        }
+
+        [Test]
+        public void Verify_that_the_Extension_of_an_EnterpriseArchitect_document_round_trips()
+        {
+            var originalResult = this.CreateReader().Read(Path.Combine(this.rootPath, "EAExport.xmi"));
+
+            var originalRoot = originalResult.QueryRoot(null, "EA_Model") as IPackage;
+            var originalExtension = originalResult.XmiRoot.Extensions.Single();
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            writer.Write(originalRoot, stream, "EAExport.xmi", originalResult.XmiRoot.Extensions);
+
+            stream.Position = 0;
+
+            var rereadResult = this.CreateReader().Read(stream, "EAExport.xmi");
+
+            var rereadRoot = rereadResult.QueryRoot(null, "EA_Model") as IPackage;
+            var rereadExtension = rereadResult.XmiRoot.Extensions.Single();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(rereadRoot, Is.Not.Null, "the EA_Model root package was expected to be read back");
+
+                Assert.That(rereadExtension.Extender, Is.EqualTo(originalExtension.Extender));
+                Assert.That(rereadExtension.ExtenderId, Is.EqualTo(originalExtension.ExtenderId));
+
+                Assert.That(rereadExtension.ContentRawXmi, Is.EqualTo(originalExtension.ContentRawXmi),
+                    "the raw content of the xmi:Extension was expected to survive the round trip unchanged");
+            }
+
+            this.AssertContainmentTreesAreEquivalent(originalRoot, rereadRoot, "EAExport.xmi");
+        }
+
+        [Test]
+        public void Verify_that_the_Extension_is_written_as_the_last_child_of_the_root()
+        {
+            var originalResult = this.CreateReader().Read(Path.Combine(this.rootPath, "EAExport.xmi"));
+
+            var originalRoot = originalResult.QueryRoot(null, "EA_Model") as IPackage;
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            writer.Write(originalRoot, stream, "EAExport.xmi", originalResult.XmiRoot.Extensions);
+
+            stream.Position = 0;
+
+            var document = XDocument.Load(stream);
+
+            var xmiNamespace = XNamespace.Get("http://www.omg.org/spec/XMI/20131001");
+
+            var children = document.Root.Elements().ToList();
+            var extensionElement = children.SingleOrDefault(x => x.Name == xmiNamespace + "Extension");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(extensionElement, Is.Not.Null, "an xmi:Extension was expected as a child of xmi:XMI");
+                Assert.That(extensionElement.Attribute("extender")?.Value, Is.EqualTo("Enterprise Architect"));
+                Assert.That(extensionElement.Attribute("extenderID")?.Value, Is.EqualTo("6.5"));
+                Assert.That(children.Last(), Is.EqualTo(extensionElement),
+                    "the xmi:Extension was expected to be written after the model content");
+
+                Assert.That(extensionElement.Elements().Select(x => x.Name.LocalName),
+                    Is.EquivalentTo(new[] { "elements", "connectors", "primitivetypes", "profiles" }));
+            }
+        }
+
+        [Test]
+        public void Verify_that_no_Extension_is_written_when_none_is_provided()
+        {
+            var originalResult = this.CreateReader().Read(Path.Combine(this.rootPath, "EAExport.xmi"));
+
+            var originalRoot = originalResult.QueryRoot(null, "EA_Model") as IPackage;
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            writer.Write(originalRoot, stream, "EAExport.xmi");
+
+            stream.Position = 0;
+
+            var document = XDocument.Load(stream);
+
+            var xmiNamespace = XNamespace.Get("http://www.omg.org/spec/XMI/20131001");
+
+            Assert.That(document.Root.Elements().Any(x => x.Name == xmiNamespace + "Extension"), Is.False,
+                "the pre-existing overloads are expected to remain behaviour preserving and write no xmi:Extension");
+        }
+
+        /// <summary>
+        /// Asserts that the containment trees of the provided packages contain the same elements
+        /// </summary>
+        private void AssertContainmentTreesAreEquivalent(IPackage originalRoot, IPackage rereadRoot, string documentName)
+        {
+            var originalPlan = this.referenceClosureCalculator.CalculateWritePlan(originalRoot, ExternalReferenceResolutionKind.Href, documentName);
+            var rereadPlan = this.referenceClosureCalculator.CalculateWritePlan(rereadRoot, ExternalReferenceResolutionKind.Href, documentName);
+
+            var missing = originalPlan.LocalIdentifiers.Except(rereadPlan.LocalIdentifiers).Take(10).ToList();
+            var extra = rereadPlan.LocalIdentifiers.Except(originalPlan.LocalIdentifiers).Take(10).ToList();
+
+            Assert.That(rereadPlan.LocalIdentifiers.SetEquals(originalPlan.LocalIdentifiers), Is.True,
+                $"the containment trees are not equivalent; missing: [{string.Join(", ", missing)}]; extra: [{string.Join(", ", extra)}]");
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IXmiReader"/> without any registered extender reader
+        /// </summary>
+        private IXmiReader CreateReader()
+        {
+            return XmiReaderBuilder.Create()
+                .UsingSettings(x => x.LocalReferenceBasePath = this.rootPath)
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+        }
+    }
+}

--- a/uml4net.xmi.Tests/Writers/XmiWriterTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/XmiWriterTestFixture.cs
@@ -97,14 +97,38 @@ namespace uml4net.xmi.Tests.Writers
         }
 
         [Test]
-        public void Verify_that_Write_throws_when_an_element_has_no_XmiId()
+        public void Verify_that_Write_throws_when_a_contained_element_has_no_XmiId()
         {
-            var invalidPackage = new Package { Name = "invalid" };
+            this.package.PackagedElement.Add(new Class { Name = "invalid" });
 
             using var stream = new MemoryStream();
 
-            Assert.That(() => this.xmiWriter.Write(invalidPackage, stream, "output.xmi"),
+            Assert.That(() => this.xmiWriter.Write(this.package, stream, "output.xmi"),
                 Throws.InvalidOperationException.With.Message.Contains("do not have an XmiId"));
+        }
+
+        [Test]
+        public void Verify_that_a_root_package_without_an_XmiId_is_written_without_an_xmi_id_attribute()
+        {
+            var rootWithoutXmiId = new Package { Name = "package" };
+
+            using var stream = new MemoryStream();
+
+            this.xmiWriter.Write(rootWithoutXmiId, stream, "output.xmi");
+
+            var xmlDocument = new XmlDocument();
+            stream.Position = 0;
+            xmlDocument.Load(stream);
+
+            var packageElement = (XmlElement)xmlDocument.DocumentElement.FirstChild;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(packageElement.Name, Is.EqualTo("uml:Package"));
+                Assert.That(packageElement.HasAttribute("xmi:id"), Is.False,
+                    "a root package without an XmiId - which is how Enterprise Architect exports its uml:Model - is expected to be written without an xmi:id attribute rather than with an empty one");
+                Assert.That(packageElement.GetAttribute("name"), Is.EqualTo("package"));
+            }
         }
 
         [Test]

--- a/uml4net.xmi/AutoGenXmiWriters/AbstractionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AbstractionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Abstraction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Abstraction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Abstraction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Abstraction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Abstraction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Abstraction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/AcceptCallActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AcceptCallActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AcceptCallAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AcceptCallAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AcceptCallAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AcceptCallAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AcceptCallAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AcceptCallAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/AcceptEventActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AcceptEventActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AcceptEventAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AcceptEventAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AcceptEventAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -240,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -285,14 +290,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AcceptEventAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AcceptEventAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AcceptEventAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -405,6 +413,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ActionExecutionSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActionExecutionSpecificationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ActionExecutionSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ActionExecutionSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActionExecutionSpecification");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -215,6 +218,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -260,14 +265,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ActionExecutionSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ActionExecutionSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActionExecutionSpecification");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -355,6 +363,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Start, "start", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ActionInputPinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActionInputPinWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ActionInputPin with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ActionInputPin with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActionInputPin");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +278,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -320,14 +325,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ActionInputPin with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ActionInputPin with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActionInputPin");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -475,6 +483,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityFinalNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityFinalNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ActivityFinalNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ActivityFinalNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityFinalNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ActivityFinalNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ActivityFinalNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityFinalNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityParameterNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityParameterNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ActivityParameterNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ActivityParameterNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityParameterNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -255,6 +258,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -300,14 +305,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ActivityParameterNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ActivityParameterNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityParameterNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -435,6 +443,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityPartitionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityPartitionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ActivityPartition with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ActivityPartition with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityPartition");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -210,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -255,14 +260,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ActivityPartition with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ActivityPartition with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ActivityPartition");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -345,6 +353,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.SuperPartition, "superPartition", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Activity with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Activity with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Activity");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -400,6 +403,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -445,14 +450,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Activity with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Activity with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Activity");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -725,6 +733,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ActorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActorWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Actor with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Actor with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Actor");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -290,6 +293,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -335,14 +340,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Actor with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Actor with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Actor");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -505,6 +513,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/AddStructuralFeatureValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AddStructuralFeatureValueActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AddStructuralFeatureValueAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AddStructuralFeatureValueAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AddStructuralFeatureValueAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -260,6 +263,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -305,14 +310,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AddStructuralFeatureValueAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AddStructuralFeatureValueAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AddStructuralFeatureValueAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -445,6 +453,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/AddVariableValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AddVariableValueActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AddVariableValueAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AddVariableValueAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AddVariableValueAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -250,6 +253,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -295,14 +300,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AddVariableValueAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AddVariableValueAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AddVariableValueAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -425,6 +433,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/AnyReceiveEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AnyReceiveEventWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AnyReceiveEvent with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AnyReceiveEvent with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AnyReceiveEvent");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -175,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -220,14 +225,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AnyReceiveEvent with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AnyReceiveEvent with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AnyReceiveEvent");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +283,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ArtifactWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ArtifactWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Artifact with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Artifact with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Artifact");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +298,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -340,14 +345,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Artifact with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Artifact with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Artifact");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -515,6 +523,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/AssociationClassWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AssociationClassWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AssociationClass with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AssociationClass with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AssociationClass");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -340,6 +343,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -385,14 +390,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the AssociationClass with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the AssociationClass with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:AssociationClass");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -605,6 +613,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/AssociationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AssociationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Association with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Association with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Association");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -290,6 +293,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -335,14 +340,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Association with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Association with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Association");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -505,6 +513,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/BehaviorExecutionSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/BehaviorExecutionSpecificationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the BehaviorExecutionSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the BehaviorExecutionSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:BehaviorExecutionSpecification");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -215,6 +218,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -260,14 +265,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the BehaviorExecutionSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the BehaviorExecutionSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:BehaviorExecutionSpecification");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -355,6 +363,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Start, "start", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/BroadcastSignalActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/BroadcastSignalActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the BroadcastSignalAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the BroadcastSignalAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:BroadcastSignalAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -250,6 +253,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -295,14 +300,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the BroadcastSignalAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the BroadcastSignalAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:BroadcastSignalAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -425,6 +433,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signal, "signal", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CallBehaviorActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CallBehaviorActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CallBehaviorAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CallBehaviorAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallBehaviorAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -260,6 +263,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -305,14 +310,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CallBehaviorAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CallBehaviorAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallBehaviorAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -445,6 +453,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CallEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CallEventWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CallEvent with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CallEvent with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallEvent");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -185,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -230,14 +235,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CallEvent with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CallEvent with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallEvent");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +303,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CallOperationActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CallOperationActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CallOperationAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CallOperationAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallOperationAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -265,6 +268,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -310,14 +315,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CallOperationAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CallOperationAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CallOperationAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -455,6 +463,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CentralBufferNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CentralBufferNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CentralBufferNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CentralBufferNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CentralBufferNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CentralBufferNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CentralBufferNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CentralBufferNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ChangeEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ChangeEventWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ChangeEvent with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ChangeEvent with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ChangeEvent");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -180,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -225,14 +230,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ChangeEvent with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ChangeEvent with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ChangeEvent");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -285,6 +293,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ClassWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClassWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Class with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Class with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Class");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -320,6 +323,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -365,14 +370,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Class with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Class with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Class");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -565,6 +573,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ClassifierTemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClassifierTemplateParameterWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ClassifierTemplateParameter with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ClassifierTemplateParameter with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClassifierTemplateParameter");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ClassifierTemplateParameter with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ClassifierTemplateParameter with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClassifierTemplateParameter");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ClauseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClauseWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Clause with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Clause with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Clause");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -175,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -220,14 +225,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Clause with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Clause with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Clause");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +283,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "test", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ClearAssociationActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClearAssociationActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ClearAssociationAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ClearAssociationAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearAssociationAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -240,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -285,14 +290,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ClearAssociationAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ClearAssociationAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearAssociationAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -405,6 +413,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ClearStructuralFeatureActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClearStructuralFeatureActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ClearStructuralFeatureAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ClearStructuralFeatureAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearStructuralFeatureAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ClearStructuralFeatureAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ClearStructuralFeatureAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearStructuralFeatureAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ClearVariableActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClearVariableActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ClearVariableAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ClearVariableAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearVariableAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -235,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -280,14 +285,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ClearVariableAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ClearVariableAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ClearVariableAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -395,6 +403,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CollaborationUseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CollaborationUseWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CollaborationUse with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CollaborationUse with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CollaborationUse");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -169,6 +172,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -215,14 +220,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CollaborationUse with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CollaborationUse with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CollaborationUse");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -265,6 +273,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CollaborationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CollaborationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Collaboration with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Collaboration with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Collaboration");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +308,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -350,14 +355,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Collaboration with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Collaboration with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Collaboration");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -535,6 +543,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CombinedFragmentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CombinedFragmentWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CombinedFragment with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CombinedFragment with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CombinedFragment");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -200,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -245,14 +250,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CombinedFragment with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CombinedFragment with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CombinedFragment");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +333,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CommentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CommentWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Comment with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Comment with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Comment");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -149,6 +152,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -195,14 +200,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Comment with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Comment with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Comment");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -225,6 +233,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CommunicationPathWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CommunicationPathWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CommunicationPath with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CommunicationPath with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CommunicationPath");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -290,6 +293,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -335,14 +340,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CommunicationPath with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CommunicationPath with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CommunicationPath");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -505,6 +513,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ComponentRealizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ComponentRealizationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ComponentRealization with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ComponentRealization with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ComponentRealization");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ComponentRealization with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ComponentRealization with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ComponentRealization");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ComponentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ComponentWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Component with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Component with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Component");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +338,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -380,14 +385,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Component with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Component with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Component");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -595,6 +603,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ConditionalNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConditionalNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ConditionalNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ConditionalNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConditionalNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -285,6 +288,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -330,14 +335,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ConditionalNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ConditionalNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConditionalNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -495,6 +503,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectableElementTemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectableElementTemplateParameterWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ConnectableElementTemplateParameter with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ConnectableElementTemplateParameter with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectableElementTemplateParameter");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -180,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -225,14 +230,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ConnectableElementTemplateParameter with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ConnectableElementTemplateParameter with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectableElementTemplateParameter");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -285,6 +293,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectionPointReferenceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectionPointReferenceWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ConnectionPointReference with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ConnectionPointReference with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectionPointReference");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -200,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -245,14 +250,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ConnectionPointReference with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ConnectionPointReference with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectionPointReference");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +333,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.State, "state", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectorEndWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectorEndWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ConnectorEnd with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ConnectorEnd with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectorEnd");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -180,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -225,14 +230,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ConnectorEnd with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ConnectorEnd with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConnectorEnd");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -285,6 +293,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectorWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Connector with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Connector with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Connector");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Connector with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Connector with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Connector");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ConsiderIgnoreFragmentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConsiderIgnoreFragmentWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ConsiderIgnoreFragment with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ConsiderIgnoreFragment with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConsiderIgnoreFragment");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ConsiderIgnoreFragment with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ConsiderIgnoreFragment with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ConsiderIgnoreFragment");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConstraintWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Constraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Constraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Constraint");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -195,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -240,14 +245,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Constraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Constraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Constraint");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +323,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ContinuationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ContinuationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Continuation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Continuation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Continuation");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Continuation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Continuation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Continuation");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ControlFlowWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ControlFlowWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ControlFlow with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ControlFlow with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ControlFlow");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -230,6 +233,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -275,14 +280,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ControlFlow with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ControlFlow with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ControlFlow");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -385,6 +393,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "weight", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CreateLinkActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CreateLinkActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CreateLinkAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CreateLinkAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateLinkAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -235,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -280,14 +285,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CreateLinkAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CreateLinkAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateLinkAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -395,6 +403,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CreateLinkObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CreateLinkObjectActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CreateLinkObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CreateLinkObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateLinkObjectAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -240,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -285,14 +290,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CreateLinkObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CreateLinkObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateLinkObjectAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -405,6 +413,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/CreateObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CreateObjectActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CreateObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CreateObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateObjectAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -240,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -285,14 +290,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the CreateObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the CreateObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:CreateObjectAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -405,6 +413,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DataStoreNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DataStoreNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DataStoreNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DataStoreNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DataStoreNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DataStoreNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DataStoreNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DataStoreNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DataTypeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DataTypeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DataType with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DataType with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DataType");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -280,6 +283,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -325,14 +330,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DataType with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DataType with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DataType");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -485,6 +493,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DecisionNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DecisionNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DecisionNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DecisionNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DecisionNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -225,6 +228,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -270,14 +275,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DecisionNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DecisionNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DecisionNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -375,6 +383,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DependencyWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DependencyWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Dependency with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Dependency with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Dependency");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -185,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -230,14 +235,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Dependency with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Dependency with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Dependency");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +303,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DeploymentSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DeploymentSpecificationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DeploymentSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DeploymentSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DeploymentSpecification");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +318,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -360,14 +365,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DeploymentSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DeploymentSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DeploymentSpecification");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -555,6 +563,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DeploymentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DeploymentWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Deployment with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Deployment with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Deployment");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Deployment with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Deployment with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Deployment");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DestroyLinkActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DestroyLinkActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DestroyLinkAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DestroyLinkAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestroyLinkAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -235,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -280,14 +285,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DestroyLinkAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DestroyLinkAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestroyLinkAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -395,6 +403,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DestroyObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DestroyObjectActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DestroyObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DestroyObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestroyObjectAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -240,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -285,14 +290,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DestroyObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DestroyObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestroyObjectAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -405,6 +413,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DestructionOccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DestructionOccurrenceSpecificationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DestructionOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DestructionOccurrenceSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestructionOccurrenceSpecification");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -210,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -255,14 +260,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DestructionOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DestructionOccurrenceSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DestructionOccurrenceSpecification");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -345,6 +353,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DeviceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DeviceWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Device with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Device with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Device");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -330,6 +333,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -375,14 +380,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Device with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Device with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Device");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -585,6 +593,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DurationConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationConstraintWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DurationConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DurationConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationConstraint");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -200,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -245,14 +250,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DurationConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DurationConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationConstraint");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +333,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DurationIntervalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationIntervalWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DurationInterval with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DurationInterval with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationInterval");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DurationInterval with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DurationInterval with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationInterval");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DurationObservationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationObservationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DurationObservation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DurationObservation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationObservation");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -185,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -230,14 +235,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the DurationObservation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the DurationObservation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:DurationObservation");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +303,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/DurationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Duration with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Duration with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Duration");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -195,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -240,14 +245,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Duration with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Duration with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Duration");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +323,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ElementImportWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ElementImportWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ElementImport with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ElementImport with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ElementImport");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -169,6 +172,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -215,14 +220,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ElementImport with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ElementImport with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ElementImport");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -265,6 +273,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/EnumerationLiteralWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/EnumerationLiteralWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the EnumerationLiteral with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the EnumerationLiteral with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:EnumerationLiteral");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -200,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -245,14 +250,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the EnumerationLiteral with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the EnumerationLiteral with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:EnumerationLiteral");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +333,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/EnumerationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/EnumerationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Enumeration with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Enumeration with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Enumeration");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -285,6 +288,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -330,14 +335,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Enumeration with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Enumeration with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Enumeration");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -495,6 +503,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ExceptionHandlerWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExceptionHandlerWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExceptionHandler with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExceptionHandler with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExceptionHandler");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -175,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -220,14 +225,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExceptionHandler with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExceptionHandler with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExceptionHandler");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +283,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ProtectedNode, "protectedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ExecutionEnvironmentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExecutionEnvironmentWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExecutionEnvironment with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExecutionEnvironment with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExecutionEnvironment");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -330,6 +333,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -375,14 +380,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExecutionEnvironment with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExecutionEnvironment with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExecutionEnvironment");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -585,6 +593,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ExecutionOccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExecutionOccurrenceSpecificationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExecutionOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExecutionOccurrenceSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExecutionOccurrenceSpecification");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -210,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -255,14 +260,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExecutionOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExecutionOccurrenceSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExecutionOccurrenceSpecification");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -345,6 +353,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ExpansionNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExpansionNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExpansionNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExpansionNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExpansionNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -265,6 +268,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -310,14 +315,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExpansionNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExpansionNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExpansionNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -455,6 +463,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ExpansionRegionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExpansionRegionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExpansionRegion with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExpansionRegion with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExpansionRegion");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -285,6 +288,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -330,14 +335,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExpansionRegion with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExpansionRegion with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExpansionRegion");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -495,6 +503,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExpressionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Expression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Expression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Expression");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -195,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -240,14 +245,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Expression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Expression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Expression");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +323,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ExtendWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtendWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Extend with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Extend with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Extend");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -185,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -230,14 +235,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Extend with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Extend with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Extend");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +303,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ExtensionEndWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtensionEndWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExtensionEnd with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExtensionEnd with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExtensionEnd");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +328,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -370,14 +375,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExtensionEnd with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExtensionEnd with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExtensionEnd");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -575,6 +583,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ExtensionPointWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtensionPointWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExtensionPoint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExtensionPoint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExtensionPoint");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -169,6 +172,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.UseCase, "useCase", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -215,14 +220,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ExtensionPoint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ExtensionPoint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ExtensionPoint");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -265,6 +273,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.UseCase, "useCase", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ExtensionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtensionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Extension with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Extension with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Extension");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -290,6 +293,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -335,14 +340,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Extension with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Extension with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Extension");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -505,6 +513,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/FinalStateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/FinalStateWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the FinalState with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the FinalState with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FinalState");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the FinalState with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the FinalState with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FinalState");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Submachine, "submachine", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/FlowFinalNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/FlowFinalNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the FlowFinalNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the FlowFinalNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FlowFinalNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the FlowFinalNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the FlowFinalNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FlowFinalNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ForkNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ForkNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ForkNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ForkNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ForkNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ForkNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ForkNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ForkNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/FunctionBehaviorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/FunctionBehaviorWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the FunctionBehavior with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the FunctionBehavior with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FunctionBehavior");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -370,6 +373,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -415,14 +420,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the FunctionBehavior with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the FunctionBehavior with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:FunctionBehavior");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -665,6 +673,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/GateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GateWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Gate with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Gate with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Gate");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -164,6 +167,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -210,14 +215,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Gate with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Gate with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Gate");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -255,6 +263,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/GeneralOrderingWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GeneralOrderingWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the GeneralOrdering with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the GeneralOrdering with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:GeneralOrdering");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -175,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -220,14 +225,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the GeneralOrdering with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the GeneralOrdering with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:GeneralOrdering");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +283,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/GeneralizationSetWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GeneralizationSetWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the GeneralizationSet with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the GeneralizationSet with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:GeneralizationSet");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -200,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -245,14 +250,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the GeneralizationSet with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the GeneralizationSet with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:GeneralizationSet");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +333,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/GeneralizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GeneralizationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Generalization with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Generalization with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Generalization");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -169,6 +172,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Specific, "specific", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -215,14 +220,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Generalization with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Generalization with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Generalization");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -265,6 +273,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specific, "specific", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ImageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ImageWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Image with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Image with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Image");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -154,6 +157,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -200,14 +205,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Image with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Image with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Image");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -235,6 +243,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/IncludeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/IncludeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Include with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Include with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Include");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -175,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -220,14 +225,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Include with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Include with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Include");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +283,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InformationFlowWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InformationFlowWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InformationFlow with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InformationFlow with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InformationFlow");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -210,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -255,14 +260,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InformationFlow with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InformationFlow with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InformationFlow");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -345,6 +353,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InformationItemWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InformationItemWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InformationItem with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InformationItem with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InformationItem");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +278,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -320,14 +325,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InformationItem with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InformationItem with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InformationItem");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -475,6 +483,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InitialNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InitialNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InitialNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InitialNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InitialNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InitialNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InitialNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InitialNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InputPinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InputPinWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InputPin with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InputPin with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InputPin");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -270,6 +273,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -315,14 +320,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InputPin with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InputPin with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InputPin");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -465,6 +473,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InstanceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InstanceSpecificationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InstanceSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InstanceSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InstanceSpecification");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -195,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -240,14 +245,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InstanceSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InstanceSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InstanceSpecification");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +323,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InstanceValueWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InstanceValueWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InstanceValue with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InstanceValue with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InstanceValue");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -195,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -240,14 +245,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InstanceValue with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InstanceValue with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InstanceValue");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +323,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionConstraintWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InteractionConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InteractionConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionConstraint");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InteractionConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InteractionConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionConstraint");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionOperandWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionOperandWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InteractionOperand with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InteractionOperand with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionOperand");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -210,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -255,14 +260,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InteractionOperand with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InteractionOperand with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionOperand");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -345,6 +353,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionUseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionUseWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InteractionUse with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InteractionUse with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionUse");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -220,6 +223,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -265,14 +270,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InteractionUse with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InteractionUse with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InteractionUse");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -365,6 +373,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReturnValueRecipient, "returnValueRecipient", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Interaction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Interaction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interaction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +418,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -460,14 +465,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Interaction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Interaction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interaction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -755,6 +763,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InterfaceRealizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InterfaceRealizationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InterfaceRealization with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InterfaceRealization with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InterfaceRealization");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -210,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -255,14 +260,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InterfaceRealization with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InterfaceRealization with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InterfaceRealization");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -345,6 +353,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InterfaceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InterfaceWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Interface with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Interface with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interface");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -300,6 +303,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -345,14 +350,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Interface with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Interface with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interface");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -525,6 +533,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/InterruptibleActivityRegionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InterruptibleActivityRegionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InterruptibleActivityRegion with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InterruptibleActivityRegion with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InterruptibleActivityRegion");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -175,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -220,14 +225,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the InterruptibleActivityRegion with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the InterruptibleActivityRegion with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:InterruptibleActivityRegion");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +283,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/IntervalConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/IntervalConstraintWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the IntervalConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the IntervalConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:IntervalConstraint");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -195,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -240,14 +245,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the IntervalConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the IntervalConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:IntervalConstraint");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +323,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/IntervalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/IntervalWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Interval with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Interval with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interval");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Interval with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Interval with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Interval");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/JoinNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/JoinNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the JoinNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the JoinNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:JoinNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -215,6 +218,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -260,14 +265,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the JoinNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the JoinNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:JoinNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -355,6 +363,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LifelineWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LifelineWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Lifeline with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Lifeline with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Lifeline");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -195,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -240,14 +245,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Lifeline with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Lifeline with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Lifeline");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +323,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "selector", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LinkEndCreationDataWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LinkEndCreationDataWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LinkEndCreationData with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LinkEndCreationData with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndCreationData");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -180,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -225,14 +230,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LinkEndCreationData with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LinkEndCreationData with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndCreationData");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -285,6 +293,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LinkEndDataWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LinkEndDataWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LinkEndData with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LinkEndData with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndData");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -164,6 +167,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Value, "value", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -210,14 +215,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LinkEndData with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LinkEndData with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndData");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -255,6 +263,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LinkEndDestructionDataWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LinkEndDestructionDataWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LinkEndDestructionData with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LinkEndDestructionData with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndDestructionData");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -180,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -225,14 +230,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LinkEndDestructionData with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LinkEndDestructionData with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LinkEndDestructionData");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -285,6 +293,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralBooleanWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralBooleanWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralBoolean with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralBoolean with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralBoolean");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralBoolean with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralBoolean with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralBoolean");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralIntegerWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralIntegerWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralInteger with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralInteger with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralInteger");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralInteger with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralInteger with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralInteger");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralNullWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralNullWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralNull with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralNull with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralNull");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -185,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -230,14 +235,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralNull with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralNull with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralNull");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +303,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralRealWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralRealWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralReal with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralReal with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralReal");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralReal with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralReal with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralReal");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralStringWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralStringWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralString with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralString with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralString");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralString with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralString with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralString");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralUnlimitedNatural with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralUnlimitedNatural with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralUnlimitedNatural");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LiteralUnlimitedNatural with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LiteralUnlimitedNatural with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LiteralUnlimitedNatural");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/LoopNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LoopNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LoopNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LoopNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LoopNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -310,6 +313,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -355,14 +360,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the LoopNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the LoopNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:LoopNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -545,6 +553,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ManifestationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ManifestationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Manifestation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Manifestation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Manifestation");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -200,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -245,14 +250,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Manifestation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Manifestation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Manifestation");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +333,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.UtilizedElement, "utilizedElement", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/MergeNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/MergeNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the MergeNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the MergeNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:MergeNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the MergeNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the MergeNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:MergeNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/MessageOccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/MessageOccurrenceSpecificationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the MessageOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the MessageOccurrenceSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:MessageOccurrenceSpecification");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -210,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -255,14 +260,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the MessageOccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the MessageOccurrenceSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:MessageOccurrenceSpecification");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -345,6 +353,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/MessageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/MessageWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Message with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Message with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Message");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -215,6 +218,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -260,14 +265,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Message with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Message with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Message");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -355,6 +363,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ModelWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ModelWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Model with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Model with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Model");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -235,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -280,14 +285,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Model with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Model with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Model");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -395,6 +403,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/NodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/NodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Node with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Node with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Node");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -330,6 +333,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -375,14 +380,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Node with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Node with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Node");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -585,6 +593,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ObjectFlowWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ObjectFlowWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ObjectFlow with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ObjectFlow with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ObjectFlow");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -260,6 +263,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -305,14 +310,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ObjectFlow with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ObjectFlow with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ObjectFlow");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -445,6 +453,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "weight", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/OccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OccurrenceSpecificationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OccurrenceSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OccurrenceSpecification");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -200,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -245,14 +250,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OccurrenceSpecification with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OccurrenceSpecification with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OccurrenceSpecification");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +333,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/OpaqueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OpaqueActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OpaqueAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OpaqueAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OpaqueAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OpaqueAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/OpaqueBehaviorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OpaqueBehaviorWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OpaqueBehavior with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OpaqueBehavior with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueBehavior");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -370,6 +373,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -415,14 +420,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OpaqueBehavior with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OpaqueBehavior with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueBehavior");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -665,6 +673,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/OpaqueExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OpaqueExpressionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OpaqueExpression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OpaqueExpression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueExpression");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OpaqueExpression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OpaqueExpression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OpaqueExpression");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/OperationTemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OperationTemplateParameterWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OperationTemplateParameter with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OperationTemplateParameter with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OperationTemplateParameter");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -180,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -225,14 +230,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OperationTemplateParameter with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OperationTemplateParameter with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OperationTemplateParameter");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -285,6 +293,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/OperationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OperationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Operation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Operation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Operation");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +298,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -340,14 +345,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Operation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Operation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Operation");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -515,6 +523,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/OutputPinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OutputPinWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OutputPin with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OutputPin with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OutputPin");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -270,6 +273,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -315,14 +320,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the OutputPin with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the OutputPin with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:OutputPin");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -465,6 +473,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/PackageImportWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PackageImportWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the PackageImport with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the PackageImport with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PackageImport");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -164,6 +167,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -210,14 +215,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the PackageImport with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the PackageImport with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PackageImport");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -255,6 +263,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/PackageMergeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PackageMergeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the PackageMerge with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the PackageMerge with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PackageMerge");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -159,6 +162,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.ReceivingPackage, "receivingPackage", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -205,14 +210,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the PackageMerge with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the PackageMerge with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PackageMerge");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +253,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReceivingPackage, "receivingPackage", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/PackageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PackageWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Package with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Package with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Package");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -230,6 +233,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -275,14 +280,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Package with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Package with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Package");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -385,6 +393,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ParameterSetWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ParameterSetWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ParameterSet with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ParameterSet with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ParameterSet");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -164,6 +167,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "parameter", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -210,14 +215,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ParameterSet with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ParameterSet with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ParameterSet");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -255,6 +263,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "parameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ParameterWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Parameter with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Parameter with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Parameter");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Parameter with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Parameter with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Parameter");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/PartDecompositionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PartDecompositionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the PartDecomposition with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the PartDecomposition with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PartDecomposition");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -220,6 +223,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -265,14 +270,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the PartDecomposition with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the PartDecomposition with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PartDecomposition");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -365,6 +373,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReturnValueRecipient, "returnValueRecipient", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/PortWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PortWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Port with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Port with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Port");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -355,6 +358,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -400,14 +405,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Port with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Port with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Port");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -635,6 +643,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/PrimitiveTypeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PrimitiveTypeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the PrimitiveType with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the PrimitiveType with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PrimitiveType");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -280,6 +283,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -325,14 +330,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the PrimitiveType with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the PrimitiveType with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:PrimitiveType");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -485,6 +493,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ProfileApplicationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProfileApplicationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ProfileApplication with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ProfileApplication with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProfileApplication");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -164,6 +167,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -210,14 +215,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ProfileApplication with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ProfileApplication with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProfileApplication");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -255,6 +263,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ProfileWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProfileWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Profile with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Profile with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Profile");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -240,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -285,14 +290,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Profile with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Profile with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Profile");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -405,6 +413,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/PropertyWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PropertyWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Property with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Property with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Property");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +328,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -370,14 +375,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Property with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Property with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Property");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -575,6 +583,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ProtocolConformanceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProtocolConformanceWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ProtocolConformance with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ProtocolConformance with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolConformance");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -159,6 +162,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.SpecificMachine, "specificMachine", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -205,14 +210,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ProtocolConformance with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ProtocolConformance with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolConformance");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +253,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.SpecificMachine, "specificMachine", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ProtocolStateMachineWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProtocolStateMachineWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ProtocolStateMachine with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ProtocolStateMachine with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolStateMachine");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -380,6 +383,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -425,14 +430,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ProtocolStateMachine with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ProtocolStateMachine with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolStateMachine");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -685,6 +693,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ProtocolTransitionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProtocolTransitionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ProtocolTransition with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ProtocolTransition with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolTransition");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ProtocolTransition with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ProtocolTransition with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ProtocolTransition");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/PseudostateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PseudostateWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Pseudostate with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Pseudostate with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Pseudostate");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Pseudostate with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Pseudostate with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Pseudostate");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StateMachine, "stateMachine", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/QualifierValueWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/QualifierValueWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the QualifierValue with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the QualifierValue with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:QualifierValue");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -159,6 +162,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Value, "value", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -205,14 +210,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the QualifierValue with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the QualifierValue with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:QualifierValue");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +253,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/RaiseExceptionActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RaiseExceptionActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the RaiseExceptionAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the RaiseExceptionAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RaiseExceptionAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -230,6 +233,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -275,14 +280,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the RaiseExceptionAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the RaiseExceptionAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RaiseExceptionAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -385,6 +393,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReadExtentActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadExtentActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadExtentAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadExtentAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadExtentAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -240,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -285,14 +290,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadExtentAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadExtentAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadExtentAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -405,6 +413,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReadIsClassifiedObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadIsClassifiedObjectActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadIsClassifiedObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadIsClassifiedObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadIsClassifiedObjectAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -250,6 +253,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -295,14 +300,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadIsClassifiedObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadIsClassifiedObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadIsClassifiedObjectAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -425,6 +433,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReadLinkActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadLinkActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadLinkAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadLinkAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -240,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -285,14 +290,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadLinkAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadLinkAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -405,6 +413,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadLinkObjectEndAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadLinkObjectEndAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkObjectEndAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadLinkObjectEndAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadLinkObjectEndAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkObjectEndAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndQualifierActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndQualifierActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadLinkObjectEndQualifierAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadLinkObjectEndQualifierAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkObjectEndQualifierAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadLinkObjectEndQualifierAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadLinkObjectEndQualifierAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadLinkObjectEndQualifierAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReadSelfActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadSelfActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadSelfAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadSelfAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadSelfAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -230,6 +233,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -275,14 +280,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadSelfAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadSelfAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadSelfAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -385,6 +393,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReadStructuralFeatureActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadStructuralFeatureActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadStructuralFeatureAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadStructuralFeatureAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadStructuralFeatureAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadStructuralFeatureAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadStructuralFeatureAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadStructuralFeatureAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReadVariableActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadVariableActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadVariableAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadVariableAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadVariableAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -240,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -285,14 +290,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReadVariableAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReadVariableAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReadVariableAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -405,6 +413,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/RealizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RealizationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Realization with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Realization with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Realization");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Realization with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Realization with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Realization");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReceptionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReceptionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Reception with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Reception with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Reception");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -220,6 +223,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -265,14 +270,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Reception with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Reception with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Reception");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -365,6 +373,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signal, "signal", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReclassifyObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReclassifyObjectActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReclassifyObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReclassifyObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReclassifyObjectAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReclassifyObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReclassifyObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReclassifyObjectAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/RedefinableTemplateSignatureWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RedefinableTemplateSignatureWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the RedefinableTemplateSignature with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the RedefinableTemplateSignature with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RedefinableTemplateSignature");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -185,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -230,14 +235,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the RedefinableTemplateSignature with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the RedefinableTemplateSignature with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RedefinableTemplateSignature");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +303,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "parameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReduceActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReduceActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReduceAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReduceAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReduceAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -250,6 +253,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -295,14 +300,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReduceAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReduceAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReduceAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -425,6 +433,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/RegionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RegionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Region with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Region with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Region");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -215,6 +218,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -260,14 +265,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Region with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Region with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Region");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -355,6 +363,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "transition", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/RemoveStructuralFeatureValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RemoveStructuralFeatureValueActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the RemoveStructuralFeatureValueAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the RemoveStructuralFeatureValueAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RemoveStructuralFeatureValueAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -260,6 +263,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -305,14 +310,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the RemoveStructuralFeatureValueAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the RemoveStructuralFeatureValueAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RemoveStructuralFeatureValueAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -445,6 +453,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/RemoveVariableValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RemoveVariableValueActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the RemoveVariableValueAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the RemoveVariableValueAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RemoveVariableValueAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -250,6 +253,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -295,14 +300,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the RemoveVariableValueAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the RemoveVariableValueAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:RemoveVariableValueAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -425,6 +433,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ReplyActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReplyActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReplyAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReplyAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReplyAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ReplyAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ReplyAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ReplyAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "returnInformation", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/SendObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SendObjectActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the SendObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the SendObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SendObjectAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the SendObjectAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the SendObjectAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SendObjectAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/SendSignalActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SendSignalActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the SendSignalAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the SendSignalAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SendSignalAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -255,6 +258,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -300,14 +305,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the SendSignalAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the SendSignalAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SendSignalAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -435,6 +443,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/SequenceNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SequenceNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the SequenceNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the SequenceNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SequenceNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -270,6 +273,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -315,14 +320,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the SequenceNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the SequenceNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SequenceNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -465,6 +473,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/SignalEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SignalEventWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the SignalEvent with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the SignalEvent with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SignalEvent");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -185,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -230,14 +235,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the SignalEvent with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the SignalEvent with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:SignalEvent");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +303,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/SignalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SignalWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Signal with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Signal with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Signal");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +278,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -320,14 +325,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Signal with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Signal with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Signal");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -475,6 +483,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/SlotWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SlotWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Slot with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Slot with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Slot");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -164,6 +167,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteContainedElement(xmlWriter, value, "value", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -210,14 +215,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Slot with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Slot with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Slot");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -255,6 +263,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/StartClassifierBehaviorActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StartClassifierBehaviorActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StartClassifierBehaviorAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StartClassifierBehaviorAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StartClassifierBehaviorAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -230,6 +233,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -275,14 +280,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StartClassifierBehaviorAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StartClassifierBehaviorAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StartClassifierBehaviorAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -385,6 +393,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/StartObjectBehaviorActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StartObjectBehaviorActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StartObjectBehaviorAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StartObjectBehaviorAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StartObjectBehaviorAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -255,6 +258,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -300,14 +305,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StartObjectBehaviorAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StartObjectBehaviorAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StartObjectBehaviorAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -435,6 +443,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/StateInvariantWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StateInvariantWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StateInvariant with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StateInvariant with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateInvariant");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -195,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -240,14 +245,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StateInvariant with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StateInvariant with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateInvariant");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +323,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/StateMachineWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StateMachineWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StateMachine with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StateMachine with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateMachine");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -375,6 +378,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -420,14 +425,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StateMachine with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StateMachine with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StateMachine");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -675,6 +683,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/StateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StateWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the State with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the State with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:State");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the State with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the State with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:State");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Submachine, "submachine", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/StereotypeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StereotypeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Stereotype with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Stereotype with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Stereotype");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +328,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -370,14 +375,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Stereotype with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Stereotype with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Stereotype");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -575,6 +583,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/StringExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StringExpressionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StringExpression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StringExpression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StringExpression");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -220,6 +223,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -265,14 +270,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StringExpression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StringExpression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StringExpression");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -365,6 +373,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/StructuredActivityNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StructuredActivityNodeWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StructuredActivityNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StructuredActivityNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StructuredActivityNode");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -270,6 +273,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -315,14 +320,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the StructuredActivityNode with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the StructuredActivityNode with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:StructuredActivityNode");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -465,6 +473,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/SubstitutionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SubstitutionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Substitution with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Substitution with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Substitution");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -210,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -255,14 +260,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Substitution with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Substitution with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Substitution");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -345,6 +353,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateBindingWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateBindingWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TemplateBinding with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TemplateBinding with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateBinding");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -164,6 +167,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -210,14 +215,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TemplateBinding with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TemplateBinding with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateBinding");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -255,6 +263,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateParameterSubstitutionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateParameterSubstitutionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TemplateParameterSubstitution with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TemplateParameterSubstitution with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateParameterSubstitution");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -175,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -220,14 +225,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TemplateParameterSubstitution with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TemplateParameterSubstitution with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateParameterSubstitution");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +283,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateBinding, "templateBinding", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateParameterWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TemplateParameter with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TemplateParameter with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateParameter");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -180,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -225,14 +230,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TemplateParameter with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TemplateParameter with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateParameter");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -285,6 +293,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateSignatureWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateSignatureWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TemplateSignature with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TemplateSignature with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateSignature");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -159,6 +162,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, element.Template, "template", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -205,14 +210,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TemplateSignature with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TemplateSignature with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TemplateSignature");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +253,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Template, "template", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TestIdentityActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TestIdentityActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TestIdentityAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TestIdentityAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TestIdentityAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -240,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -285,14 +290,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TestIdentityAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TestIdentityAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TestIdentityAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -405,6 +413,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "second", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TimeConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeConstraintWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeConstraint");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -200,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -245,14 +250,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeConstraint with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeConstraint with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeConstraint");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -325,6 +333,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TimeEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeEventWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeEvent with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeEvent with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeEvent");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -185,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -230,14 +235,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeEvent with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeEvent with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeEvent");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +303,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "when", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TimeExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeExpressionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeExpression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeExpression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeExpression");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -195,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -240,14 +245,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeExpression with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeExpression with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeExpression");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -315,6 +323,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TimeIntervalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeIntervalWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeInterval with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeInterval with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeInterval");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -205,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -250,14 +255,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeInterval with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeInterval with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeInterval");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -335,6 +343,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TimeObservationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeObservationWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeObservation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeObservation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeObservation");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -190,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -235,14 +240,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the TimeObservation with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the TimeObservation with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:TimeObservation");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -305,6 +313,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TransitionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TransitionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Transition with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Transition with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Transition");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -235,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -280,14 +285,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Transition with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Transition with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Transition");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -395,6 +403,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/TriggerWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TriggerWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Trigger with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Trigger with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Trigger");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -169,6 +172,8 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.WriteReferenceElement(xmlWriter, value, "port", writeContext);
             }
 
+
+            this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
         }
@@ -215,14 +220,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Trigger with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Trigger with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Trigger");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -265,6 +273,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "port", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/UnmarshallActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/UnmarshallActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the UnmarshallAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the UnmarshallAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:UnmarshallAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -245,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -290,14 +295,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the UnmarshallAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the UnmarshallAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:UnmarshallAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -415,6 +423,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.UnmarshallType, "unmarshallType", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/UsageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/UsageWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Usage with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Usage with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Usage");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -185,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -230,14 +235,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Usage with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Usage with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Usage");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -295,6 +303,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/UseCaseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/UseCaseWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the UseCase with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the UseCase with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:UseCase");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -310,6 +313,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -355,14 +360,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the UseCase with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the UseCase with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:UseCase");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -545,6 +553,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ValuePinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ValuePinWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ValuePin with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ValuePin with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ValuePin");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -275,6 +278,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -320,14 +325,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ValuePin with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ValuePin with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ValuePin");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -475,6 +483,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/ValueSpecificationActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ValueSpecificationActionWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ValueSpecificationAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ValueSpecificationAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ValueSpecificationAction");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -235,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -280,14 +285,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the ValueSpecificationAction with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the ValueSpecificationAction with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:ValueSpecificationAction");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -395,6 +403,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/AutoGenXmiWriters/VariableWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/VariableWriter.cs
@@ -119,14 +119,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Variable with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Variable with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             this.WriteStartElement(xmlWriter, elementName);
 
             xmlWriter.WriteAttributeString("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Variable");
 
-            xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -225,6 +228,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            this.WriteExtensions(xmlWriter, element.Extensions);
+
             xmlWriter.WriteEndElement();
         }
 
@@ -270,14 +275,17 @@ namespace uml4net.xmi.Writers
 
             if (element.Extensions.Count > 0)
             {
-                this.logger.LogWarning("The Extensions of the Variable with id [{Id}] are not written", element.XmiId);
+                this.logger.LogTrace("writing the {Count} Extension(s) of the Variable with id [{Id}]", element.Extensions.Count, element.XmiId);
             }
 
             await this.WriteStartElementAsync(xmlWriter, elementName);
 
             await xmlWriter.WriteAttributeStringAsync("xmi", "type", this.XmiWriterSettings.XmiNamespaceUri, "uml:Variable");
 
-            await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            if (!string.IsNullOrEmpty(element.XmiId))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.XmiWriterSettings.XmiNamespaceUri, element.XmiId);
+            }
 
             if (!string.IsNullOrEmpty(element.XmiGuid))
             {
@@ -375,6 +383,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 
             await xmlWriter.WriteEndElementAsync();
         }

--- a/uml4net.xmi/Writers/IXmiWriter.cs
+++ b/uml4net.xmi/Writers/IXmiWriter.cs
@@ -21,6 +21,7 @@
 namespace uml4net.xmi.Writers
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
@@ -94,5 +95,85 @@ namespace uml4net.xmi.Writers
         /// an awaitable <see cref="Task"/>
         /// </returns>
         Task WriteAsync(IPackage package, Stream stream, string documentName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/> and <see cref="XmiExtension"/>s to a UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        void Write(IPackage package, string fileUri, IEnumerable<XmiExtension> documentExtensions);
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/> and <see cref="XmiExtension"/>s to a UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        void Write(IPackage package, Stream stream, string documentName, IEnumerable<XmiExtension> documentExtensions);
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/> and <see cref="XmiExtension"/>s to a
+        /// UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        Task WriteAsync(IPackage package, string fileUri, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/> and <see cref="XmiExtension"/>s to a
+        /// UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        Task WriteAsync(IPackage package, Stream stream, string documentName, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default);
     }
 }

--- a/uml4net.xmi/Writers/ReferenceClosureCalculator.cs
+++ b/uml4net.xmi/Writers/ReferenceClosureCalculator.cs
@@ -102,6 +102,13 @@ namespace uml4net.xmi.Writers
                 this.IncludeExternalRootPackages(package, rootPackages, localElements, localIdentifiers, elementsMissingXmiId);
             }
 
+            // A root package is written as a top-level element of the document, it is therefore never referred to
+            // by means of an xmi:idref or an href. A missing XmiId on a root package - which is how Enterprise
+            // Architect exports its uml:Model - is consequently harmless and is preserved as-is, rather than
+            // being reported as an offender. For any contained element a missing XmiId remains an error since
+            // such an element degrades into a dangling href and would lose its complete containment tree.
+            elementsMissingXmiId.RemoveAll(element => rootPackages.Any(rootPackage => ReferenceEquals(rootPackage, element)));
+
             return new XmiWritePlan(rootPackages, localIdentifiers, elementsMissingXmiId);
         }
 

--- a/uml4net.xmi/Writers/XmiElementWriter.cs
+++ b/uml4net.xmi/Writers/XmiElementWriter.cs
@@ -21,6 +21,7 @@
 namespace uml4net.xmi.Writers
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using System.Xml;
 
@@ -165,6 +166,58 @@ namespace uml4net.xmi.Writers
             }
 
             return xmlWriter.WriteStartElementAsync(null, elementName, null);
+        }
+
+        /// <summary>
+        /// Writes the <see cref="XmiExtension"/>s of an <see cref="IXmiElement"/> to the <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="extensions">
+        /// The <see cref="XmiExtension"/>s that are to be written
+        /// </param>
+        protected void WriteExtensions(XmlWriter xmlWriter, List<XmiExtension> extensions)
+        {
+            if (extensions == null || extensions.Count == 0)
+            {
+                return;
+            }
+
+            var xmiExtensionWriter = new XmiExtensionWriter(this.XmiWriterSettings, this.LoggerFactory);
+
+            foreach (var extension in extensions)
+            {
+                xmiExtensionWriter.Write(xmlWriter, extension);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="XmiExtension"/>s of an <see cref="IXmiElement"/> to the
+        /// <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="extensions">
+        /// The <see cref="XmiExtension"/>s that are to be written
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        protected async Task WriteExtensionsAsync(XmlWriter xmlWriter, List<XmiExtension> extensions)
+        {
+            if (extensions == null || extensions.Count == 0)
+            {
+                return;
+            }
+
+            var xmiExtensionWriter = new XmiExtensionWriter(this.XmiWriterSettings, this.LoggerFactory);
+
+            foreach (var extension in extensions)
+            {
+                await xmiExtensionWriter.WriteAsync(xmlWriter, extension);
+            }
         }
 
         /// <summary>

--- a/uml4net.xmi/Writers/XmiExtensionWriter.cs
+++ b/uml4net.xmi/Writers/XmiExtensionWriter.cs
@@ -1,0 +1,184 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiExtensionWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net.xmi.Settings;
+
+    /// <summary>
+    /// The purpose of the <see cref="XmiExtensionWriter"/> is to write an instance of <see cref="XmiExtension"/>
+    /// to an XMI document.
+    /// </summary>
+    /// <remarks>
+    /// The content of an <see cref="XmiExtension"/> is tool-vendor specific and is therefore not represented
+    /// by the UML 2.5.1 metamodel. It is written verbatim, using the
+    /// <see cref="XmiExtension.ContentRawXmi"/> that was captured when the extension was read, which makes
+    /// an extension survive a read-write cycle.
+    /// </remarks>
+    public class XmiExtensionWriter
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<XmiExtensionWriter> logger;
+
+        /// <summary>
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </summary>
+        private readonly IXmiWriterSettings xmiWriterSettings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XmiExtensionWriter"/> class.
+        /// </summary>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public XmiExtensionWriter(IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+        {
+            this.xmiWriterSettings = xmiWriterSettings;
+            this.logger = loggerFactory == null ? NullLogger<XmiExtensionWriter>.Instance : loggerFactory.CreateLogger<XmiExtensionWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="XmiExtension"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="extension">
+        /// The <see cref="XmiExtension"/> that is to be written
+        /// </param>
+        public void Write(XmlWriter xmlWriter, XmiExtension extension)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (extension == null)
+            {
+                throw new ArgumentNullException(nameof(extension));
+            }
+
+            this.logger.LogTrace("writing the XmiExtension of {Extender}:{ExtenderID}", extension.Extender, extension.ExtenderId);
+
+            xmlWriter.WriteStartElement("xmi", "Extension", this.xmiWriterSettings.XmiNamespaceUri);
+
+            if (!string.IsNullOrEmpty(extension.Id))
+            {
+                xmlWriter.WriteAttributeString("xmi", "id", this.xmiWriterSettings.XmiNamespaceUri, extension.Id);
+            }
+
+            if (!string.IsNullOrEmpty(extension.Uuid))
+            {
+                xmlWriter.WriteAttributeString("xmi", "uuid", this.xmiWriterSettings.XmiNamespaceUri, extension.Uuid);
+            }
+
+            if (!string.IsNullOrEmpty(extension.Extender))
+            {
+                xmlWriter.WriteAttributeString("extender", extension.Extender);
+            }
+
+            if (!string.IsNullOrEmpty(extension.ExtenderId))
+            {
+                xmlWriter.WriteAttributeString("extenderID", extension.ExtenderId);
+            }
+
+            if (!string.IsNullOrEmpty(extension.ContentRawXmi))
+            {
+                // the content is already serialized markup, it is therefore written as raw XML and
+                // not as (escaped) text. As a consequence the content is not indented along with the
+                // rest of the document.
+                xmlWriter.WriteRaw(extension.ContentRawXmi);
+            }
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="XmiExtension"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="extension">
+        /// The <see cref="XmiExtension"/> that is to be written
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task WriteAsync(XmlWriter xmlWriter, XmiExtension extension)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (extension == null)
+            {
+                throw new ArgumentNullException(nameof(extension));
+            }
+
+            this.logger.LogTrace("writing the XmiExtension of {Extender}:{ExtenderID}", extension.Extender, extension.ExtenderId);
+
+            await xmlWriter.WriteStartElementAsync("xmi", "Extension", this.xmiWriterSettings.XmiNamespaceUri);
+
+            if (!string.IsNullOrEmpty(extension.Id))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "id", this.xmiWriterSettings.XmiNamespaceUri, extension.Id);
+            }
+
+            if (!string.IsNullOrEmpty(extension.Uuid))
+            {
+                await xmlWriter.WriteAttributeStringAsync("xmi", "uuid", this.xmiWriterSettings.XmiNamespaceUri, extension.Uuid);
+            }
+
+            if (!string.IsNullOrEmpty(extension.Extender))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "extender", null, extension.Extender);
+            }
+
+            if (!string.IsNullOrEmpty(extension.ExtenderId))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "extenderID", null, extension.ExtenderId);
+            }
+
+            if (!string.IsNullOrEmpty(extension.ContentRawXmi))
+            {
+                // the content is already serialized markup, it is therefore written as raw XML and
+                // not as (escaped) text. As a consequence the content is not indented along with the
+                // rest of the document.
+                await xmlWriter.WriteRawAsync(extension.ContentRawXmi);
+            }
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}

--- a/uml4net.xmi/Writers/XmiWriter.cs
+++ b/uml4net.xmi/Writers/XmiWriter.cs
@@ -21,6 +21,7 @@
 namespace uml4net.xmi.Writers
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
@@ -111,6 +112,24 @@ namespace uml4net.xmi.Writers
         /// </param>
         public void Write(IPackage package, string fileUri)
         {
+            this.Write(package, fileUri, null);
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/> and <see cref="XmiExtension"/>s to a UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        public void Write(IPackage package, string fileUri, IEnumerable<XmiExtension> documentExtensions)
+        {
             if (string.IsNullOrEmpty(fileUri))
             {
                 throw new ArgumentException(nameof(fileUri));
@@ -122,7 +141,7 @@ namespace uml4net.xmi.Writers
 
             this.logger.LogInformation("start serializing to {Path}", fileUri);
 
-            this.Write(package, fileStream, new FileInfo(fileUri).Name);
+            this.Write(package, fileStream, new FileInfo(fileUri).Name, documentExtensions);
 
             this.logger.LogInformation("File {Path} serialized in {Time} [ms]", fileUri, sw.ElapsedMilliseconds);
         }
@@ -140,6 +159,27 @@ namespace uml4net.xmi.Writers
         /// The name of the document that is being written.
         /// </param>
         public void Write(IPackage package, Stream stream, string documentName)
+        {
+            this.Write(package, stream, documentName, null);
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/> and <see cref="XmiExtension"/>s to a UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        public void Write(IPackage package, Stream stream, string documentName, IEnumerable<XmiExtension> documentExtensions)
         {
             if (package == null)
             {
@@ -169,6 +209,16 @@ namespace uml4net.xmi.Writers
                 this.XmiElementWriterFacade.Write(xmlWriter, rootPackage, $"uml:{rootPackage.GetType().Name}", writeContext);
             }
 
+            if (documentExtensions != null)
+            {
+                var xmiExtensionWriter = new XmiExtensionWriter(this.XmiWriterSettings, this.LoggerFactory);
+
+                foreach (var documentExtension in documentExtensions)
+                {
+                    xmiExtensionWriter.Write(xmlWriter, documentExtension);
+                }
+            }
+
             xmlWriter.WriteEndElement();
             xmlWriter.WriteEndDocument();
             xmlWriter.Flush();
@@ -189,7 +239,32 @@ namespace uml4net.xmi.Writers
         /// <returns>
         /// an awaitable <see cref="Task"/>
         /// </returns>
-        public async Task WriteAsync(IPackage package, string fileUri, CancellationToken cancellationToken = default)
+        public Task WriteAsync(IPackage package, string fileUri, CancellationToken cancellationToken = default)
+        {
+            return this.WriteAsync(package, fileUri, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/> and <see cref="XmiExtension"/>s to a
+        /// UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task WriteAsync(IPackage package, string fileUri, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(fileUri))
             {
@@ -202,7 +277,7 @@ namespace uml4net.xmi.Writers
 
             this.logger.LogInformation("start serializing to {Path}", fileUri);
 
-            await this.WriteAsync(package, fileStream, new FileInfo(fileUri).Name, cancellationToken);
+            await this.WriteAsync(package, fileStream, new FileInfo(fileUri).Name, documentExtensions, cancellationToken);
 
             this.logger.LogInformation("File {Path} serialized in {Time} [ms]", fileUri, sw.ElapsedMilliseconds);
         }
@@ -225,7 +300,35 @@ namespace uml4net.xmi.Writers
         /// <returns>
         /// an awaitable <see cref="Task"/>
         /// </returns>
-        public async Task WriteAsync(IPackage package, Stream stream, string documentName, CancellationToken cancellationToken = default)
+        public Task WriteAsync(IPackage package, Stream stream, string documentName, CancellationToken cancellationToken = default)
+        {
+            return this.WriteAsync(package, stream, documentName, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/> and <see cref="XmiExtension"/>s to a
+        /// UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task WriteAsync(IPackage package, Stream stream, string documentName, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default)
         {
             if (package == null)
             {
@@ -255,6 +358,18 @@ namespace uml4net.xmi.Writers
                 cancellationToken.ThrowIfCancellationRequested();
 
                 await this.XmiElementWriterFacade.WriteAsync(xmlWriter, rootPackage, $"uml:{rootPackage.GetType().Name}", writeContext);
+            }
+
+            if (documentExtensions != null)
+            {
+                var xmiExtensionWriter = new XmiExtensionWriter(this.XmiWriterSettings, this.LoggerFactory);
+
+                foreach (var documentExtension in documentExtensions)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    await xmiExtensionWriter.WriteAsync(xmlWriter, documentExtension);
+                }
             }
 
             await xmlWriter.WriteEndElementAsync();


### PR DESCRIPTION
Fixes #200

## Approach

The `XmiWriter` dropped every `xmi:Extension` (with a log warning) at both the element and the
document level. Extension content is tool-vendor specific and therefore not represented by the UML
2.5.1 metamodel, so it is now written **verbatim** from the `XmiExtension.ContentRawXmi` captured
while reading, rather than via a structured generated writer per vendor type. That keeps the change
small and makes an Enterprise Architect model survive a read-write cycle.

Depends on #201 (merged), which made `ContentRawXmi` hold the *complete* extension content.

## Changes

- **`XmiExtensionWriter`** (new) — counterpart of `XmiExtensionReader`, writes one `XmiExtension`.
  `xmi:id`/`xmi:uuid` namespaced, `extender`/`extenderID` plain, exactly mirroring how they are read.
  No `xmi:type` is emitted: it is never populated on read and is absent from real EA exports.
- **`XmiElementWriter.WriteExtensions`/`WriteExtensionsAsync`** — called from
  `xmi-writer-template.hbs` so all ~194 generated writers emit their element's `Extensions` as the
  last child. `AutoGenXmiWriters` regenerated via the `[Explicit]` regeneration test; the 16
  `Expected/AutoGenXmiWriters` golden files updated.
- **`IXmiWriter`/`XmiWriter`** — four additive overloads taking the document-level extensions (the
  `XmiRoot.Extensions`), written as a sibling of the model content. The four pre-existing overloads
  delegate to them and are behaviour preserving.

### Two blocking defects fixed

Writing an EA model failed outright before this, for reasons unrelated to extensions:

1. **Root package without an `XmiId`.** EA exports `<uml:Model xmi:type="uml:Model" name="EA_Model">`
   with no `xmi:id`, which made `CreateWriteContext` throw. A root package is written as a top-level
   element and is never referred to by `xmi:idref`/`href`, so a missing id there is harmless: it is
   no longer reported, and the `xmi:id` attribute is now omitted rather than written empty (guarded
   exactly as `xmi:uuid` already was). **For a contained element a missing `XmiId` remains an
   error** — such an element silently degrades into a dangling `href="doc#"` and loses its whole
   subtree. `Verify_that_Write_throws_when_an_element_has_no_XmiId` was retargeted accordingly to a
   contained element, which is where the real hazard is.
2. **Id-less synthesised `Comment`s.** The EA extender's `PostProcess` created 15 `Comment`s from
   extension documentation with no `XmiId` and no `DocumentName`, making the model unwritable and
   causing `XmiElementCache` collisions on the key `doc#` on re-read. They now get both, derived
   from their owner, and applying documentation is **idempotent** — otherwise re-reading a written
   document would duplicate every comment on each cycle.

## Verification

Beyond the test suite, I compared the **written file against the original `EAExport.xmi`** directly,
so the result does not rely on `ContentRawXmi` alone (which is canonicalised by the reader on both
sides and could mask a shared-mode fault):

| Check | Result |
|---|---|
| Extension descendant elements | 1327 / 1327 |
| Extension **non-namespace** attributes | 4128 / 4128 |
| Extension `xmlns` declarations | 8 → 25 — `XmlWriter` redeclares inherited namespaces; no data loss |
| `xmi:id`s in model | 41 / 41, none added, none missing |
| Empty `xmi:id` attributes written | 0 |
| Dangling `href` ending in `#` | 0 |
| `uml:Model` has `xmi:id` | false in both — faithfully preserved |
| `ContentRawXmi` after read→write→read | **byte-identical** |
| Containment tree (`LocalIdentifiers` SetEquals) | equivalent |

`<type>` children go 16 → 4, which is **lossless**: 12 `<type xmi:idref="…"/>` stubs become
`type="…"` attributes (verified count: 12) and the 4 external primitive-type `href`s stay as
children. Both forms are valid XMI, which is why the re-read succeeds.

### Known pre-existing gap (not introduced here, not fixed here)

The 4 `<appliedProfile xmi:type="uml:Profile" href="http://www.sparxsystems.com/…"/>` elements are
**not** written back: `ProfileApplication.AppliedProfile` is already `null` in memory after reading,
because the reader does not resolve those external profile hrefs. The writer correctly writes
nothing for a null reference. This is a read-side limitation independent of #200 and does not affect
extension content, owned model content, or identifiers. Happy to file it separately.

## Tests

Full suite: **451 passed, 0 failed** across all 8 projects (was 444).

New: `XmiExtensionRoundTripTestFixture` (3 tests, plain `uml4net.xmi` path — no extender registered)
and `EnterpriseArchitectExtensionRoundTripTestFixture` (3 tests, EA extender registered, asserting
raw content, structured `Element`/`Connector` content, and document shape). Plus
`Verify_that_a_root_package_without_an_XmiId_is_written_without_an_xmi_id_attribute` and the
retargeted contained-element variant.
