### PR TITLE
[Update] Bump outdated top-level NuGet package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,9 +17,9 @@
          check (.github/workflows/nuget-reference-check.yml) lists this package in IGNORE_PACKAGES so it
          never raises a "package outdated" issue. Keep both in sync. -->
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageVersion Include="Autofac" Version="9.3.2" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="11.0.2" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
@@ -28,7 +28,7 @@
     <PackageVersion Include="Microsoft.Msagl" Version="1.1.6" />
     <PackageVersion Include="Svg" Version="3.4.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="5.6.0" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.10" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.11" />
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
     <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup Label="Build / packaging (PrivateAssets set on the reference in Directory.Build.targets)">
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
   </ItemGroup>
   <ItemGroup Label="Test">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />


### PR DESCRIPTION
Addresses the top-level-package portion of #209 (NuGet Package Issues Detected).

## What

Bumps the top-level `PackageVersion` entries in `Directory.Packages.props` that had newer stable releases available:

| Package | From | To |
|---|---|---|
| `Microsoft.Extensions.Logging.Console` | 10.0.10 | 10.0.11 |
| `Microsoft.Extensions.Http` | 10.0.10 | 10.0.11 |
| `Microsoft.Extensions.Hosting` | 10.0.10 | 10.0.11 |
| `System.CommandLine` | 2.0.10 | 2.0.11 |
| `Microsoft.SourceLink.GitHub` | 10.0.301 | 10.0.400 |

## What's deliberately excluded

- `Microsoft.Extensions.Logging.Abstractions` stays at its 6.0.0 floor — per the existing comment in `Directory.Packages.props` and the `IGNORE_PACKAGES` list in `nuget-reference-check.yml`, this is a deliberately low-floored stable abstraction so downstream consumers aren't forced to upgrade their `Microsoft.Extensions.*` stack.
- Everything else in #209's outdated-package report is transitive-only. `Directory.Packages.props` intentionally does not enable transitive pinning ("Transitive dependencies keep resolving upward (NuGet's normal unification)"), so those aren't under direct control here — they'll resolve upward once their owning packages update.
- GitHub Actions versions are handled separately by Dependabot (already has #212 and #213 open) — not touched by this PR.

## Verification

`dotnet restore` + `dotnet build` + full solution test suite, all passing, no failures.
