### PR TITLE
[Fix] preserve unresolved external references as raw XMI; fixes #204

### DIFF
--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ActivityWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ActivityWriter.cs
@@ -403,6 +403,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -733,6 +735,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/AssociationWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/AssociationWriter.cs
@@ -293,6 +293,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -513,6 +515,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ClassWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ClassWriter.cs
@@ -323,6 +323,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -573,6 +575,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ConnectorWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ConnectorWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationConstraintWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationConstraintWriter.cs
@@ -203,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -333,6 +335,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationObservationWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/DurationObservationWriter.cs
@@ -188,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -303,6 +305,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExceptionHandlerWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExceptionHandlerWriter.cs
@@ -178,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -283,6 +285,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ProtectedNode, "protectedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExpressionWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/ExpressionWriter.cs
@@ -198,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -323,6 +325,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/GeneralizationWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/GeneralizationWriter.cs
@@ -173,6 +173,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -273,6 +275,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specific, "specific", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralIntegerWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralIntegerWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralRealWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralRealWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/OpaqueExpressionWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/OpaqueExpressionWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/PropertyWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/PropertyWriter.cs
@@ -328,6 +328,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -583,6 +585,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/StateMachineWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/StateMachineWriter.cs
@@ -378,6 +378,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -683,6 +685,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/TimeConstraintWriter.cs
+++ b/uml4net.CodeGenerator.Tests/Expected/AutoGenXmiWriters/TimeConstraintWriter.cs
@@ -203,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -333,6 +335,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.CodeGenerator/Templates/xmi-writer-template.hbs
+++ b/uml4net.CodeGenerator/Templates/xmi-writer-template.hbs
@@ -144,6 +144,8 @@ namespace uml4net.xmi.Writers
             {{ #Property.WriteXmlElementForXmiWriter property ../ }}
             {{/each}}
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -215,6 +217,8 @@ namespace uml4net.xmi.Writers
             {{ #each (Class.QueryAllNonDerivedNonReadOnlyProperties this) as | property | }}
             {{ #Property.WriteXmlElementForXmiWriter property ../ true }}
             {{/each}}
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.Extensions.Tests/TypeExtensionsTestFixture.cs
+++ b/uml4net.Extensions.Tests/TypeExtensionsTestFixture.cs
@@ -74,6 +74,7 @@ namespace uml4net.Extensions.Tests
             public string FullyQualifiedIdentifier { get; }
             public Dictionary<string, string> SingleValueReferencePropertyIdentifiers { get; set; }
             public Dictionary<string, List<string>> MultiValueReferencePropertyIdentifiers { get; set; }
+            public List<XmiUnresolvedReference> UnresolvedReferences { get; set; }
             public IXmiElementCache Cache { get; set; }
             public List<XmiExtension> Extensions { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
             //public List<IElement> Extensions { get; set; }

--- a/uml4net.Tests/AssemblerTestFixture.cs
+++ b/uml4net.Tests/AssemblerTestFixture.cs
@@ -29,6 +29,7 @@ namespace uml4net.Tests
     
     using uml4net.Classification;
     using uml4net.CommonStructure;
+    using uml4net.Packages;
     using uml4net.SimpleClassifiers;
     using uml4net.StructuredClassifiers;
     using uml4net.Values;
@@ -471,6 +472,120 @@ namespace uml4net.Tests
             this.assembler.Synchronize();
 
             Assert.That(property.Type, Is.EqualTo(enumeration));
+        }
+
+        [Test]
+        public void Synchronize_ShouldRemoveThePreservedReferenceElement_WhenTheSingleValueReferenceIsResolved()
+        {
+            var property = new Property
+            {
+                XmiId = "Property-1",
+                Name = "property",
+                DocumentName = this.documentName
+            };
+
+            var primitiveType = new PrimitiveType
+            {
+                XmiId = "Boolean",
+                Name = "Boolean",
+                DocumentName = "PrimitiveTypes.xmi"
+            };
+
+            property.SingleValueReferencePropertyIdentifiers.Add("type", "PrimitiveTypes.xmi#Boolean");
+            property.UnresolvedReferences.Add(new XmiUnresolvedReference
+            {
+                PropertyName = "type",
+                Identifier = "PrimitiveTypes.xmi#Boolean",
+                ContentRawXmi = "<type href=\"PrimitiveTypes.xmi#Boolean\" />"
+            });
+
+            Assert.That(this.cache.TryAdd(property), Is.True);
+            Assert.That(this.cache.TryAdd(primitiveType), Is.True);
+
+            this.assembler.Synchronize();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(property.Type, Is.SameAs(primitiveType));
+                Assert.That(property.UnresolvedReferences, Is.Empty,
+                    "a resolved reference is written from the reference property and must not be written a second time from its preserved XMI");
+            }
+        }
+
+        [Test]
+        public void Synchronize_ShouldKeepThePreservedReferenceElement_WhenTheSingleValueReferenceIsNotResolved()
+        {
+            var profileApplication = new ProfileApplication
+            {
+                XmiId = "profileap_8C9E6706-8",
+                DocumentName = this.documentName
+            };
+
+            const string href = "http://www.sparxsystems.com/profiles/EAUML/1.0#8C9E6706-8";
+
+            profileApplication.SingleValueReferencePropertyIdentifiers.Add("appliedProfile", href);
+            profileApplication.UnresolvedReferences.Add(new XmiUnresolvedReference
+            {
+                PropertyName = "appliedProfile",
+                Identifier = href,
+                ContentRawXmi = $"<appliedProfile href=\"{href}\" />"
+            });
+
+            Assert.That(this.cache.TryAdd(profileApplication), Is.True);
+
+            this.assembler.Synchronize();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(profileApplication.AppliedProfile, Is.Null);
+                Assert.That(profileApplication.UnresolvedReferences.Single().Identifier, Is.EqualTo(href),
+                    "a reference that cannot be resolved is preserved so that it is written back verbatim");
+            }
+        }
+
+        [Test]
+        public void Synchronize_ShouldRemoveOnlyThePreservedReferenceElementsThatAreResolved_ForAMultiValueReference()
+        {
+            var classElement = new Class
+            {
+                XmiId = "Class-1",
+                Name = "TestClass",
+                DocumentName = this.documentName
+            };
+
+            var comment = new Comment
+            {
+                XmiId = "Comment-1",
+                Body = "Comment 1",
+                DocumentName = "other.xmi"
+            };
+
+            classElement.MultiValueReferencePropertyIdentifiers.Add("OwnedComment", ["other.xmi#Comment-1", "missing.xmi#Comment-2"]);
+
+            classElement.UnresolvedReferences.Add(new XmiUnresolvedReference
+            {
+                PropertyName = "OwnedComment",
+                Identifier = "other.xmi#Comment-1",
+                ContentRawXmi = "<ownedComment href=\"other.xmi#Comment-1\" />"
+            });
+
+            classElement.UnresolvedReferences.Add(new XmiUnresolvedReference
+            {
+                PropertyName = "OwnedComment",
+                Identifier = "missing.xmi#Comment-2",
+                ContentRawXmi = "<ownedComment href=\"missing.xmi#Comment-2\" />"
+            });
+
+            Assert.That(this.cache.TryAdd(classElement), Is.True);
+            Assert.That(this.cache.TryAdd(comment), Is.True);
+
+            this.assembler.Synchronize();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(classElement.OwnedComment, Has.Count.EqualTo(1));
+                Assert.That(classElement.UnresolvedReferences.Single().Identifier, Is.EqualTo("missing.xmi#Comment-2"));
+            }
         }
     }
 }

--- a/uml4net.xmi.Tests/Readers/XmiElementReaderTestFixture.cs
+++ b/uml4net.xmi.Tests/Readers/XmiElementReaderTestFixture.cs
@@ -20,6 +20,7 @@
 
 namespace uml4net.xmi.Tests.Readers
 {
+    using System.Linq;
     using System.Xml;
 
     using Microsoft.Extensions.Logging.Abstractions;
@@ -72,6 +73,87 @@ namespace uml4net.xmi.Tests.Readers
             {
                 Assert.That(result, Is.True);
                 Assert.That(element.MultiValueReferencePropertyIdentifiers["ref"], Has.Member("id1"));
+            }
+        }
+
+        [Test]
+        public void CollectSingleValueReferencePropertyIdentifier_PreservesTheReferenceElementOfAnHref()
+        {
+            var reader = new TestReader();
+            var element = new LiteralBoolean();
+            using var xr = XmlReader.Create(new System.IO.StringReader("<appliedProfile xmlns:xmi='http://www.omg.org/spec/XMI/20131001' xmi:type='uml:Profile' href='http://www.sparxsystems.com/profiles/EAUML/1.0#8C9E6706-8'/>"), new XmlReaderSettings());
+            xr.MoveToContent();
+            reader.InvokeCollect(xr, element, "appliedProfile");
+
+            var unresolvedReference = element.UnresolvedReferences.Single();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(unresolvedReference.PropertyName, Is.EqualTo("appliedProfile"));
+                Assert.That(unresolvedReference.Identifier, Is.EqualTo("http://www.sparxsystems.com/profiles/EAUML/1.0#8C9E6706-8"));
+                Assert.That(unresolvedReference.ContentRawXmi, Does.Contain("appliedProfile"));
+                Assert.That(unresolvedReference.ContentRawXmi, Does.Contain("href=\"http://www.sparxsystems.com/profiles/EAUML/1.0#8C9E6706-8\""));
+                Assert.That(unresolvedReference.ContentRawXmi, Does.Contain("uml:Profile"),
+                    "the xmi:type of the reference element is expected to be preserved as part of the raw XMI");
+            }
+        }
+
+        [Test]
+        public void CollectSingleValueReferencePropertyIdentifier_DoesNotPreserveTheReferenceElementOfAnIdRef()
+        {
+            var reader = new TestReader();
+            var element = new LiteralBoolean();
+            using var xr = XmlReader.Create(new System.IO.StringReader("<type xmlns:xmi='http://www.omg.org/spec/XMI/20131001' xmi:idref='refId'/>"), new XmlReaderSettings());
+            xr.MoveToContent();
+            reader.InvokeCollect(xr, element, "type");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(element.SingleValueReferencePropertyIdentifiers["type"], Is.EqualTo("refId"));
+                Assert.That(element.UnresolvedReferences, Is.Empty,
+                    "an xmi:idref is a reference within the same document and does not depend on a document that may be unavailable");
+            }
+        }
+
+        [Test]
+        public void TryCollectMultiValueReferencePropertyIdentifiers_PreservesTheReferenceElementOfEachHref()
+        {
+            var reader = new TestReader();
+            var element = new LiteralBoolean();
+
+            using (var xr = XmlReader.Create(new System.IO.StringReader("<ref href='other.xmi#id1'/>"), new XmlReaderSettings()))
+            {
+                xr.MoveToContent();
+                reader.InvokeTryCollect(xr, element, "ref");
+            }
+
+            using (var xr = XmlReader.Create(new System.IO.StringReader("<ref href='other.xmi#id2'/>"), new XmlReaderSettings()))
+            {
+                xr.MoveToContent();
+                reader.InvokeTryCollect(xr, element, "ref");
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(element.UnresolvedReferences.Select(x => x.Identifier),
+                    Is.EqualTo(new[] { "other.xmi#id1", "other.xmi#id2" }));
+                Assert.That(element.UnresolvedReferences.Select(x => x.PropertyName), Is.All.EqualTo("ref"));
+            }
+        }
+
+        [Test]
+        public void TryCollectMultiValueReferencePropertyIdentifiers_DoesNotPreserveTheReferenceElementOfAnIdRef()
+        {
+            var reader = new TestReader();
+            var element = new LiteralBoolean();
+            using var xr = XmlReader.Create(new System.IO.StringReader("<ref xmlns:xmi='http://www.omg.org/spec/XMI/20131001' xmi:idref='id1'/>"), new XmlReaderSettings());
+            xr.MoveToContent();
+            var result = reader.InvokeTryCollect(xr, element, "ref");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.True);
+                Assert.That(element.UnresolvedReferences, Is.Empty);
             }
         }
     }

--- a/uml4net.xmi.Tests/Writers/UnresolvedExternalReferenceRoundTripTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/UnresolvedExternalReferenceRoundTripTestFixture.cs
@@ -1,0 +1,221 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="UnresolvedExternalReferenceRoundTripTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Tests.Writers
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Xml.Linq;
+
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using NUnit.Framework;
+
+    using uml4net.Packages;
+    using uml4net.xmi.Readers;
+    using uml4net.xmi.Writers;
+
+    /// <summary>
+    /// Verifies that a reference to a document that cannot be resolved - the <c>appliedProfile</c> of an
+    /// Enterprise Architect document references profiles by a <c>http://www.sparxsystems.com/profiles/…</c>
+    /// URL that is an identifier rather than a location - is preserved in its original XMI form and is
+    /// written back verbatim rather than being silently lost.
+    /// </summary>
+    /// <remarks>
+    /// This is the regression fixture of https://github.com/STARIONGROUP/uml4net/issues/204
+    /// </remarks>
+    [TestFixture]
+    public class UnresolvedExternalReferenceRoundTripTestFixture
+    {
+        private string rootPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.rootPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData");
+        }
+
+        [Test]
+        public void Verify_that_an_unresolvable_appliedProfile_is_preserved_in_its_original_xmi_form()
+        {
+            var model = this.ReadEnterpriseArchitectModel();
+
+            var unresolvedReferences = model.ProfileApplication
+                .SelectMany(x => x.UnresolvedReferences)
+                .ToList();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(model.ProfileApplication, Has.Count.EqualTo(4));
+
+                Assert.That(model.ProfileApplication.Select(x => x.UnresolvedReferences.Count),
+                    Is.All.EqualTo(1),
+                    "each profileApplication declares exactly one appliedProfile that cannot be resolved");
+
+                Assert.That(unresolvedReferences.Select(x => x.PropertyName), Is.All.EqualTo("appliedProfile"));
+
+                Assert.That(unresolvedReferences.Select(x => x.Identifier),
+                    Is.EqualTo(QueryAppliedProfileHrefs(this.LoadSourceDocument())));
+
+                Assert.That(unresolvedReferences.Select(x => x.ContentRawXmi),
+                    Is.All.Contains("appliedProfile"));
+            }
+        }
+
+        [Test]
+        public void Verify_that_an_unresolvable_appliedProfile_survives_a_write()
+        {
+            var model = this.ReadEnterpriseArchitectModel();
+
+            var writtenDocument = XDocument.Load(new MemoryStream(Write(model)));
+            var sourceDocument = this.LoadSourceDocument();
+
+            var writtenElements = QueryAppliedProfileElements(writtenDocument);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(QueryAppliedProfileHrefs(writtenDocument), Is.EqualTo(QueryAppliedProfileHrefs(sourceDocument)),
+                    "the appliedProfile references of the source document were expected to be written back unchanged");
+
+                Assert.That(writtenElements.Select(x => x.Attribute(XmiNamespace + "type")?.Value),
+                    Is.All.EqualTo("uml:Profile"),
+                    "the xmi:type of the reference element was expected to be preserved as well");
+
+                Assert.That(writtenElements, Has.Count.EqualTo(4));
+            }
+        }
+
+        [Test]
+        public void Verify_that_an_unresolvable_appliedProfile_survives_a_read_write_read_cycle()
+        {
+            var model = this.ReadEnterpriseArchitectModel();
+
+            using var stream = new MemoryStream(Write(model));
+
+            var rereadResult = this.CreateReader().Read(stream, "EAExport.xmi");
+            var rereadModel = rereadResult.QueryRoot(null, "EA_Model") as IPackage;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(rereadModel, Is.Not.Null);
+
+                Assert.That(rereadModel.ProfileApplication.SelectMany(x => x.UnresolvedReferences).Select(x => x.Identifier),
+                    Is.EqualTo(model.ProfileApplication.SelectMany(x => x.UnresolvedReferences).Select(x => x.Identifier)),
+                    "the preserved references were expected to be read back and to remain unresolvable");
+            }
+        }
+
+        [Test]
+        public async Task Verify_that_the_asynchronous_write_preserves_an_unresolvable_appliedProfile()
+        {
+            var model = this.ReadEnterpriseArchitectModel();
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            await writer.WriteAsync(model, stream, "EAExport.xmi");
+
+            stream.Position = 0;
+
+            Assert.That(QueryAppliedProfileHrefs(XDocument.Load(stream)),
+                Is.EqualTo(QueryAppliedProfileHrefs(this.LoadSourceDocument())));
+        }
+
+        /// <summary>
+        /// The XMI namespace of the documents that are read and written
+        /// </summary>
+        private static XNamespace XmiNamespace => XNamespace.Get("http://www.omg.org/spec/XMI/20131001");
+
+        /// <summary>
+        /// Loads the Enterprise Architect source document as an <see cref="XDocument"/>
+        /// </summary>
+        /// <remarks>
+        /// The document declares the <c>windows-1252</c> encoding, which is not registered by default on
+        /// .NET Core. The content is therefore decoded explicitly; loading from a <see cref="TextReader"/>
+        /// makes the encoding declaration irrelevant
+        /// </remarks>
+        private XDocument LoadSourceDocument()
+        {
+            using var streamReader = new StreamReader(Path.Combine(this.rootPath, "EAExport.xmi"), Encoding.Latin1);
+
+            return XDocument.Load(streamReader);
+        }
+
+        /// <summary>
+        /// Queries the <c>appliedProfile</c> elements of the provided <see cref="XDocument"/>, in document order
+        /// </summary>
+        private static List<XElement> QueryAppliedProfileElements(XDocument document)
+        {
+            return document.Descendants().Where(x => x.Name.LocalName == "appliedProfile").ToList();
+        }
+
+        /// <summary>
+        /// Queries the <c>href</c> of the <c>appliedProfile</c> elements of the provided <see cref="XDocument"/>,
+        /// in document order
+        /// </summary>
+        private static List<string> QueryAppliedProfileHrefs(XDocument document)
+        {
+            return QueryAppliedProfileElements(document).Select(x => x.Attribute("href")?.Value).ToList();
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/> and returns the written bytes
+        /// </summary>
+        private static byte[] Write(IPackage package)
+        {
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            writer.Write(package, stream, "EAExport.xmi");
+
+            return stream.ToArray();
+        }
+
+        /// <summary>
+        /// Reads the Enterprise Architect model and returns its root <see cref="IPackage"/>
+        /// </summary>
+        private IPackage ReadEnterpriseArchitectModel()
+        {
+            var xmiReaderResult = this.CreateReader().Read(Path.Combine(this.rootPath, "EAExport.xmi"));
+
+            return xmiReaderResult.QueryRoot(null, "EA_Model") as IPackage;
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IXmiReader"/> without any registered extender reader
+        /// </summary>
+        private IXmiReader CreateReader()
+        {
+            return XmiReaderBuilder.Create()
+                .UsingSettings(x => x.LocalReferenceBasePath = this.rootPath)
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+        }
+    }
+}

--- a/uml4net.xmi.Tests/Writers/XmiWriterTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/XmiWriterTestFixture.cs
@@ -167,6 +167,78 @@ namespace uml4net.xmi.Tests.Writers
         }
 
         [Test]
+        public void Verify_that_a_reference_that_could_not_be_resolved_is_written_in_its_original_xmi_form()
+        {
+            var @class = new Class { XmiId = "Class-1", Name = "class" };
+            @class.UnresolvedReferences.Add(new XmiUnresolvedReference
+            {
+                PropertyName = "type",
+                Identifier = "http://www.sparxsystems.com/profiles/EAUML/1.0#8C9E6706-8",
+                ContentRawXmi = "<type href=\"http://www.sparxsystems.com/profiles/EAUML/1.0#8C9E6706-8\" />"
+            });
+
+            this.package.PackagedElement.Add(@class);
+
+            using var stream = new MemoryStream();
+
+            this.xmiWriter.Write(this.package, stream, "output.xmi");
+
+            var xmlDocument = new XmlDocument();
+            stream.Position = 0;
+            xmlDocument.Load(stream);
+
+            var classElement = (XmlElement)xmlDocument.DocumentElement.FirstChild.FirstChild;
+            var referenceElement = (XmlElement)classElement.FirstChild;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(referenceElement, Is.Not.Null, "the preserved reference element was expected to be written");
+                Assert.That(referenceElement.Name, Is.EqualTo("type"));
+                Assert.That(referenceElement.GetAttribute("href"), Is.EqualTo("http://www.sparxsystems.com/profiles/EAUML/1.0#8C9E6706-8"));
+            }
+        }
+
+        [Test]
+        public void Verify_that_an_unresolved_reference_without_raw_xmi_is_not_written()
+        {
+            var @class = new Class { XmiId = "Class-1", Name = "class" };
+            @class.UnresolvedReferences.Add(new XmiUnresolvedReference { PropertyName = "type", Identifier = "other.xmi#Boolean" });
+
+            this.package.PackagedElement.Add(@class);
+
+            using var stream = new MemoryStream();
+
+            this.xmiWriter.Write(this.package, stream, "output.xmi");
+
+            var xmlDocument = new XmlDocument();
+            stream.Position = 0;
+            xmlDocument.Load(stream);
+
+            var classElement = (XmlElement)xmlDocument.DocumentElement.FirstChild.FirstChild;
+
+            Assert.That(classElement.HasChildNodes, Is.False);
+        }
+
+        [Test]
+        public void Verify_that_nothing_is_written_when_there_are_no_unresolved_references()
+        {
+            var @class = new Class { XmiId = "Class-1", Name = "class" };
+            this.package.PackagedElement.Add(@class);
+
+            using var stream = new MemoryStream();
+
+            this.xmiWriter.Write(this.package, stream, "output.xmi");
+
+            var xmlDocument = new XmlDocument();
+            stream.Position = 0;
+            xmlDocument.Load(stream);
+
+            var classElement = (XmlElement)xmlDocument.DocumentElement.FirstChild.FirstChild;
+
+            Assert.That(classElement.HasChildNodes, Is.False);
+        }
+
+        [Test]
         public void Verify_that_a_model_is_written_with_a_uml_Model_root_element()
         {
             var model = new Model { XmiId = "Model-1", Name = "model" };

--- a/uml4net.xmi/AutoGenXmiWriters/AbstractionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AbstractionWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/AcceptCallActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AcceptCallActionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/AcceptEventActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AcceptEventActionWriter.cs
@@ -243,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -413,6 +415,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ActionExecutionSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActionExecutionSpecificationWriter.cs
@@ -218,6 +218,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -363,6 +365,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Start, "start", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ActionInputPinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActionInputPinWriter.cs
@@ -278,6 +278,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -483,6 +485,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityFinalNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityFinalNodeWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityParameterNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityParameterNodeWriter.cs
@@ -258,6 +258,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -443,6 +445,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityPartitionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityPartitionWriter.cs
@@ -213,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -353,6 +355,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.SuperPartition, "superPartition", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ActivityWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActivityWriter.cs
@@ -403,6 +403,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -733,6 +735,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ActorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ActorWriter.cs
@@ -293,6 +293,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -513,6 +515,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/AddStructuralFeatureValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AddStructuralFeatureValueActionWriter.cs
@@ -263,6 +263,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -453,6 +455,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/AddVariableValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AddVariableValueActionWriter.cs
@@ -253,6 +253,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -433,6 +435,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/AnyReceiveEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AnyReceiveEventWriter.cs
@@ -178,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -283,6 +285,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ArtifactWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ArtifactWriter.cs
@@ -298,6 +298,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -523,6 +525,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/AssociationClassWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AssociationClassWriter.cs
@@ -343,6 +343,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -613,6 +615,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/AssociationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/AssociationWriter.cs
@@ -293,6 +293,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -513,6 +515,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/BehaviorExecutionSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/BehaviorExecutionSpecificationWriter.cs
@@ -218,6 +218,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -363,6 +365,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Start, "start", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/BroadcastSignalActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/BroadcastSignalActionWriter.cs
@@ -253,6 +253,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -433,6 +435,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signal, "signal", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CallBehaviorActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CallBehaviorActionWriter.cs
@@ -263,6 +263,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -453,6 +455,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CallEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CallEventWriter.cs
@@ -188,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -303,6 +305,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CallOperationActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CallOperationActionWriter.cs
@@ -268,6 +268,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -463,6 +465,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CentralBufferNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CentralBufferNodeWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ChangeEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ChangeEventWriter.cs
@@ -183,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -293,6 +295,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ClassWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClassWriter.cs
@@ -323,6 +323,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -573,6 +575,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ClassifierTemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClassifierTemplateParameterWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ClauseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClauseWriter.cs
@@ -178,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -283,6 +285,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "test", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ClearAssociationActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClearAssociationActionWriter.cs
@@ -243,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -413,6 +415,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ClearStructuralFeatureActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClearStructuralFeatureActionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ClearVariableActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ClearVariableActionWriter.cs
@@ -238,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -403,6 +405,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CollaborationUseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CollaborationUseWriter.cs
@@ -173,6 +173,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -273,6 +275,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CollaborationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CollaborationWriter.cs
@@ -308,6 +308,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -543,6 +545,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CombinedFragmentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CombinedFragmentWriter.cs
@@ -203,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -333,6 +335,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CommentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CommentWriter.cs
@@ -153,6 +153,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -233,6 +235,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CommunicationPathWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CommunicationPathWriter.cs
@@ -293,6 +293,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -513,6 +515,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ComponentRealizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ComponentRealizationWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ComponentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ComponentWriter.cs
@@ -338,6 +338,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -603,6 +605,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ConditionalNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConditionalNodeWriter.cs
@@ -288,6 +288,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -503,6 +505,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectableElementTemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectableElementTemplateParameterWriter.cs
@@ -183,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -293,6 +295,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectionPointReferenceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectionPointReferenceWriter.cs
@@ -203,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -333,6 +335,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.State, "state", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectorEndWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectorEndWriter.cs
@@ -183,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -293,6 +295,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ConnectorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConnectorWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ConsiderIgnoreFragmentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConsiderIgnoreFragmentWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ConstraintWriter.cs
@@ -198,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -323,6 +325,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ContinuationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ContinuationWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ControlFlowWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ControlFlowWriter.cs
@@ -233,6 +233,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -393,6 +395,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "weight", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CreateLinkActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CreateLinkActionWriter.cs
@@ -238,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -403,6 +405,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CreateLinkObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CreateLinkObjectActionWriter.cs
@@ -243,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -413,6 +415,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/CreateObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/CreateObjectActionWriter.cs
@@ -243,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -413,6 +415,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DataStoreNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DataStoreNodeWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DataTypeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DataTypeWriter.cs
@@ -283,6 +283,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -493,6 +495,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DecisionNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DecisionNodeWriter.cs
@@ -228,6 +228,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -383,6 +385,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DependencyWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DependencyWriter.cs
@@ -188,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -303,6 +305,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DeploymentSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DeploymentSpecificationWriter.cs
@@ -318,6 +318,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -563,6 +565,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DeploymentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DeploymentWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DestroyLinkActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DestroyLinkActionWriter.cs
@@ -238,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -403,6 +405,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DestroyObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DestroyObjectActionWriter.cs
@@ -243,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -413,6 +415,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DestructionOccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DestructionOccurrenceSpecificationWriter.cs
@@ -213,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -353,6 +355,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DeviceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DeviceWriter.cs
@@ -333,6 +333,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -593,6 +595,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DurationConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationConstraintWriter.cs
@@ -203,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -333,6 +335,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DurationIntervalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationIntervalWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DurationObservationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationObservationWriter.cs
@@ -188,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -303,6 +305,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/DurationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/DurationWriter.cs
@@ -198,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -323,6 +325,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ElementImportWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ElementImportWriter.cs
@@ -173,6 +173,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -273,6 +275,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/EnumerationLiteralWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/EnumerationLiteralWriter.cs
@@ -203,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -333,6 +335,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/EnumerationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/EnumerationWriter.cs
@@ -288,6 +288,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -503,6 +505,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ExceptionHandlerWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExceptionHandlerWriter.cs
@@ -178,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -283,6 +285,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ProtectedNode, "protectedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ExecutionEnvironmentWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExecutionEnvironmentWriter.cs
@@ -333,6 +333,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -593,6 +595,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ExecutionOccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExecutionOccurrenceSpecificationWriter.cs
@@ -213,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -353,6 +355,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ExpansionNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExpansionNodeWriter.cs
@@ -268,6 +268,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -463,6 +465,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperBound", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ExpansionRegionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExpansionRegionWriter.cs
@@ -288,6 +288,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -503,6 +505,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExpressionWriter.cs
@@ -198,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -323,6 +325,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ExtendWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtendWriter.cs
@@ -188,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -303,6 +305,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ExtensionEndWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtensionEndWriter.cs
@@ -328,6 +328,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -583,6 +585,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ExtensionPointWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtensionPointWriter.cs
@@ -173,6 +173,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -273,6 +275,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.UseCase, "useCase", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ExtensionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ExtensionWriter.cs
@@ -293,6 +293,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -513,6 +515,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/FinalStateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/FinalStateWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Submachine, "submachine", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/FlowFinalNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/FlowFinalNodeWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ForkNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ForkNodeWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/FunctionBehaviorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/FunctionBehaviorWriter.cs
@@ -373,6 +373,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -673,6 +675,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/GateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GateWriter.cs
@@ -168,6 +168,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -263,6 +265,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/GeneralOrderingWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GeneralOrderingWriter.cs
@@ -178,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -283,6 +285,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/GeneralizationSetWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GeneralizationSetWriter.cs
@@ -203,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -333,6 +335,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/GeneralizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/GeneralizationWriter.cs
@@ -173,6 +173,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -273,6 +275,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Specific, "specific", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ImageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ImageWriter.cs
@@ -158,6 +158,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -243,6 +245,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/IncludeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/IncludeWriter.cs
@@ -178,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -283,6 +285,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InformationFlowWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InformationFlowWriter.cs
@@ -213,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -353,6 +355,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InformationItemWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InformationItemWriter.cs
@@ -278,6 +278,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -483,6 +485,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InitialNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InitialNodeWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InputPinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InputPinWriter.cs
@@ -273,6 +273,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -473,6 +475,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InstanceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InstanceSpecificationWriter.cs
@@ -198,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -323,6 +325,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InstanceValueWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InstanceValueWriter.cs
@@ -198,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -323,6 +325,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionConstraintWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionOperandWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionOperandWriter.cs
@@ -213,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -353,6 +355,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "packageImport", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionUseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionUseWriter.cs
@@ -223,6 +223,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -373,6 +375,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReturnValueRecipient, "returnValueRecipient", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InteractionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InteractionWriter.cs
@@ -418,6 +418,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -763,6 +765,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InterfaceRealizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InterfaceRealizationWriter.cs
@@ -213,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -353,6 +355,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InterfaceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InterfaceWriter.cs
@@ -303,6 +303,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -533,6 +535,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/InterruptibleActivityRegionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/InterruptibleActivityRegionWriter.cs
@@ -178,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -283,6 +285,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/IntervalConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/IntervalConstraintWriter.cs
@@ -198,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -323,6 +325,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/IntervalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/IntervalWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/JoinNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/JoinNodeWriter.cs
@@ -218,6 +218,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -363,6 +365,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LifelineWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LifelineWriter.cs
@@ -198,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -323,6 +325,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "selector", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LinkEndCreationDataWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LinkEndCreationDataWriter.cs
@@ -183,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -293,6 +295,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LinkEndDataWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LinkEndDataWriter.cs
@@ -168,6 +168,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -263,6 +265,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LinkEndDestructionDataWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LinkEndDestructionDataWriter.cs
@@ -183,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -293,6 +295,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralBooleanWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralBooleanWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralIntegerWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralIntegerWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralNullWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralNullWriter.cs
@@ -188,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -303,6 +305,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralRealWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralRealWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralStringWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralStringWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LiteralUnlimitedNaturalWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/LoopNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/LoopNodeWriter.cs
@@ -313,6 +313,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -553,6 +555,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ManifestationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ManifestationWriter.cs
@@ -203,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -333,6 +335,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.UtilizedElement, "utilizedElement", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/MergeNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/MergeNodeWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/MessageOccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/MessageOccurrenceSpecificationWriter.cs
@@ -213,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -353,6 +355,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/MessageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/MessageWriter.cs
@@ -218,6 +218,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -363,6 +365,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ModelWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ModelWriter.cs
@@ -238,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -403,6 +405,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/NodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/NodeWriter.cs
@@ -333,6 +333,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -593,6 +595,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ObjectFlowWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ObjectFlowWriter.cs
@@ -263,6 +263,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -453,6 +455,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "weight", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/OccurrenceSpecificationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OccurrenceSpecificationWriter.cs
@@ -203,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -333,6 +335,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "toBefore", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/OpaqueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OpaqueActionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/OpaqueBehaviorWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OpaqueBehaviorWriter.cs
@@ -373,6 +373,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -673,6 +675,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/OpaqueExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OpaqueExpressionWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/OperationTemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OperationTemplateParameterWriter.cs
@@ -183,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -293,6 +295,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/OperationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OperationWriter.cs
@@ -298,6 +298,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -523,6 +525,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/OutputPinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/OutputPinWriter.cs
@@ -273,6 +273,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -473,6 +475,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/PackageImportWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PackageImportWriter.cs
@@ -168,6 +168,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -263,6 +265,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/PackageMergeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PackageMergeWriter.cs
@@ -163,6 +163,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -253,6 +255,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReceivingPackage, "receivingPackage", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/PackageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PackageWriter.cs
@@ -233,6 +233,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -393,6 +395,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ParameterSetWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ParameterSetWriter.cs
@@ -168,6 +168,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -263,6 +265,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "parameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ParameterWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/PartDecompositionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PartDecompositionWriter.cs
@@ -223,6 +223,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -373,6 +375,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.ReturnValueRecipient, "returnValueRecipient", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/PortWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PortWriter.cs
@@ -358,6 +358,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -643,6 +645,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/PrimitiveTypeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PrimitiveTypeWriter.cs
@@ -283,6 +283,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -493,6 +495,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ProfileApplicationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProfileApplicationWriter.cs
@@ -168,6 +168,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -263,6 +265,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ProfileWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProfileWriter.cs
@@ -243,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -413,6 +415,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/PropertyWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PropertyWriter.cs
@@ -328,6 +328,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -583,6 +585,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ProtocolConformanceWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProtocolConformanceWriter.cs
@@ -163,6 +163,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -253,6 +255,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.SpecificMachine, "specificMachine", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ProtocolStateMachineWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProtocolStateMachineWriter.cs
@@ -383,6 +383,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -693,6 +695,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ProtocolTransitionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ProtocolTransitionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/PseudostateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/PseudostateWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StateMachine, "stateMachine", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/QualifierValueWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/QualifierValueWriter.cs
@@ -163,6 +163,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -253,6 +255,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Value, "value", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/RaiseExceptionActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RaiseExceptionActionWriter.cs
@@ -233,6 +233,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -393,6 +395,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReadExtentActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadExtentActionWriter.cs
@@ -243,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -413,6 +415,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReadIsClassifiedObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadIsClassifiedObjectActionWriter.cs
@@ -253,6 +253,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -433,6 +435,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReadLinkActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadLinkActionWriter.cs
@@ -243,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -413,6 +415,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndActionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndQualifierActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadLinkObjectEndQualifierActionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReadSelfActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadSelfActionWriter.cs
@@ -233,6 +233,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -393,6 +395,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReadStructuralFeatureActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadStructuralFeatureActionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.StructuralFeature, "structuralFeature", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReadVariableActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReadVariableActionWriter.cs
@@ -243,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -413,6 +415,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/RealizationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RealizationWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReceptionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReceptionWriter.cs
@@ -223,6 +223,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -373,6 +375,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signal, "signal", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReclassifyObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReclassifyObjectActionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/RedefinableTemplateSignatureWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RedefinableTemplateSignatureWriter.cs
@@ -188,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -303,6 +305,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "parameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReduceActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReduceActionWriter.cs
@@ -253,6 +253,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -433,6 +435,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/RegionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RegionWriter.cs
@@ -218,6 +218,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -363,6 +365,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "transition", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/RemoveStructuralFeatureValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RemoveStructuralFeatureValueActionWriter.cs
@@ -263,6 +263,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -453,6 +455,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/RemoveVariableValueActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/RemoveVariableValueActionWriter.cs
@@ -253,6 +253,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -433,6 +435,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Variable, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ReplyActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ReplyActionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "returnInformation", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/SendObjectActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SendObjectActionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/SendSignalActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SendSignalActionWriter.cs
@@ -258,6 +258,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -443,6 +445,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "target", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/SequenceNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SequenceNodeWriter.cs
@@ -273,6 +273,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -473,6 +475,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/SignalEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SignalEventWriter.cs
@@ -188,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -303,6 +305,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/SignalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SignalWriter.cs
@@ -278,6 +278,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -483,6 +485,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/SlotWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SlotWriter.cs
@@ -168,6 +168,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -263,6 +265,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/StartClassifierBehaviorActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StartClassifierBehaviorActionWriter.cs
@@ -233,6 +233,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -393,6 +395,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "redefinedNode", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/StartObjectBehaviorActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StartObjectBehaviorActionWriter.cs
@@ -258,6 +258,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -443,6 +445,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "result", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/StateInvariantWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StateInvariantWriter.cs
@@ -198,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -323,6 +325,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "ownedComment", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/StateMachineWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StateMachineWriter.cs
@@ -378,6 +378,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -683,6 +685,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/StateWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StateWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Submachine, "submachine", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/StereotypeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StereotypeWriter.cs
@@ -328,6 +328,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -583,6 +585,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/StringExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StringExpressionWriter.cs
@@ -223,6 +223,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -373,6 +375,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/StructuredActivityNodeWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/StructuredActivityNodeWriter.cs
@@ -273,6 +273,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -473,6 +475,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "variable", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/SubstitutionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/SubstitutionWriter.cs
@@ -213,6 +213,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -353,6 +355,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateBindingWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateBindingWriter.cs
@@ -168,6 +168,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -263,6 +265,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateParameterSubstitutionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateParameterSubstitutionWriter.cs
@@ -178,6 +178,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -283,6 +285,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateBinding, "templateBinding", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateParameterWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateParameterWriter.cs
@@ -183,6 +183,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -293,6 +295,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Signature, "signature", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TemplateSignatureWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TemplateSignatureWriter.cs
@@ -163,6 +163,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -253,6 +255,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Template, "template", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TestIdentityActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TestIdentityActionWriter.cs
@@ -243,6 +243,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -413,6 +415,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "second", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TimeConstraintWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeConstraintWriter.cs
@@ -203,6 +203,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -333,6 +335,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TimeEventWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeEventWriter.cs
@@ -188,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -303,6 +305,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "when", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TimeExpressionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeExpressionWriter.cs
@@ -198,6 +198,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -323,6 +325,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TimeIntervalWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeIntervalWriter.cs
@@ -208,6 +208,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -343,6 +345,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.Type, "type", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TimeObservationWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TimeObservationWriter.cs
@@ -193,6 +193,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -313,6 +315,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TransitionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TransitionWriter.cs
@@ -238,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -403,6 +405,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "trigger", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/TriggerWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/TriggerWriter.cs
@@ -173,6 +173,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -273,6 +275,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "port", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/UnmarshallActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/UnmarshallActionWriter.cs
@@ -248,6 +248,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -423,6 +425,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.UnmarshallType, "unmarshallType", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/UsageWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/UsageWriter.cs
@@ -188,6 +188,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -303,6 +305,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, element.TemplateParameter, "templateParameter", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/UseCaseWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/UseCaseWriter.cs
@@ -313,6 +313,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -553,6 +555,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteReferenceElementAsync(xmlWriter, value, "useCases", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ValuePinWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ValuePinWriter.cs
@@ -278,6 +278,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -483,6 +485,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/ValueSpecificationActionWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/ValueSpecificationActionWriter.cs
@@ -238,6 +238,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -403,6 +405,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "value", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/AutoGenXmiWriters/VariableWriter.cs
+++ b/uml4net.xmi/AutoGenXmiWriters/VariableWriter.cs
@@ -228,6 +228,8 @@ namespace uml4net.xmi.Writers
             }
 
 
+            WriteUnresolvedReferences(xmlWriter, element.UnresolvedReferences);
+
             this.WriteExtensions(xmlWriter, element.Extensions);
 
             xmlWriter.WriteEndElement();
@@ -383,6 +385,8 @@ namespace uml4net.xmi.Writers
                 await this.XmiElementWriterFacade.WriteContainedElementAsync(xmlWriter, value, "upperValue", writeContext);
             }
 
+
+            await WriteUnresolvedReferencesAsync(xmlWriter, element.UnresolvedReferences);
 
             await this.WriteExtensionsAsync(xmlWriter, element.Extensions);
 

--- a/uml4net.xmi/Readers/XmiElementReader.cs
+++ b/uml4net.xmi/Readers/XmiElementReader.cs
@@ -22,6 +22,7 @@ namespace uml4net.xmi.Readers
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Xml;
 
     using Microsoft.Extensions.Logging;
@@ -181,6 +182,8 @@ namespace uml4net.xmi.Readers
                 if (!string.IsNullOrEmpty(reference))
                 {
                     xmiElement.SingleValueReferencePropertyIdentifiers.Add(localName, reference);
+
+                    CollectUnresolvedReference(subXmlReader, xmiElement, localName, reference);
                 }
                 else if (subXmlReader.GetAttribute("xmi:idref") is { Length: > 0 } idRef)
                 {
@@ -238,6 +241,9 @@ namespace uml4net.xmi.Readers
                     }
 
                     references.Add(href);
+
+                    CollectUnresolvedReference(subXmlReader, xmiElement, localName, href);
+
                     return true;
                 }
 
@@ -256,6 +262,46 @@ namespace uml4net.xmi.Readers
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Adds the reference element, in its original XMI form, to the
+        /// <see cref="IXmiElement.UnresolvedReferences"/> collection of the provided <see cref="IXmiElement"/>
+        /// </summary>
+        /// <param name="xmlReader">
+        /// An instance of <see cref="XmlReader"/> that is positioned on the reference element
+        /// </param>
+        /// <param name="xmiElement">
+        /// The <see cref="IXmiElement"/> that declares the reference
+        /// </param>
+        /// <param name="localName">
+        /// The name of the reference property through which the referenced <see cref="IXmiElement"/> is reached
+        /// </param>
+        /// <param name="reference">
+        /// The unique identifier of the referenced <see cref="IXmiElement"/>, which is the value of the
+        /// <c>href</c> attribute of the reference element
+        /// </param>
+        /// <remarks>
+        /// Only a reference to another document - an <c>href</c> - is captured, since it is the only reference
+        /// that depends on a document that may not be available. The captured reference is removed again by the
+        /// <see cref="IAssembler"/> as soon as it is resolved, so that only the references that could not be
+        /// resolved remain and are written back verbatim
+        /// </remarks>
+        protected static void CollectUnresolvedReference(XmlReader xmlReader, IXmiElement xmiElement, string localName, string reference)
+        {
+            var stringWriter = new StringWriter();
+
+            using (var xmlWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings { OmitXmlDeclaration = true }))
+            {
+                xmlWriter.WriteNode(xmlReader, true);
+            }
+
+            xmiElement.UnresolvedReferences.Add(new XmiUnresolvedReference
+            {
+                PropertyName = localName,
+                Identifier = reference,
+                ContentRawXmi = stringWriter.ToString()
+            });
         }
 
         /// <summary>

--- a/uml4net.xmi/Writers/XmiElementWriter.cs
+++ b/uml4net.xmi/Writers/XmiElementWriter.cs
@@ -221,6 +221,67 @@ namespace uml4net.xmi.Writers
         }
 
         /// <summary>
+        /// Writes the references of an <see cref="IXmiElement"/> that could not be resolved while reading to
+        /// the <see cref="XmlWriter"/> in their original XMI form.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="unresolvedReferences">
+        /// The <see cref="XmiUnresolvedReference"/>s that are to be written
+        /// </param>
+        /// <remarks>
+        /// The reference element is written verbatim, so that a reference to a document that is not available -
+        /// an Enterprise Architect profile identified by a <c>http://www.sparxsystems.com/profiles/…</c> URL for
+        /// instance - is preserved rather than silently lost. The raw content is not indented, since it is
+        /// written as markup and not as content.
+        /// </remarks>
+        protected static void WriteUnresolvedReferences(XmlWriter xmlWriter, List<XmiUnresolvedReference> unresolvedReferences)
+        {
+            if (unresolvedReferences == null || unresolvedReferences.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var unresolvedReference in unresolvedReferences)
+            {
+                if (!string.IsNullOrEmpty(unresolvedReference.ContentRawXmi))
+                {
+                    xmlWriter.WriteRaw(unresolvedReference.ContentRawXmi);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes the references of an <see cref="IXmiElement"/> that could not be resolved while
+        /// reading to the <see cref="XmlWriter"/> in their original XMI form.
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// The <see cref="XmlWriter"/> to write to
+        /// </param>
+        /// <param name="unresolvedReferences">
+        /// The <see cref="XmiUnresolvedReference"/>s that are to be written
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        protected static async Task WriteUnresolvedReferencesAsync(XmlWriter xmlWriter, List<XmiUnresolvedReference> unresolvedReferences)
+        {
+            if (unresolvedReferences == null || unresolvedReferences.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var unresolvedReference in unresolvedReferences)
+            {
+                if (!string.IsNullOrEmpty(unresolvedReference.ContentRawXmi))
+                {
+                    await xmlWriter.WriteRawAsync(unresolvedReference.ContentRawXmi);
+                }
+            }
+        }
+
+        /// <summary>
         /// Returns the provided value with the first letter converted to lower case, which is used to
         /// serialize enumeration literals.
         /// </summary>

--- a/uml4net.xmi/Writers/XmiElementWriter.cs
+++ b/uml4net.xmi/Writers/XmiElementWriter.cs
@@ -22,6 +22,7 @@ namespace uml4net.xmi.Writers
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using System.Xml;
 
@@ -243,12 +244,9 @@ namespace uml4net.xmi.Writers
                 return;
             }
 
-            foreach (var unresolvedReference in unresolvedReferences)
+            foreach (var unresolvedReference in unresolvedReferences.Where(x => !string.IsNullOrEmpty(x.ContentRawXmi)))
             {
-                if (!string.IsNullOrEmpty(unresolvedReference.ContentRawXmi))
-                {
-                    xmlWriter.WriteRaw(unresolvedReference.ContentRawXmi);
-                }
+                xmlWriter.WriteRaw(unresolvedReference.ContentRawXmi);
             }
         }
 
@@ -272,12 +270,9 @@ namespace uml4net.xmi.Writers
                 return;
             }
 
-            foreach (var unresolvedReference in unresolvedReferences)
+            foreach (var unresolvedReference in unresolvedReferences.Where(x => !string.IsNullOrEmpty(x.ContentRawXmi)))
             {
-                if (!string.IsNullOrEmpty(unresolvedReference.ContentRawXmi))
-                {
-                    await xmlWriter.WriteRawAsync(unresolvedReference.ContentRawXmi);
-                }
+                await xmlWriter.WriteRawAsync(unresolvedReference.ContentRawXmi);
             }
         }
 

--- a/uml4net/Assembler.cs
+++ b/uml4net/Assembler.cs
@@ -98,6 +98,8 @@ namespace uml4net
                 }
 
                 targetProperty.SetValue(element, referencedElement);
+
+                RemoveResolvedReference(element, property.Key, property.Value);
             }
 
             foreach (var property in element.MultiValueReferencePropertyIdentifiers)
@@ -110,7 +112,7 @@ namespace uml4net
                     throw new KeyNotFoundException($"The target property {property.Key} was not found on {element.GetType().Name} or the type is null");
                 }
 
-                var resolvedReferences = this.ResolveMultiValueReferences(element.DocumentName,property.Value, property.Key, underlyingType);
+                var resolvedReferences = this.ResolveMultiValueReferences(element, property.Value, property.Key, underlyingType);
 
                 if (targetProperty.GetValue(element) is not IList list)
                 {
@@ -157,8 +159,8 @@ namespace uml4net
         /// <summary>
         /// resolves multi-valued reference properties
         /// </summary>
-        /// <param name="documentName">
-        /// The name of the document or resource from where the <see cref="IXmiElement"/> was parsed/read
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that declares the multi-valued reference property
         /// </param>
         /// <param name="propertyValues">
         /// The values of the property, which are references by unique identifier to other <see cref="IXmiElement"/>s
@@ -168,22 +170,48 @@ namespace uml4net
         /// </param>
         /// <param name="expectedType"></param>
         /// <returns></returns>
-        private List<IXmiElement> ResolveMultiValueReferences(string documentName, IEnumerable<string> propertyValues, string key, Type expectedType)
+        private List<IXmiElement> ResolveMultiValueReferences(IXmiElement element, IEnumerable<string> propertyValues, string key, Type expectedType)
         {
             var resolvedReferences = new List<IXmiElement>();
 
             foreach (var propertyValue in propertyValues)
             {
-                if (!this.TryGetReferencedElement(documentName,propertyValue, out var referencedElement) || !expectedType.IsAssignableFrom(referencedElement.GetType()))
+                if (!this.TryGetReferencedElement(element.DocumentName, propertyValue, out var referencedElement) || !expectedType.IsAssignableFrom(referencedElement.GetType()))
                 {
                     this.logger.LogWarning("The reference with the id [{Key}] to [{PropertyValue}] was not found in the cache, probably because its type is not supported.", key, propertyValue);
                     continue;
                 }
 
                 resolvedReferences.Add(referencedElement);
+
+                RemoveResolvedReference(element, key, propertyValue);
             }
 
             return resolvedReferences;
+        }
+
+        /// <summary>
+        /// Removes the reference element that was preserved in its original XMI form while reading from the
+        /// <see cref="IXmiElement.UnresolvedReferences"/> of the provided <see cref="IXmiElement"/>, since the
+        /// reference has been resolved and is written from the reference property that it has been assigned to
+        /// </summary>
+        /// <param name="element">
+        /// The <see cref="IXmiElement"/> that declares the reference
+        /// </param>
+        /// <param name="propertyName">
+        /// The name of the reference property through which the referenced <see cref="IXmiElement"/> is reached
+        /// </param>
+        /// <param name="referenceIdentifier">
+        /// The unique identifier of the referenced <see cref="IXmiElement"/>
+        /// </param>
+        private static void RemoveResolvedReference(IXmiElement element, string propertyName, string referenceIdentifier)
+        {
+            if (element.UnresolvedReferences.Count == 0)
+            {
+                return;
+            }
+
+            element.UnresolvedReferences.RemoveAll(x => x.PropertyName == propertyName && x.Identifier == referenceIdentifier);
         }
 
         /// <summary>

--- a/uml4net/Assembler.cs
+++ b/uml4net/Assembler.cs
@@ -176,7 +176,7 @@ namespace uml4net
 
             foreach (var propertyValue in propertyValues)
             {
-                if (!this.TryGetReferencedElement(element.DocumentName, propertyValue, out var referencedElement) || !expectedType.IsAssignableFrom(referencedElement.GetType()))
+                if (!this.TryGetReferencedElement(element.DocumentName, propertyValue, out var referencedElement) || !expectedType.IsInstanceOfType(referencedElement))
                 {
                     this.logger.LogWarning("The reference with the id [{Key}] to [{PropertyValue}] was not found in the cache, probably because its type is not supported.", key, propertyValue);
                     continue;

--- a/uml4net/IXmiElement.cs
+++ b/uml4net/IXmiElement.cs
@@ -87,6 +87,18 @@ namespace uml4net
         public Dictionary<string, List<string>> MultiValueReferencePropertyIdentifiers { get; set; }
 
         /// <summary>
+        /// Gets or sets the references to <see cref="IXmiElement"/>s in another document that could not be
+        /// resolved while reading, preserved in their original XMI form
+        /// </summary>
+        /// <remarks>
+        /// A reference element is captured while reading and is removed again as soon as the reference is
+        /// resolved, so that once the object graph has been assembled this collection holds exactly those
+        /// references that could not be turned into an object reference. Those are written back verbatim so
+        /// that they survive a read - write cycle
+        /// </remarks>
+        public List<XmiUnresolvedReference> UnresolvedReferences { get; set; }
+
+        /// <summary>
         /// Gets or sets the <see cref="IXmiElementCache"/>
         /// </summary>
         public IXmiElementCache Cache { get; set; }

--- a/uml4net/IXmiUnresolvedReference.cs
+++ b/uml4net/IXmiUnresolvedReference.cs
@@ -1,0 +1,53 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="IXmiUnresolvedReference.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net
+{
+    /// <summary>
+    /// Defines the contract for objects representing a reference to an <see cref="IXmiElement"/> in another
+    /// document that could not be resolved while reading.
+    /// <para>
+    /// A reference such as <c>&lt;appliedProfile xmi:type="uml:Profile" href="http://…#id"/&gt;</c> can only be
+    /// turned into an object reference when the referenced document is available. When it is not - an
+    /// Enterprise Architect profile identified by a <c>http://www.sparxsystems.com/profiles/…</c> URL for
+    /// instance is not retrievable at all - the reference element is preserved in its original XMI form so
+    /// that it is written back verbatim rather than silently lost.
+    /// </para>
+    /// </summary>
+    public interface IXmiUnresolvedReference
+    {
+        /// <summary>
+        /// Gets or sets the name of the reference property through which the referenced <see cref="IXmiElement"/>
+        /// is reached, such as <c>appliedProfile</c>
+        /// </summary>
+        string PropertyName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier of the referenced <see cref="IXmiElement"/>, which is the value of
+        /// the <c>href</c> attribute of the reference element
+        /// </summary>
+        string Identifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reference element in its original XMI form
+        /// </summary>
+        string ContentRawXmi { get; set; }
+    }
+}

--- a/uml4net/XmiElement.cs
+++ b/uml4net/XmiElement.cs
@@ -91,6 +91,18 @@ namespace uml4net
         public Dictionary<string, List<string>> MultiValueReferencePropertyIdentifiers { get; set; } = new();
 
         /// <summary>
+        /// Gets or sets the references to <see cref="IXmiElement"/>s in another document that could not be
+        /// resolved while reading, preserved in their original XMI form
+        /// </summary>
+        /// <remarks>
+        /// A reference element is captured while reading and is removed again as soon as the reference is
+        /// resolved, so that once the object graph has been assembled this collection holds exactly those
+        /// references that could not be turned into an object reference. Those are written back verbatim so
+        /// that they survive a read - write cycle
+        /// </remarks>
+        public List<XmiUnresolvedReference> UnresolvedReferences { get; set; } = [];
+
+        /// <summary>
         /// Gets or sets the <see cref="IXmiElementCache"/>
         /// </summary>
         public IXmiElementCache Cache { get; set; }

--- a/uml4net/XmiUnresolvedReference.cs
+++ b/uml4net/XmiUnresolvedReference.cs
@@ -1,0 +1,53 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="XmiUnresolvedReference.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net
+{
+    /// <summary>
+    /// Represents a reference to an <see cref="IXmiElement"/> in another document that could not be resolved
+    /// while reading, preserved in its original XMI form.
+    /// <para>
+    /// The reference element is captured verbatim while reading and is removed again as soon as the reference
+    /// is resolved, so that after the object graph has been assembled the
+    /// <see cref="IXmiElement.UnresolvedReferences"/> of an <see cref="IXmiElement"/> hold exactly those
+    /// references that could not be turned into an object reference. Those are written back verbatim, which
+    /// preserves them across a read - write cycle even though uml4net cannot interpret them.
+    /// </para>
+    /// </summary>
+    public class XmiUnresolvedReference : IXmiUnresolvedReference
+    {
+        /// <summary>
+        /// Gets or sets the name of the reference property through which the referenced <see cref="IXmiElement"/>
+        /// is reached, such as <c>appliedProfile</c>
+        /// </summary>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier of the referenced <see cref="IXmiElement"/>, which is the value of
+        /// the <c>href</c> attribute of the reference element
+        /// </summary>
+        public string Identifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reference element in its original XMI form
+        /// </summary>
+        public string ContentRawXmi { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes #204

## The problem

Reading `resources/Enterprise Architect Extensions/EAExport.xmi` and writing it back dropped all four `<appliedProfile>` elements, and `ProfileApplication.AppliedProfile` was `null` for all of them.

The root cause is that **failure to resolve was conflated with absence**:

1. `XmiElementReader.CollectSingleValueReferencePropertyIdentifier` defers the reference — it records the raw href and leaves the typed property null.
2. `ExternalReferenceResolver` cannot follow `http://www.sparxsystems.com/profiles/EAUML/1.0`. That URL is an *identifier*, not a location — there is no file anywhere to point at, so the reference is permanently unresolvable.
3. `Assembler.ResolveReferences` misses the cache, logs a warning and continues.
4. Every generated writer is driven purely by the typed property (`if (element.AppliedProfile != null)`), and nothing ever reads the identifier dictionaries. Null ⇒ nothing written.

So a reference that merely *could not be followed* became indistinguishable from one that *was never there*, and uml4net silently downgraded the document.

## The fix

The same treatment `xmi:Extension` already gets via `ContentRawXmi`: preserve the reference element **verbatim** and replay it on write.

- **`XmiUnresolvedReference`** (new) holds the property name, the raw href and the reference element in its original XMI form; exposed as `IXmiElement.UnresolvedReferences`.
- **`XmiElementReader`** captures the reference element of an `href` in both the single- and multi-valued collect helpers. A bare `xmi:idref` is a same-document reference and is not captured. Both helpers keep their signatures, so no `AutoGenXmiReaders` change.
- **`Assembler`** removes the captured element as soon as the reference resolves. What remains is by definition a reference the normal writer path will not emit — which is what keeps the writer change to a single template line with no per-property logic.
- **`XmiElementWriter.WriteUnresolvedReferences`** writes each preserved element raw, called from `xmi-writer-template.hbs` just before the extensions. The `AutoGenXmiWriters` and the 16 golden files are regenerated accordingly.

This was chosen over materialising a placeholder/proxy object on the graph. It has the higher fidelity — it survives attributes uml4net does not model — and it **changes no read behaviour**, so no existing fixture or consumer is affected.

## Verified

Empirically, on the real EA export (read → write, counted against the source document):

| element | source | written before | written after |
|---|---|---|---|
| `<appliedProfile>` | 4 | 0 | 4 |
| `<importedPackage>` | 4 | 0 | 4 |
| `<profileApplication>` | 4 | 4 | 4 |

The written markup is byte-identical to the source, including `xmi:type`:

```xml
<appliedProfile xmi:type="uml:Profile" href="http://www.sparxsystems.com/profiles/EAUML/1.0#8C9E6706-8" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" />
```

(The redundant `xmlns:xmi` redeclaration is inherent to `WriteRaw` of a captured fragment and is the same as for `xmi:Extension` content — valid, and it re-reads correctly.)

Full suite: **465 passed, 0 failed** across 8 projects, up from 451 — no existing test needed changing. The new tests were confirmed to be genuine regression tests by neutralising the write-back and observing 3 failures.

## Tests

- **new** `UnresolvedExternalReferenceRoundTripTestFixture` — the #204 regression fixture over `EAExport.xmi`: references preserved on read; hrefs written back byte-identical to the source (compared against the source document, not hard-coded); idempotent read → write → read; async write equivalent.
- `XmiElementReaderTestFixture` — captured for an href, not captured for an `xmi:idref`, captured per item for the multi-valued helper.
- `AssemblerTestFixture` — a resolved reference has its captured element removed, an unresolved one keeps it, and only the resolved items of a multi-valued reference are removed.
- `XmiWriterTestFixture` — the preserved element is written as a child; nothing is written when there are none or when the raw XMI is empty.

## Notes for review

- `IXmiElement` gains one member. `XmiElement` is the only production implementer; one test double in `uml4net.Extensions.Tests` was updated.
- The raw markup of every *href* reference is held until `Synchronize()` prunes it, so documents with many resolvable hrefs carry those strings for the duration of the read.
- A replayed element is written as the last child rather than in its original position. Irrelevant for `<appliedProfile>`, which is the only child of `<profileApplication>`, but output element order can differ from the source in general.
- The object graph is unchanged — `AppliedProfile` is still `null`; the information lives in `UnresolvedReferences`. Surfacing those on `XmiReaderResult` as a manifest of what a document lost would be a natural follow-up.
