### PR TITLE
[Bugfix] write xmi:Documentation back on XMI write

### DIFF
--- a/uml4net.xmi.Tests/Writers/DocumentationRoundTripTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/DocumentationRoundTripTestFixture.cs
@@ -1,0 +1,155 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="DocumentationRoundTripTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Tests.Writers
+{
+    using System.IO;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using NUnit.Framework;
+
+    using uml4net.xmi.Readers;
+    using uml4net.xmi.Writers;
+
+    /// <summary>
+    /// Verifies that the <c>xmi:Documentation</c> header of an XMI document survives a
+    /// read - write - read cycle (issue #210).
+    /// </summary>
+    [TestFixture]
+    public class DocumentationRoundTripTestFixture
+    {
+        private string rootPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.rootPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData");
+        }
+
+        [Test]
+        public void Verify_that_the_Documentation_of_a_document_round_trips()
+        {
+            var originalResult = this.CreateReader().Read(Path.Combine(this.rootPath, "documentation-as-attributes.xmi"));
+
+            var originalRoot = originalResult.QueryRoot("_P1");
+            var originalDocumentation = originalResult.XmiRoot.Documentation;
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            writer.Write(originalRoot, stream, "documentation-as-attributes.xmi", originalDocumentation, null);
+
+            stream.Position = 0;
+
+            var rereadResult = this.CreateReader().Read(stream, "documentation-as-attributes.xmi");
+
+            var rereadDocumentation = rereadResult.XmiRoot.Documentation;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(rereadDocumentation, Is.Not.Null);
+                Assert.That(rereadDocumentation.Contact, Is.EqualTo(originalDocumentation.Contact));
+                Assert.That(rereadDocumentation.Exporter, Is.EqualTo(originalDocumentation.Exporter));
+                Assert.That(rereadDocumentation.ExporterID, Is.EqualTo(originalDocumentation.ExporterID));
+                Assert.That(rereadDocumentation.ExporterVersion, Is.EqualTo(originalDocumentation.ExporterVersion));
+                Assert.That(rereadDocumentation.TimeStamp, Is.EqualTo(originalDocumentation.TimeStamp));
+                Assert.That(rereadDocumentation.LongDescription, Is.EqualTo(originalDocumentation.LongDescription));
+                Assert.That(rereadDocumentation.ShortDescription, Is.EqualTo(originalDocumentation.ShortDescription));
+                Assert.That(rereadDocumentation.Notice, Is.EqualTo(originalDocumentation.Notice));
+                Assert.That(rereadDocumentation.Owner, Is.EqualTo(originalDocumentation.Owner));
+            }
+        }
+
+        [Test]
+        public void Verify_that_the_Documentation_is_written_as_the_first_child_of_the_root()
+        {
+            var originalResult = this.CreateReader().Read(Path.Combine(this.rootPath, "documentation-as-attributes.xmi"));
+
+            var originalRoot = originalResult.QueryRoot("_P1");
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            writer.Write(originalRoot, stream, "documentation-as-attributes.xmi", originalResult.XmiRoot.Documentation, null);
+
+            stream.Position = 0;
+
+            var document = XDocument.Load(stream);
+
+            var xmiNamespace = XNamespace.Get("http://www.omg.org/spec/XMI/20131001");
+
+            var children = document.Root.Elements().ToList();
+            var documentationElement = children.SingleOrDefault(x => x.Name == xmiNamespace + "Documentation");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(documentationElement, Is.Not.Null, "an xmi:Documentation was expected as a child of xmi:XMI");
+                Assert.That(documentationElement.Attribute("exporter")?.Value, Is.EqualTo("uml4net"));
+                Assert.That(children.First(), Is.EqualTo(documentationElement),
+                    "the xmi:Documentation was expected to be written before the model content");
+            }
+        }
+
+        [Test]
+        public void Verify_that_no_Documentation_is_written_when_none_is_provided()
+        {
+            var originalResult = this.CreateReader().Read(Path.Combine(this.rootPath, "documentation-as-attributes.xmi"));
+
+            var originalRoot = originalResult.QueryRoot("_P1");
+
+            using var stream = new MemoryStream();
+
+            var writer = XmiWriterBuilder.Create()
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+
+            writer.Write(originalRoot, stream, "documentation-as-attributes.xmi", (System.Collections.Generic.IEnumerable<XmiExtension>)null);
+
+            stream.Position = 0;
+
+            var document = XDocument.Load(stream);
+
+            var xmiNamespace = XNamespace.Get("http://www.omg.org/spec/XMI/20131001");
+
+            Assert.That(document.Root.Elements().Any(x => x.Name == xmiNamespace + "Documentation"), Is.False,
+                "the pre-existing overloads are expected to remain behaviour preserving and write no xmi:Documentation");
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IXmiReader"/>
+        /// </summary>
+        private IXmiReader CreateReader()
+        {
+            return XmiReaderBuilder.Create()
+                .UsingSettings(x => x.LocalReferenceBasePath = this.rootPath)
+                .WithLogger(NullLoggerFactory.Instance)
+                .Build();
+        }
+    }
+}

--- a/uml4net.xmi.Tests/Writers/DocumentationWriterTestFixture.cs
+++ b/uml4net.xmi.Tests/Writers/DocumentationWriterTestFixture.cs
@@ -1,0 +1,182 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="DocumentationWriterTestFixture.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Tests.Writers
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using System.Xml.Linq;
+
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using NUnit.Framework;
+
+    using uml4net.xmi.Settings;
+    using uml4net.xmi.Writers;
+    using uml4net.xmi.Xmi;
+
+    [TestFixture]
+    public class DocumentationWriterTestFixture
+    {
+        private IXmiWriterSettings xmiWriterSettings;
+
+        private DocumentationWriter documentationWriter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.xmiWriterSettings = new DefaultWriterSettings();
+
+            this.documentationWriter = new DocumentationWriter(this.xmiWriterSettings, NullLoggerFactory.Instance);
+        }
+
+        [Test]
+        public void Verify_that_Write_throws_when_arguments_are_null()
+        {
+            using var stringWriter = new StringWriter();
+            using var xmlWriter = XmlWriter.Create(stringWriter);
+
+            Assert.That(() => this.documentationWriter.Write(null, new Documentation()), Throws.TypeOf<ArgumentNullException>());
+            Assert.That(() => this.documentationWriter.Write(xmlWriter, null), Throws.TypeOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void Verify_that_WriteAsync_throws_when_arguments_are_null()
+        {
+            using var stringWriter = new StringWriter();
+            using var xmlWriter = XmlWriter.Create(stringWriter);
+
+            Assert.That(async () => await this.documentationWriter.WriteAsync(null, new Documentation()), Throws.TypeOf<ArgumentNullException>());
+            Assert.That(async () => await this.documentationWriter.WriteAsync(xmlWriter, null), Throws.TypeOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void Verify_that_a_fully_populated_Documentation_is_written_as_expected()
+        {
+            var documentation = new Documentation
+            {
+                Contact = "info@stariongroup.eu",
+                Exporter = "uml4net",
+                ExporterID = "4.5.6",
+                ExporterVersion = "1.0.0",
+                TimeStamp = new DateTime(2025, 10, 12)
+            };
+
+            documentation.LongDescription.Add("long description 1");
+            documentation.LongDescription.Add("long description 2");
+            documentation.ShortDescription.Add("short description");
+            documentation.Notice.Add("notice");
+            documentation.Owner.Add("Starion Group S.A.");
+
+            var element = this.WriteAndParse(documentation);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(element.Name.LocalName, Is.EqualTo("Documentation"));
+                Assert.That(element.Attribute("contact")?.Value, Is.EqualTo("info@stariongroup.eu"));
+                Assert.That(element.Attribute("exporter")?.Value, Is.EqualTo("uml4net"));
+                Assert.That(element.Attribute("exporterID")?.Value, Is.EqualTo("4.5.6"));
+                Assert.That(element.Attribute("exporterVersion")?.Value, Is.EqualTo("1.0.0"));
+                Assert.That(element.Attribute("timestamp")?.Value, Is.EqualTo(XmlConvert.ToString(documentation.TimeStamp, XmlDateTimeSerializationMode.RoundtripKind)));
+
+                var xmiNamespace = XNamespace.Get(this.xmiWriterSettings.XmiNamespaceUri);
+
+                Assert.That(element.Elements(xmiNamespace + "longDescription").Select(x => x.Value), Is.EqualTo(new[] { "long description 1", "long description 2" }));
+                Assert.That(element.Elements(xmiNamespace + "shortDescription").Select(x => x.Value), Is.EqualTo(new[] { "short description" }));
+                Assert.That(element.Elements(xmiNamespace + "notice").Select(x => x.Value), Is.EqualTo(new[] { "notice" }));
+                Assert.That(element.Elements(xmiNamespace + "owner").Select(x => x.Value), Is.EqualTo(new[] { "Starion Group S.A." }));
+            }
+        }
+
+        [Test]
+        public void Verify_that_an_empty_Documentation_is_written_without_optional_attributes_or_elements()
+        {
+            var element = this.WriteAndParse(new Documentation());
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(element.Attributes(), Is.Empty);
+                Assert.That(element.Elements(), Is.Empty);
+            }
+        }
+
+        [Test]
+        public async Task Verify_that_WriteAsync_writes_the_same_content_as_Write()
+        {
+            var documentation = new Documentation
+            {
+                Exporter = "Enterprise Architect",
+                ExporterVersion = "6.5",
+                ExporterID = "1704"
+            };
+
+            using var stream = new MemoryStream();
+
+            await using (var xmlWriter = XmlWriter.Create(stream, new XmlWriterSettings { Async = true, OmitXmlDeclaration = true }))
+            {
+                await xmlWriter.WriteStartElementAsync("xmi", "XMI", this.xmiWriterSettings.XmiNamespaceUri);
+
+                await this.documentationWriter.WriteAsync(xmlWriter, documentation);
+
+                await xmlWriter.WriteEndElementAsync();
+            }
+
+            stream.Position = 0;
+
+            var xmiNamespace = XNamespace.Get(this.xmiWriterSettings.XmiNamespaceUri);
+            var element = XDocument.Load(stream).Root!.Element(xmiNamespace + "Documentation");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(element, Is.Not.Null);
+                Assert.That(element.Attribute("exporter")?.Value, Is.EqualTo("Enterprise Architect"));
+                Assert.That(element.Attribute("exporterVersion")?.Value, Is.EqualTo("6.5"));
+                Assert.That(element.Attribute("exporterID")?.Value, Is.EqualTo("1704"));
+            }
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="Documentation"/> as the sole child of a synthetic root element and
+        /// returns the resulting <see cref="XElement"/> for the <c>xmi:Documentation</c> element.
+        /// </summary>
+        private XElement WriteAndParse(Documentation documentation)
+        {
+            using var stream = new MemoryStream();
+
+            using (var xmlWriter = XmlWriter.Create(stream, new XmlWriterSettings { OmitXmlDeclaration = true }))
+            {
+                xmlWriter.WriteStartElement("xmi", "XMI", this.xmiWriterSettings.XmiNamespaceUri);
+
+                this.documentationWriter.Write(xmlWriter, documentation);
+
+                xmlWriter.WriteEndElement();
+            }
+
+            stream.Position = 0;
+
+            var xmiNamespace = XNamespace.Get(this.xmiWriterSettings.XmiNamespaceUri);
+
+            return XDocument.Load(stream).Root!.Element(xmiNamespace + "Documentation");
+        }
+    }
+}

--- a/uml4net.xmi/Writers/DocumentationWriter.cs
+++ b/uml4net.xmi/Writers/DocumentationWriter.cs
@@ -1,0 +1,217 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="DocumentationWriter.cs" company="Starion Group S.A.">
+//
+//   Copyright (C) 2019-2026 Starion Group S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace uml4net.xmi.Writers
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using uml4net.xmi.Settings;
+    using uml4net.xmi.Xmi;
+
+    /// <summary>
+    /// The purpose of the <see cref="DocumentationWriter"/> is to write an instance of
+    /// <see cref="Documentation"/> to an XMI document.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="Documentation"/> is written as the <c>xmi:Documentation</c> element, a
+    /// sibling of the model content, which makes it survive a read - write cycle.
+    /// </remarks>
+    public class DocumentationWriter
+    {
+        /// <summary>
+        /// The (injected) logger
+        /// </summary>
+        private readonly ILogger<DocumentationWriter> logger;
+
+        /// <summary>
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </summary>
+        private readonly IXmiWriterSettings xmiWriterSettings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DocumentationWriter"/> class.
+        /// </summary>
+        /// <param name="xmiWriterSettings">
+        /// The <see cref="IXmiWriterSettings"/> used to configure writing
+        /// </param>
+        /// <param name="loggerFactory">
+        /// The (injected) <see cref="ILoggerFactory"/> used to set up logging
+        /// </param>
+        public DocumentationWriter(IXmiWriterSettings xmiWriterSettings, ILoggerFactory loggerFactory)
+        {
+            this.xmiWriterSettings = xmiWriterSettings;
+            this.logger = loggerFactory == null ? NullLogger<DocumentationWriter>.Instance : loggerFactory.CreateLogger<DocumentationWriter>();
+        }
+
+        /// <summary>
+        /// Writes the <see cref="Documentation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="documentation">
+        /// The <see cref="Documentation"/> that is to be written
+        /// </param>
+        public void Write(XmlWriter xmlWriter, Documentation documentation)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (documentation == null)
+            {
+                throw new ArgumentNullException(nameof(documentation));
+            }
+
+            this.logger.LogTrace("writing the Documentation of {Exporter}:{ExporterVersion}", documentation.Exporter, documentation.ExporterVersion);
+
+            xmlWriter.WriteStartElement("xmi", "Documentation", this.xmiWriterSettings.XmiNamespaceUri);
+
+            if (!string.IsNullOrEmpty(documentation.Contact))
+            {
+                xmlWriter.WriteAttributeString("contact", documentation.Contact);
+            }
+
+            if (!string.IsNullOrEmpty(documentation.Exporter))
+            {
+                xmlWriter.WriteAttributeString("exporter", documentation.Exporter);
+            }
+
+            if (!string.IsNullOrEmpty(documentation.ExporterID))
+            {
+                xmlWriter.WriteAttributeString("exporterID", documentation.ExporterID);
+            }
+
+            if (!string.IsNullOrEmpty(documentation.ExporterVersion))
+            {
+                xmlWriter.WriteAttributeString("exporterVersion", documentation.ExporterVersion);
+            }
+
+            if (documentation.TimeStamp != default)
+            {
+                xmlWriter.WriteAttributeString("timestamp", XmlConvert.ToString(documentation.TimeStamp, XmlDateTimeSerializationMode.RoundtripKind));
+            }
+
+            foreach (var longDescription in documentation.LongDescription)
+            {
+                xmlWriter.WriteElementString("xmi", "longDescription", this.xmiWriterSettings.XmiNamespaceUri, longDescription);
+            }
+
+            foreach (var shortDescription in documentation.ShortDescription)
+            {
+                xmlWriter.WriteElementString("xmi", "shortDescription", this.xmiWriterSettings.XmiNamespaceUri, shortDescription);
+            }
+
+            foreach (var notice in documentation.Notice)
+            {
+                xmlWriter.WriteElementString("xmi", "notice", this.xmiWriterSettings.XmiNamespaceUri, notice);
+            }
+
+            foreach (var owner in documentation.Owner)
+            {
+                xmlWriter.WriteElementString("xmi", "owner", this.xmiWriterSettings.XmiNamespaceUri, owner);
+            }
+
+            xmlWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="Documentation"/> object to its XML representation
+        /// </summary>
+        /// <param name="xmlWriter">
+        /// an instance of <see cref="XmlWriter"/>
+        /// </param>
+        /// <param name="documentation">
+        /// The <see cref="Documentation"/> that is to be written
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task WriteAsync(XmlWriter xmlWriter, Documentation documentation)
+        {
+            if (xmlWriter == null)
+            {
+                throw new ArgumentNullException(nameof(xmlWriter));
+            }
+
+            if (documentation == null)
+            {
+                throw new ArgumentNullException(nameof(documentation));
+            }
+
+            this.logger.LogTrace("writing the Documentation of {Exporter}:{ExporterVersion}", documentation.Exporter, documentation.ExporterVersion);
+
+            await xmlWriter.WriteStartElementAsync("xmi", "Documentation", this.xmiWriterSettings.XmiNamespaceUri);
+
+            if (!string.IsNullOrEmpty(documentation.Contact))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "contact", null, documentation.Contact);
+            }
+
+            if (!string.IsNullOrEmpty(documentation.Exporter))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "exporter", null, documentation.Exporter);
+            }
+
+            if (!string.IsNullOrEmpty(documentation.ExporterID))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "exporterID", null, documentation.ExporterID);
+            }
+
+            if (!string.IsNullOrEmpty(documentation.ExporterVersion))
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "exporterVersion", null, documentation.ExporterVersion);
+            }
+
+            if (documentation.TimeStamp != default)
+            {
+                await xmlWriter.WriteAttributeStringAsync(null, "timestamp", null, XmlConvert.ToString(documentation.TimeStamp, XmlDateTimeSerializationMode.RoundtripKind));
+            }
+
+            foreach (var longDescription in documentation.LongDescription)
+            {
+                await xmlWriter.WriteElementStringAsync("xmi", "longDescription", this.xmiWriterSettings.XmiNamespaceUri, longDescription);
+            }
+
+            foreach (var shortDescription in documentation.ShortDescription)
+            {
+                await xmlWriter.WriteElementStringAsync("xmi", "shortDescription", this.xmiWriterSettings.XmiNamespaceUri, shortDescription);
+            }
+
+            foreach (var notice in documentation.Notice)
+            {
+                await xmlWriter.WriteElementStringAsync("xmi", "notice", this.xmiWriterSettings.XmiNamespaceUri, notice);
+            }
+
+            foreach (var owner in documentation.Owner)
+            {
+                await xmlWriter.WriteElementStringAsync("xmi", "owner", this.xmiWriterSettings.XmiNamespaceUri, owner);
+            }
+
+            await xmlWriter.WriteEndElementAsync();
+        }
+    }
+}

--- a/uml4net.xmi/Writers/IXmiWriter.cs
+++ b/uml4net.xmi/Writers/IXmiWriter.cs
@@ -27,6 +27,7 @@ namespace uml4net.xmi.Writers
     using System.Threading.Tasks;
 
     using uml4net.Packages;
+    using uml4net.xmi.Xmi;
 
     /// <summary>
     /// The purpose of the <see cref="IXmiWriter"/> is to provide a means to write (serialize)
@@ -175,5 +176,103 @@ namespace uml4net.xmi.Writers
         /// an awaitable <see cref="Task"/>
         /// </returns>
         Task WriteAsync(IPackage package, Stream stream, string documentName, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/>, <see cref="Documentation"/> and <see cref="XmiExtension"/>s to
+        /// a UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        /// <param name="documentation">
+        /// The <see cref="Documentation"/> that is to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Documentation</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        void Write(IPackage package, string fileUri, Documentation documentation, IEnumerable<XmiExtension> documentExtensions);
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/>, <see cref="Documentation"/> and <see cref="XmiExtension"/>s to
+        /// a UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="documentation">
+        /// The <see cref="Documentation"/> that is to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Documentation</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        void Write(IPackage package, Stream stream, string documentName, Documentation documentation, IEnumerable<XmiExtension> documentExtensions);
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/>, <see cref="Documentation"/> and
+        /// <see cref="XmiExtension"/>s to a UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        /// <param name="documentation">
+        /// The <see cref="Documentation"/> that is to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Documentation</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        Task WriteAsync(IPackage package, string fileUri, Documentation documentation, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/>, <see cref="Documentation"/> and
+        /// <see cref="XmiExtension"/>s to a UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="documentation">
+        /// The <see cref="Documentation"/> that is to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Documentation</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        Task WriteAsync(IPackage package, Stream stream, string documentName, Documentation documentation, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default);
     }
 }

--- a/uml4net.xmi/Writers/XmiWriter.cs
+++ b/uml4net.xmi/Writers/XmiWriter.cs
@@ -35,6 +35,7 @@ namespace uml4net.xmi.Writers
 
     using uml4net.Packages;
     using uml4net.xmi.Settings;
+    using uml4net.xmi.Xmi;
 
     /// <summary>
     /// The purpose of the <see cref="XmiWriter"/> is to provide a means to write (serialize)
@@ -130,6 +131,29 @@ namespace uml4net.xmi.Writers
         /// </param>
         public void Write(IPackage package, string fileUri, IEnumerable<XmiExtension> documentExtensions)
         {
+            this.Write(package, fileUri, null, documentExtensions);
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/>, <see cref="Documentation"/> and <see cref="XmiExtension"/>s to
+        /// a UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        /// <param name="documentation">
+        /// The <see cref="Documentation"/> that is to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Documentation</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        public void Write(IPackage package, string fileUri, Documentation documentation, IEnumerable<XmiExtension> documentExtensions)
+        {
             if (string.IsNullOrEmpty(fileUri))
             {
                 throw new ArgumentException(nameof(fileUri));
@@ -141,7 +165,7 @@ namespace uml4net.xmi.Writers
 
             this.logger.LogInformation("start serializing to {Path}", fileUri);
 
-            this.Write(package, fileStream, new FileInfo(fileUri).Name, documentExtensions);
+            this.Write(package, fileStream, new FileInfo(fileUri).Name, documentation, documentExtensions);
 
             this.logger.LogInformation("File {Path} serialized in {Time} [ms]", fileUri, sw.ElapsedMilliseconds);
         }
@@ -181,6 +205,32 @@ namespace uml4net.xmi.Writers
         /// </param>
         public void Write(IPackage package, Stream stream, string documentName, IEnumerable<XmiExtension> documentExtensions)
         {
+            this.Write(package, stream, documentName, null, documentExtensions);
+        }
+
+        /// <summary>
+        /// Writes the provided <see cref="IPackage"/>, <see cref="Documentation"/> and <see cref="XmiExtension"/>s to
+        /// a UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="documentation">
+        /// The <see cref="Documentation"/> that is to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Documentation</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        public void Write(IPackage package, Stream stream, string documentName, Documentation documentation, IEnumerable<XmiExtension> documentExtensions)
+        {
             if (package == null)
             {
                 throw new ArgumentNullException(nameof(package));
@@ -203,6 +253,13 @@ namespace uml4net.xmi.Writers
             xmlWriter.WriteStartDocument();
             xmlWriter.WriteStartElement("xmi", "XMI", this.XmiWriterSettings.XmiNamespaceUri);
             xmlWriter.WriteAttributeString("xmlns", "uml", null, this.XmiWriterSettings.UmlNamespaceUri);
+
+            if (documentation != null)
+            {
+                var documentationWriter = new DocumentationWriter(this.XmiWriterSettings, this.LoggerFactory);
+
+                documentationWriter.Write(xmlWriter, documentation);
+            }
 
             foreach (var rootPackage in xmiWritePlan.RootPackages)
             {
@@ -264,7 +321,36 @@ namespace uml4net.xmi.Writers
         /// <returns>
         /// an awaitable <see cref="Task"/>
         /// </returns>
-        public async Task WriteAsync(IPackage package, string fileUri, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default)
+        public Task WriteAsync(IPackage package, string fileUri, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default)
+        {
+            return this.WriteAsync(package, fileUri, null, documentExtensions, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/>, <see cref="Documentation"/> and
+        /// <see cref="XmiExtension"/>s to a UML XMI 2.5.1 file.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="fileUri">
+        /// The URI of the XMI file that is to be written.
+        /// </param>
+        /// <param name="documentation">
+        /// The <see cref="Documentation"/> that is to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Documentation</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task WriteAsync(IPackage package, string fileUri, Documentation documentation, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(fileUri))
             {
@@ -277,7 +363,7 @@ namespace uml4net.xmi.Writers
 
             this.logger.LogInformation("start serializing to {Path}", fileUri);
 
-            await this.WriteAsync(package, fileStream, new FileInfo(fileUri).Name, documentExtensions, cancellationToken);
+            await this.WriteAsync(package, fileStream, new FileInfo(fileUri).Name, documentation, documentExtensions, cancellationToken);
 
             this.logger.LogInformation("File {Path} serialized in {Time} [ms]", fileUri, sw.ElapsedMilliseconds);
         }
@@ -328,7 +414,39 @@ namespace uml4net.xmi.Writers
         /// <returns>
         /// an awaitable <see cref="Task"/>
         /// </returns>
-        public async Task WriteAsync(IPackage package, Stream stream, string documentName, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default)
+        public Task WriteAsync(IPackage package, Stream stream, string documentName, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default)
+        {
+            return this.WriteAsync(package, stream, documentName, null, documentExtensions, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the provided <see cref="IPackage"/>, <see cref="Documentation"/> and
+        /// <see cref="XmiExtension"/>s to a UML XMI 2.5.1 stream.
+        /// </summary>
+        /// <param name="package">
+        /// The <see cref="IPackage"/> that is to be written
+        /// </param>
+        /// <param name="stream">
+        /// The <see cref="Stream"/> to which the XMI content is written.
+        /// </param>
+        /// <param name="documentName">
+        /// The name of the document that is being written.
+        /// </param>
+        /// <param name="documentation">
+        /// The <see cref="Documentation"/> that is to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Documentation</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="documentExtensions">
+        /// The <see cref="XmiExtension"/>s that are to be written as a sibling of the <paramref name="package"/>,
+        /// typically the <c>Extensions</c> of the <c>XmiRoot</c> that was read. May be null.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="CancellationToken"/> used to cancel the write operation
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task WriteAsync(IPackage package, Stream stream, string documentName, Documentation documentation, IEnumerable<XmiExtension> documentExtensions, CancellationToken cancellationToken = default)
         {
             if (package == null)
             {
@@ -352,6 +470,13 @@ namespace uml4net.xmi.Writers
             await xmlWriter.WriteStartDocumentAsync();
             await xmlWriter.WriteStartElementAsync("xmi", "XMI", this.XmiWriterSettings.XmiNamespaceUri);
             await xmlWriter.WriteAttributeStringAsync("xmlns", "uml", null, this.XmiWriterSettings.UmlNamespaceUri);
+
+            if (documentation != null)
+            {
+                var documentationWriter = new DocumentationWriter(this.XmiWriterSettings, this.LoggerFactory);
+
+                await documentationWriter.WriteAsync(xmlWriter, documentation);
+            }
 
             foreach (var rootPackage in xmiWritePlan.RootPackages)
             {


### PR DESCRIPTION
## Summary

`xmi:Documentation` was read into `XmiRoot.Documentation` but never written back out, so a
read -> write round trip silently dropped it (e.g. the `<xmi:Documentation exporter=Enterprise
Architect .../>` header Enterprise Architect writes).

Fixes #210.

## Changes

- New `DocumentationWriter` (`uml4net.xmi/Writers/DocumentationWriter.cs`), hand-written, mirrors
  the existing `DocumentationReader` and follows the same shape as `XmiExtensionWriter` (added for
  #200/#201).
- `IXmiWriter`/`XmiWriter` gain new `Write`/`WriteAsync` overloads that accept a
  `Documentation documentation` parameter alongside the existing `documentExtensions` parameter.
  Existing overloads are unchanged and now simply delegate with `documentation: null`, so this is
  fully backward compatible.
- `xmi:Documentation` is written as the first child of `xmi:XMI` (before the model content),
  matching real Enterprise Architect exports; `xmi:Extension`s continue to be written last.
- New tests: `DocumentationWriterTestFixture` (unit tests for the new writer) and
  `DocumentationRoundTripTestFixture` (read -> write -> read round trip, ordering, and
  backward-compatibility checks), mirroring the existing `XmiExtensionRoundTripTestFixture`.

## Testing

- `dotnet build uml4net.sln`
- `dotnet test uml4net.sln --no-restore --no-build` - all 473 tests pass across the solution.
- Coverage scoped to the new `DocumentationWriter`: 100% line / 95.83% branch / 100% method.